### PR TITLE
test: commonize DB API integration fixtures and row counter

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from portfolio_fdc.db_api import app as db_app
+from portfolio_fdc.db_api.db import MAIN_DB
+
+
+@pytest.fixture
+def db_api_client() -> Iterator[TestClient]:
+    """Lifespan を含めて DB API アプリへアクセスする TestClient を提供する。"""
+    with TestClient(db_app.app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def client(db_api_client: TestClient) -> TestClient:
+    """既存テストとの互換のため client 名でも同じ TestClient を提供する。"""
+    return db_api_client
+
+
+@pytest.fixture
+def count_rows() -> Callable[[str], tuple[int, int, int]]:
+    """指定 process_id の ProcessInfo/StepWindows/Parameters 件数を返す関数。"""
+
+    def _count_rows(process_id: str) -> tuple[int, int, int]:
+        con = sqlite3.connect(MAIN_DB.as_posix())
+        try:
+            p = con.execute(
+                "SELECT COUNT(*) FROM processInfo WHERE process_id = ?",
+                (process_id,),
+            ).fetchone()[0]
+            s = con.execute(
+                "SELECT COUNT(*) FROM StepWindows WHERE process_id = ?",
+                (process_id,),
+            ).fetchone()[0]
+            f = con.execute(
+                "SELECT COUNT(*) FROM Parameters WHERE process_id = ?",
+                (process_id,),
+            ).fetchone()[0]
+            return int(p), int(s), int(f)
+        finally:
+            con.close()
+
+    return _count_rows

--- a/tests/test_aggregate_db_api_integration.py
+++ b/tests/test_aggregate_db_api_integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -13,7 +14,6 @@ import pytest
 import yaml
 from fastapi.testclient import TestClient
 
-from portfolio_fdc.db_api import app as db_app
 from portfolio_fdc.db_api.db import MAIN_DB
 from portfolio_fdc.main import aggregate
 
@@ -37,30 +37,13 @@ class _RequestsBridgeResponse:
         return self._payload
 
 
-def _count_rows(process_id: str) -> tuple[int, int, int]:
-    """指定 process_id の process/step/feature レコード件数を返す。"""
-    con = sqlite3.connect(MAIN_DB.as_posix())
-    try:
-        p = con.execute(
-            "SELECT COUNT(*) FROM processInfo WHERE process_id = ?",
-            (process_id,),
-        ).fetchone()[0]
-        s = con.execute(
-            "SELECT COUNT(*) FROM StepWindows WHERE process_id = ?",
-            (process_id,),
-        ).fetchone()[0]
-        f = con.execute(
-            "SELECT COUNT(*) FROM Parameters WHERE process_id = ?",
-            (process_id,),
-        ).fetchone()[0]
-        return int(p), int(s), int(f)
-    finally:
-        con.close()
-
-
-def test_aggregate_http_flow_to_db_api(monkeypatch) -> None:
+def test_aggregate_http_flow_to_db_api(
+    monkeypatch: pytest.MonkeyPatch,
+    db_api_client: TestClient,
+    count_rows: Callable[[str], tuple[int, int, int]],
+) -> None:
     """aggregate の通常投稿フローが DB API 経由で永続化されることを確認する。"""
-    client = TestClient(db_app.app)
+    client = db_api_client
 
     def fake_post(url: str, json, timeout: int):
         path = urlsplit(url).path
@@ -121,7 +104,7 @@ def test_aggregate_http_flow_to_db_api(monkeypatch) -> None:
             feats=features,
         )
 
-        process_count, step_count, feature_count = _count_rows(process_id)
+        process_count, step_count, feature_count = count_rows(process_id)
         assert process_count == 1
         assert step_count == 1
         assert feature_count == 2
@@ -129,15 +112,20 @@ def test_aggregate_http_flow_to_db_api(monkeypatch) -> None:
     finally:
         aggregate.delete_process("http://testserver", process_id)
 
-    process_count, step_count, feature_count = _count_rows(process_id)
+    process_count, step_count, feature_count = count_rows(process_id)
     assert process_count == 0
     assert step_count == 0
     assert feature_count == 0
 
 
-def test_aggregate_main_non_dry_run_posts_to_db_api(tmp_path: Path, monkeypatch) -> None:
+def test_aggregate_main_non_dry_run_posts_to_db_api(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    db_api_client: TestClient,
+    count_rows: Callable[[str], tuple[int, int, int]],
+) -> None:
     """aggregate.main の非 dry-run 実行が DB API 投稿と後始末まで完了することを確認する。"""
-    client = TestClient(db_app.app)
+    client = db_api_client
 
     def fake_post(url: str, json, timeout: int):
         path = urlsplit(url).path
@@ -226,7 +214,7 @@ def test_aggregate_main_non_dry_run_posts_to_db_api(tmp_path: Path, monkeypatch)
     assert Path(raw_csv_path).exists()
 
     aggregate.delete_process("http://testserver", process_id)
-    process_count, step_count, feature_count = _count_rows(process_id)
+    process_count, step_count, feature_count = count_rows(process_id)
     assert process_count == 0
     assert step_count == 0
     assert feature_count == 0

--- a/tests/test_db_api_integration.py
+++ b/tests/test_db_api_integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta
 from email.utils import parsedate_to_datetime
 from urllib.parse import quote
@@ -14,34 +14,6 @@ from portfolio_fdc.db_api import app as db_app
 from portfolio_fdc.db_api.db import MAIN_DB
 
 pytestmark = pytest.mark.integration
-
-
-@pytest.fixture
-def client() -> Iterator[TestClient]:
-    """Lifespan を含めて DB API アプリへアクセスする TestClient を提供する。"""
-    with TestClient(db_app.app) as test_client:
-        yield test_client
-
-
-def _count_rows(process_id: str) -> tuple[int, int, int]:
-    """指定 process_id の ProcessInfo/StepWindows/Parameters 件数を返す。"""
-    con = sqlite3.connect(MAIN_DB.as_posix())
-    try:
-        p = con.execute(
-            "SELECT COUNT(*) FROM processInfo WHERE process_id = ?",
-            (process_id,),
-        ).fetchone()[0]
-        s = con.execute(
-            "SELECT COUNT(*) FROM StepWindows WHERE process_id = ?",
-            (process_id,),
-        ).fetchone()[0]
-        f = con.execute(
-            "SELECT COUNT(*) FROM Parameters WHERE process_id = ?",
-            (process_id,),
-        ).fetchone()[0]
-        return int(p), int(s), int(f)
-    finally:
-        con.close()
 
 
 def build_process_payload(process_id: str) -> dict[str, str]:
@@ -77,7 +49,10 @@ def assert_legacy_migration_headers(
     assert response_headers.get("Link") == expected_link
 
 
-def test_db_api_minimum_flow_for_aggregate_contract(client: TestClient) -> None:
+def test_db_api_minimum_flow_for_aggregate_contract(
+    client: TestClient,
+    count_rows: Callable[[str], tuple[int, int, int]],
+) -> None:
     """process/step/parameter の最小フローが保存・削除まで成立することを確認する。"""
     process_id = f"it_{uuid4().hex}"
 
@@ -114,7 +89,7 @@ def test_db_api_minimum_flow_for_aggregate_contract(client: TestClient) -> None:
         assert feature_res.status_code == 200
         assert feature_res.json() == {"ok": True, "inserted": 1}
 
-        process_count, step_count, feature_count = _count_rows(process_id)
+        process_count, step_count, feature_count = count_rows(process_id)
         assert process_count == 1
         assert step_count == 1
         assert feature_count == 1
@@ -124,7 +99,7 @@ def test_db_api_minimum_flow_for_aggregate_contract(client: TestClient) -> None:
         assert deleted.status_code == 200
         assert deleted.json()["ok"] is True
 
-    process_count, step_count, feature_count = _count_rows(process_id)
+    process_count, step_count, feature_count = count_rows(process_id)
     assert process_count == 0
     assert step_count == 0
     assert feature_count == 0
@@ -263,7 +238,10 @@ def test_db_api_process_upsert_on_same_process_id(client: TestClient) -> None:
         )
 
 
-def test_db_api_aggregate_write_accepts_empty_lists(client: TestClient) -> None:
+def test_db_api_aggregate_write_accepts_empty_lists(
+    client: TestClient,
+    count_rows: Callable[[str], tuple[int, int, int]],
+) -> None:
     """`/aggregate/write` が空の step_windows/parameters を受理できることを確認する。"""
     process_id = f"agg_empty_{uuid4().hex}"
 
@@ -286,7 +264,7 @@ def test_db_api_aggregate_write_accepts_empty_lists(client: TestClient) -> None:
         assert res.status_code == 200
         assert res.json() == {"ok": True, "step_windows": 0, "parameters": 0}
 
-        process_count, step_count, feature_count = _count_rows(process_id)
+        process_count, step_count, feature_count = count_rows(process_id)
         assert process_count == 1
         assert step_count == 0
         assert feature_count == 0


### PR DESCRIPTION
## What

- `tests/conftest.py` を新規追加し、DB API 統合テスト向けの共通 fixture を導入
- `db_api_client`（lifespan 管理付き `TestClient`）を共通化
- 既存互換のため `client` fixture を `db_api_client` のエイリアスとして提供
- `count_rows` fixture を追加し、`processInfo` / `StepWindows` / `Parameters` 件数取得を共通化
- `tests/test_db_api_integration.py` から重複していた `client` fixture と `_count_rows` を削除し、共通 fixture を利用
- `tests/test_aggregate_db_api_integration.py` から重複していた `_count_rows` と `TestClient` 直接初期化を削除し、共通 fixture を利用

## Why

- Issue `#9`（テストコードのリファクタリング）の一部として、重複テストユーティリティを集約するため
- `TestClient` 初期化と DB 行数確認ロジックを一元化し、保守性を上げるため
- 後続のテスト拡張（共通ヘルパー追加や fixture 拡充）をしやすくするため

## How

- `tests/conftest.py` に以下を実装
  - `db_api_client` fixture
  - `client` fixture（互換）
  - `count_rows` fixture
- 既存テスト2ファイルで、重複実装を削除して fixture 注入に置換
- 既存のテスト意図・アサーションは変更せず、共通化のみ実施

## Test

- `E:/work/python/logger/.venv/Scripts/python.exe -m pytest tests/test_db_api_integration.py tests/test_aggregate_db_api_integration.py`
- 結果: `12 passed`

## Checklist

- [x] Tests added/updated
- [x] ruff/mypy/pytest pass locally
- [x] No behavior change intended (refactor only)

close #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更概要

### 新規：共通テスト fixture の導入
- **tests/conftest.py** に3つの pytest fixture を追加：
  - `db_api_client`: lifespan を含めた TestClient（コンテキストマネージャで管理）
  - `client`: db_api_client のエイリアス（既存テストとの互換性維持）
  - `count_rows`: 指定 process_id に対して processInfo/StepWindows/Parameters テーブルの件数を返す Callable

### リファクタリング：テストファイルの統合
- **tests/test_db_api_integration.py**
  - ローカル `_count_rows` 関数を削除、共通 `count_rows` fixture を使用
  - テスト関数シグネチャに `count_rows: Callable[[str], tuple[int, int, int]]` を追加
  
- **tests/test_aggregate_db_api_integration.py**
  - ローカル `_count_rows` 関数を削除、共通 `count_rows` fixture を使用
  - `Callable` 型を `collections.abc` からインポート
  - テスト関数シグネチャに `db_api_client` と `count_rows` を追加

### リスク・テストギャップ
- **SQLite 接続管理**: count_rows fixture 内でようやく `finally` で接続をクローズしているが、複数テストの並列実行時の DB アクセス競合が発生する可能性
- **Lifespan ハンドラ検証**: startup/shutdown が正しく呼ばれていることをアサートするテストが明示されていない
- **テストデータベース隔離**: テスト間のデータベース状態の隔離方法が確認できず、テスト順序依存の発生リスク
- **型ヒント不完全**: fixture の戻り値型が `Iterator[TestClient]` と `TestClient` で混在している

### テスト実行
- ローカルで 12 tests passed を確認

<!-- end of auto-generated comment: release notes by coderabbit.ai -->