### PR TITLE
docs: enforce module boundary rules and API consumer scope (#106)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,13 @@ repos:
           - PyYAML>=6.0
           - types-PyYAML>=6.0.12
           - types-requests>=2.32.0
+
+  - repo: local
+    hooks:
+      - id: import-linter
+        name: import-linter
+        entry: python scripts/run_import_linter.py
+        language: python
+        additional_dependencies:
+          - import-linter>=2.3
+        pass_filenames: false

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -41,3 +41,20 @@
 - dashboard の read path は `db_api` 経由のみとする（Discussion #93）。
 - dashboard 実装前提の read endpoint は Issue #98 で追跡している。
 - 変更ガバナンス endpoint は Issue #102 の合意を前提に設計・実装する。
+
+## Consumer Permission Scope
+
+モジュール境界（dashboard -> api のみ、dashboard -> judge 禁止、judge -> dashboard 禁止）を維持するため、
+各 consumer の許可範囲を以下で定義する。
+
+| Consumer  | Allowed Scope                                                                                                         | Disallowed Scope                                                                                     |
+| --------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| ingest    | `POST /processes`, `POST /step_windows/bulk`, `POST /parameters/bulk`, `POST /aggregate/write`, `DELETE /processes/*` | dashboard 向け read endpoint、governance endpoint                                                    |
+| judge     | `GET /charts`, `GET /charts/active`, `GET /charts/history`, judge 結果の write endpoint（実装時）                     | dashboard 専用集計 read endpoint、governance endpoint                                                |
+| dashboard | `GET /charts*`, `GET /judge/results*`, `POST/GET /governance/*`                                                       | ingest write endpoint（`/processes*`, `/step_windows/bulk`, `/parameters/bulk`, `/aggregate/write`） |
+| ops/audit | `GET /governance/*`, `POST /governance/*`（approve/apply/ratify/retry）                                               | ingest の通常データ投入 endpoint                                                                     |
+
+検証方針:
+
+1. import 境界は `import-linter` で CI と pre-commit で機械検出する。
+2. endpoint 権限は API スキーマ実装時にテスト（認可・認証）で検証する。

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -47,14 +47,14 @@
 モジュール境界（dashboard -> api のみ、dashboard -> judge 禁止、judge -> dashboard 禁止）を維持するため、
 各 consumer の許可範囲を以下で定義する。
 
-| Consumer  | Allowed Scope                                                                                                         | Disallowed Scope                                                                                     |
-| --------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| ingest    | `POST /processes`, `POST /step_windows/bulk`, `POST /parameters/bulk`, `POST /aggregate/write`, `DELETE /processes/*` | dashboard 向け read endpoint、governance endpoint                                                    |
-| judge     | `GET /charts`, `GET /charts/active`, `GET /charts/history`, judge 結果の write endpoint（実装時）                     | dashboard 専用集計 read endpoint、governance endpoint                                                |
-| dashboard | `GET /charts*`, `GET /judge/results*`, `POST/GET /governance/*`                                                       | ingest write endpoint（`/processes*`, `/step_windows/bulk`, `/parameters/bulk`, `/aggregate/write`） |
-| ops/audit | `GET /governance/*`, `POST /governance/*`（approve/apply/ratify/retry）                                               | ingest の通常データ投入 endpoint                                                                     |
+| Consumer  | Allowed Scope                                                                                                                                                                                                                                                                                        | Disallowed Scope                                                                                   |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| ingest    | `POST /processes`, `POST /step_windows/bulk`, `POST /parameters/bulk`, `POST /aggregate/write`, `DELETE /processes/*`                                                                                                                                                                                | dashboard 向け read endpoint、governance endpoint                                                  |
+| judge     | `GET /charts`, `GET /charts/active`, judge 結果の write endpoint（実装時）                                                                                                                                                                                                                           | `GET /charts/history`（dashboard/ops 専用）、dashboard 専用集計 read endpoint、governance endpoint |
+| dashboard | `GET /charts*`, `GET /charts/history`, `GET /judge/results*`, `POST /governance/change-requests`, `POST /governance/emergency-changes`                                                                                                                                                               | `GET /governance/*`、governance approve/apply/ratify/retry endpoint、ingest write endpoint         |
+| ops/audit | `GET /governance/change-requests`, `GET /governance/audit-events`, `POST /governance/change-requests`, `POST /governance/change-requests/{id}/approve`, `POST /governance/change-requests/{id}/apply`, `POST /governance/emergency-changes/{id}/ratify`, `POST /governance/notifications/{id}/retry` | ingest の通常データ投入 endpoint                                                                   |
 
 検証方針:
 
-1. import 境界は `import-linter` で CI と pre-commit で機械検出する。
+1. import 境界は `import-linter` で pre-commit で機械検出する（CI での強制は未実装・フォローアップ: Issue #108）。
 2. endpoint 権限は API スキーマ実装時にテスト（認可・認証）で検証する。

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -36,7 +36,7 @@ Discussion #90 と PR #92 / #100 で、モジュール境界方針
 - モジュール依存違反は import-linter 契約違反として検出される
 - 開発フローに pre-commit での境界チェックが追加される
 - endpoint ごとの consumer 許可範囲が docs 上で参照可能になる
-- CI 必須化（GitHub Actions で import-linter 実行）はフォローアップタスクとして管理する
+- CI 必須化（GitHub Actions で import-linter 実行）はフォローアップタスクとして管理する（追跡: Issue #108）
 
 ## 2026-04-10: #104 正本データの扱い（DB正本 + seed復旧用）
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,5 +1,43 @@
 # Decision Log
 
+## 2026-04-11: #106 モジュール境界の機械的担保と API 許可範囲の運用ルール実装
+
+### Context
+
+Discussion #90 と PR #92 / #100 で、モジュール境界方針
+（dashboard -> api のみ許可、dashboard -> judge 禁止、judge -> dashboard 禁止）は
+合意済みだったが、コードベースで違反を検知する機械的仕組みは未実装だった。
+また、ingest/judge/dashboard/ops が api を呼ぶ際の許可範囲が
+運用手順として明文化されておらず、将来の境界逸脱リスクが残っていた。
+
+### Decision
+
+システムとして以下を実装する。
+
+1. import 境界は `import-linter` で機械検証する
+2. `pyproject.toml` に禁止依存契約を定義する
+   - dashboard must not import judge
+   - judge must not import dashboard
+   - main ingest must not import dashboard or judge
+3. `.pre-commit-config.yaml` に import-linter フックを追加する
+4. `scripts/run_import_linter.py` を追加し、`src` 配下を安定的に解析可能にする
+5. `docs/db-api-endpoints.md` に `Consumer Permission Scope` を追加し、
+   ingest/judge/dashboard/ops-audit の許可/禁止範囲を明記する
+
+### Why
+
+- 方針だけでなく機械検証を導入することで、実装拡張時の境界逸脱を早期に検出できる
+- pre-commit フックによりローカル段階で違反を止められる
+- API 許可範囲を文書化することで、モジュール責務を運用と実装の両面で一致できる
+- 将来の judge/dashboard 実装拡張時にも境界ルールを継続適用しやすい
+
+### Consequence
+
+- モジュール依存違反は import-linter 契約違反として検出される
+- 開発フローに pre-commit での境界チェックが追加される
+- endpoint ごとの consumer 許可範囲が docs 上で参照可能になる
+- CI 必須化（GitHub Actions で import-linter 実行）はフォローアップタスクとして管理する
+
 ## 2026-04-10: #104 正本データの扱い（DB正本 + seed復旧用）
 
 ### Context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "httpx>=0.28",
+  "import-linter>=2.3",
   "pytest>=8",
   "ruff>=0.6",
   "mypy>=1.10",
@@ -44,6 +45,27 @@ markers = [
   "integration: end-to-end style tests combining generators and scraper",
   "slow: heavy tests that generate large files or run longer",
 ]
+
+[tool.importlinter]
+root_packages = ["portfolio_fdc"]
+
+[[tool.importlinter.contracts]]
+name = "dashboard must not import judge"
+type = "forbidden"
+source_modules = ["portfolio_fdc.dashboard"]
+forbidden_modules = ["portfolio_fdc.judge"]
+
+[[tool.importlinter.contracts]]
+name = "judge must not import dashboard"
+type = "forbidden"
+source_modules = ["portfolio_fdc.judge"]
+forbidden_modules = ["portfolio_fdc.dashboard"]
+
+[[tool.importlinter.contracts]]
+name = "main ingest must not import dashboard or judge"
+type = "forbidden"
+source_modules = ["portfolio_fdc.main"]
+forbidden_modules = ["portfolio_fdc.dashboard", "portfolio_fdc.judge"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/run_import_linter.py
+++ b/scripts/run_import_linter.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from importlinter.cli import lint_imports_command
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    sys.path.insert(0, str(src_dir))
+
+    args = ["--config", str(repo_root / "pyproject.toml")]
+    lint_imports_command.main(args=args, standalone_mode=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

Issue #106 対応として、モジュール境界ルールを方針からシステム実装へ進める変更を追加しました。

## 変更内容

1. import 境界の機械検証
- pyproject.toml に import-linter 契約を追加
  - dashboard must not import judge
  - judge must not import dashboard
  - main ingest must not import dashboard or judge

2. pre-commit 統合
- .pre-commit-config.yaml に import-linter フックを追加
- scripts/run_import_linter.py を追加し、src パス解決を安定化

3. API 許可範囲の明文化
- docs/db-api-endpoints.md に Consumer Permission Scope を追加
- ingest/judge/dashboard/ops-audit の allowed/disallowed scope を明記

4. Decision Log 更新
- docs/decision-log.md に 2026-04-11 #106 エントリを追加

## 確認

- pre-commit hooks: ruff, mypy, import-linter を含め通過

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## モジュール境界ルールとAPI消費者スコープの強制実装

### 変更概要
- pyproject.toml に import-linter 設定を追加し、禁止インポート契約を導入
  - portfolio_fdc.dashboard → portfolio_fdc.judge 禁止
  - portfolio_fdc.judge → portfolio_fdc.dashboard 禁止
  - portfolio_fdc.main → dashboard/judge 禁止
- .pre-commit-config.yaml にローカル hook として import-linter を追加（pass_filenames: false、import-linter>=2.3）
- src パス解決を安定化するラッパー scripts/run_import_linter.py を追加（pyproject.toml を config に指定して importlinter を実行）
- docs/db-api-endpoints.md に「Consumer Permission Scope」セクションを追加し、ingest/judge/dashboard/ops-audit ごとの許可・禁止スコープをエンドポイント単位で明記（曖昧な /governance/* パターンを個別エンドポイント列挙に置換）
- docs/decision-log.md に 2026-04-11 の #106 の決定記録を追加（CI 実行はフォローアップ Issue #108 として明記）
- 検証: ローカルで pre-commit フック（ruff, mypy, import-linter）は通過した旨が報告される（CI 強制は未導入）

### リスク
- scripts/run_import_linter.py は常に exit code 0 を返す実装になっており、違反が検出されても pre-commit/CI を失敗させない可能性がある（即時修正が必要）
- import-linter は現状 pre-commit 経由のみで CI 強制は未実装（Issue #108 で追跡）
- ドキュメント化のみで API 権限の実行時強制は未実装 → 実装とドキュメントの不整合リスク
- 既存コードベースが新ルールに準拠しているかの全体検証が行われていない

### テスト／検証ギャップ
- import-linter ルールを意図どおり検出する自動テストがない
- scripts/run_import_linter.py のユニットテストがない
- API 消費者スコープ（認可ルール）に対する統合テスト／自動化検証がない
- CI（GitHub Actions）での import-linter 強制が未実装 → Pull request/merge 時点での機械的ブロックがない

### 推奨アクション（短絡）
- run_import_linter.py が import-linter の終了コードをそのまま返すよう修正し、pre-commit で違反時に失敗させる
- import-linter を CI ワークフローに追加（Issue #108 実装）
- ルール違反がないことを確認するためのテスト（ルールごとのサンプル違反ケース）を追加
- API 権限はエンドポイント実装側でも自動テスト化してドキュメントとの整合性を確保する
<!-- end of auto-generated comment: release notes by coderabbit.ai -->