### PR TITLE
fix(aggregate): fallback to UNKNOWN on recipe rule load failures

### DIFF
--- a/src/portfolio_fdc/main/aggregate.py
+++ b/src/portfolio_fdc/main/aggregate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,8 @@ import yaml
 
 from ..core.segmentation.classifier import RecipeClassifier
 from ..core.segmentation.models import StepBundle, StepPeak
+
+logger = logging.getLogger(__name__)
 
 RECIPE_RULES_PATH_ENV_VAR = "PORTFOLIO_RECIPE_RULES_PATH"
 DEFAULT_RECIPE_RULES_PATH = Path(__file__).resolve().parents[1] / "configs" / "recipe_rules.yaml"
@@ -46,7 +49,14 @@ _RECIPE_CLASSIFIER_CACHE: dict[Path, RecipeClassifier] = {}
 def get_recipe_classifier(path: Path) -> RecipeClassifier:
     cache_key = path.resolve()
     if cache_key not in _RECIPE_CLASSIFIER_CACHE:
-        _RECIPE_CLASSIFIER_CACHE[cache_key] = RecipeClassifier(load_yaml(cache_key))
+        try:
+            _RECIPE_CLASSIFIER_CACHE[cache_key] = RecipeClassifier(load_yaml(cache_key))
+        except (FileNotFoundError, OSError, yaml.YAMLError, TypeError, ValueError, AttributeError):
+            logger.exception(
+                "Failed to load recipe rules from %s. Falling back to UNKNOWN classification.",
+                cache_key,
+            )
+            _RECIPE_CLASSIFIER_CACHE[cache_key] = RecipeClassifier({})
     return _RECIPE_CLASSIFIER_CACHE[cache_key]
 
 

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 from typing import Any
@@ -350,6 +351,43 @@ def test_classify_recipe_from_peaks_returns_unknown_without_timestamp(monkeypatc
     recipe = aggregate.classify_recipe_from_peaks(queue, df.drop(columns=["timestamp"]))
 
     assert recipe == "UNKNOWN"
+
+
+def test_get_recipe_classifier_fallbacks_on_missing_rules_file(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    """ルールファイル欠落時に UNKNOWN フォールバックとログ出力を行うことを確認する。"""
+    missing_path = tmp_path / "missing_rules.yaml"
+    aggregate._RECIPE_CLASSIFIER_CACHE.clear()
+
+    with caplog.at_level(logging.ERROR):
+        classifier = aggregate.get_recipe_classifier(missing_path)
+
+    bundles = [
+        StepBundle(step_no=1, dc_bias=_make_step_peak("dc_bias", 2.0), cl2_flow=None),
+    ]
+    assert classifier.classify(bundles) == "UNKNOWN"
+    assert "Falling back to UNKNOWN classification" in caplog.text
+
+
+def test_get_recipe_classifier_fallbacks_on_yaml_parse_error(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    """ルールYAMLパース失敗時に UNKNOWN フォールバックとログ出力を行うことを確認する。"""
+    invalid_rules = tmp_path / "invalid_rules.yaml"
+    invalid_rules.write_text("recipes: [", encoding="utf-8")
+    aggregate._RECIPE_CLASSIFIER_CACHE.clear()
+
+    with caplog.at_level(logging.ERROR):
+        classifier = aggregate.get_recipe_classifier(invalid_rules)
+
+    bundles = [
+        StepBundle(step_no=1, dc_bias=_make_step_peak("dc_bias", 2.0), cl2_flow=None),
+    ]
+    assert classifier.classify(bundles) == "UNKNOWN"
+    assert "Falling back to UNKNOWN classification" in caplog.text
 
 
 def test_recipe_classifier_returns_unknown_when_channels_missing() -> None:


### PR DESCRIPTION
## What
`aggregate` のレシピルール読み込み失敗時のフォールバックを強化しました（Issue #19）。

- `get_recipe_classifier(path)` に例外ハンドリングを追加
- ルールファイルの欠落・読み込み失敗・YAMLパース失敗・不正構造時に、
  - 明示的にエラーログを出力
  - `RecipeClassifier({})` へフォールバック
- フォールバック時の分類結果は安全側で `UNKNOWN` になることを保証

## Why
PR #18 で挙がっていた「ルールファイル読み込み時の堅牢性不足（欠落・パースエラー時の不十分なフォールバック）」を解消するためです。  
分類処理の途中で例外停止せず、運用時に安全に継続できるようにします。

## How
- aggregate.py
  - `logging` を導入し `logger` を追加
  - `get_recipe_classifier` 内で以下を捕捉:
    - `FileNotFoundError`
    - `OSError`
    - `yaml.YAMLError`
    - `TypeError` / `ValueError` / `AttributeError`
  - 例外時に `logger.exception(...)` を出し、`RecipeClassifier({})` をキャッシュ

- test_aggregate.py
  - 欠落ファイル時に `UNKNOWN` フォールバック + ログ出力を確認するテストを追加
  - YAMLパースエラー時に `UNKNOWN` フォールバック + ログ出力を確認するテストを追加

## Test
- `pytest test_aggregate.py -v` → `18 passed`
- `pytest test_aggregate_db_api_integration.py test_generate_scrape_integration.py -v` → `12 passed`

## Impact
- ルール読み込み失敗時の実行時例外停止リスクを低減
- 分類処理は `UNKNOWN` で安全継続
- 失敗原因はログで追跡可能

## Issue
Closes #19

## Checklist

- [ ] Tests added/updated
- [ ] ruff/mypy/pytest pass locally
- [ ] CodeRabbit comments addressed (or resolved with rationale)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容

**aggregate.py**
- `logging` を導入、モジュールレベルのロガーを追加
- `get_recipe_classifier(path)` で例外処理を実装
  - 捕捉例外: `FileNotFoundError`, `OSError`, `yaml.YAMLError`, `TypeError`, `ValueError`, `AttributeError`
  - 失敗時は `logger.exception()` でスタックトレース付きログを出力
  - キャッシュに `RecipeClassifier({})` を格納してフォールバック
  - 空ルール辞書により自動的に `classify()` が `"UNKNOWN"` を返す設計

**test_aggregate.py**
- ファイル欠落時: `test_get_recipe_classifier_fallbacks_on_missing_rules_file()`
- YAMLパースエラー時: `test_get_recipe_classifier_fallbacks_on_yaml_parse_error()`
- 両テストで ERROR ログレベルキャプチャ、"Falling back to UNKNOWN classification" 出力確認、分類結果が "UNKNOWN" であること検証

## テスト結果
- `test_aggregate.py`: 18 passed
- 統合テスト: 12 passed

## リスク・注意点
- **キャッシュ戦略**: 一度フォールバックするとキャッシュに記録され、その後同じパスへのファイル復旧があっても反映されない。キャッシュ有効期限がないため長時間実行時に古い状態が続く可能性あり
- **例外の粒度**: `AttributeError`, `TypeError`, `ValueError` を広く捕捉しており、YAML パース以外の予期しないエラーもマスクされるリスク
- **ログ量**: `logger.exception()` はスタックトレース全量出力のため、ネットワークストレージやログ送信時に負荷となる可能性
- **テストカバレッジ**: 正常系の複数ルール条件での分類成功テストが別途必要（本PRは失敗ケースのみ）

## テスト上の制限
- モックやパッチ使用がないため、実ファイルI/O依存
- YAML エラーのバリエーション（不正な型指定、循環参照など）が単一パターンのみ
- 同時実行や複数キャッシュ競合のシナリオが未検証

<!-- end of auto-generated comment: release notes by coderabbit.ai -->