### PR TITLE
feat(db_api): implement GET /charts endpoint (#129)

### DIFF
--- a/docs/coderabbit-pr135-findings.md
+++ b/docs/coderabbit-pr135-findings.md
@@ -1,0 +1,142 @@
+# CodeRabbit Findings Memo (PR #135)
+
+更新日: 2026-04-14 (JST)
+対象PR: #135 (`feature/get-charts-endpoint-129`)
+
+## 目的
+
+このメモは、CodeRabbit から指摘された論点を「どのファイルのどの種類の問題か」で追跡するための作業メモです。
+
+## Findings 一覧（現時点）
+
+### 1. docs 系
+
+1. `docs/db-api-minimum-contract.md` 変更に対して `docs/dashboard-architecture-playbook.md` 側の同期不足
+
+- 指摘内容:
+  - Phase 1 の 5 endpoint の明示
+  - response envelope / timestamp / status code / payload 例の同期
+  - Minimum Test Matrix 実行の注記
+- 現状: 対応済み
+
+2. `docs/issues/parent-db-api-minimum-contract-phase1.md` の子Issue表記がプレースホルダ
+
+- 指摘内容:
+  - `Child - ...` 文字列を `#129`-`#133` へ置換
+  - tracking note の文言更新
+- 現状: 対応済み
+
+3. `docs/dashboard-architecture-playbook.md` の詳細契約重複とMD040
+
+- 指摘内容:
+  - 設計書に詳細JSONを重複記載しすぎ
+  - code fence に language 未指定
+  - 結合リスク評価の注意を追記
+- 現状: 対応済み
+
+### 2. db_api 実装系
+
+1. `src/portfolio_fdc/db_api/app.py` の 500 detail に内部例外文字列を露出
+
+- 指摘内容:
+  - ログには詳細、レスポンスは generic message にする
+- 現状: 対応済み
+
+2. `src/portfolio_fdc/db_api/chart_repository.py` の read path で `_init_schema` 実行
+
+- 指摘内容:
+  - repository の hidden side effect を削除
+  - schema 初期化は app startup へ移動
+- 現状: 対応済み
+
+3. 422 の error envelope が FastAPI 既定フォーマット依存
+
+- 指摘内容:
+  - `/charts` の invalid `step_no` で契約フォーマットを返すべき
+- 現状: 対応済み
+- 補足:
+  - `RequestValidationError` 共通ハンドラを導入し `ok/error/details` へ統一
+
+4. パフォーマンスリスク: `version` 算出で行ごと相関 `COUNT(*)`
+
+- 指摘内容:
+  - 大量取得時にCPU負荷増大の懸念
+- 現状: 対応済み
+- 補足:
+  - 相関サブクエリから `filtered_charts` + `history_versions` 集約JOINへ変更
+
+### 3. test 系（GET /charts）
+
+1. `tests/test_db_api_charts_endpoint.py` の filter 検証が部分集合チェック
+
+- 指摘内容:
+  - 全レスポンス配列を対象に検証する
+  - `all(...)` の前に非空確認を入れる
+- 現状: 対応済み
+
+2. 同ファイルで query filter の追加カバレッジ不足
+
+- 指摘内容:
+  - `chamber_id`, `recipe_id`, `parameter`, 正の `step_no`, `feature_type` を追加
+- 現状: 対応済み
+
+3. `updated_at` と閾値系フィールドの検証が緩い
+
+- 指摘内容:
+  - regex ではなく期待値一致（UTC正規化結果）
+  - `warning_lcl/ucl`, `lcl/ucl`, `critical_lcl/ucl` を fixture 実値と厳密比較
+- 現状: 対応済み
+
+4. `version` テストの `any(...)` が重複混入を見逃す
+
+- 指摘内容:
+  - 単一件を明示 (`len(data) == 1`) して `data[0]["version"] == 3` 検証
+- 現状: 対応済み
+
+5. history seed timestamp の生成が脆い
+
+- 指摘内容:
+  - `"0{index}"` 連結ではなく ISO 8601 生成へ
+- 現状: 対応済み
+
+### 4. test ヘルパー・fixture 構成
+
+1. `assert_validation_error_envelope` の重複定義
+
+- 指摘内容:
+  - 共通 helper へ抽出
+- 現状: 対応済み
+- 反映先:
+  - `tests/test_utils.py`
+  - `tests/test_db_api_charts_endpoint.py`
+  - `tests/test_db_api_integration.py`
+
+2. `seeded_chart_rows_for_get_charts` の setup/teardown を fixture 化
+
+- 指摘内容:
+  - `yield` fixture で ActiveChartSet 復元を明示
+- 現状: 対応済み
+
+3. `seeded_chart_rows_for_filter_tests` も同様に fixture 化
+
+- 指摘内容:
+  - DB状態変更を fixture の setup/teardown に閉じ込める
+- 現状: 対応済み
+
+4. 2つの seed fixture で重複する共通処理
+
+- 指摘内容:
+  - 共有 helper（共通フロー）へ抽出
+- 現状: 対応済み
+
+5. `tests/test_utils.py` で `details["issues"]` 検証が緩い
+
+- 指摘内容:
+  - 非空、各issueの `loc` / `msg` キーと型を必須化
+  - `issue.get` ではなく direct access で fail-loud にする
+- 現状: 対応済み
+
+## 現状サマリ
+
+- CodeRabbit 指摘のうち、ここまでに提示された項目はすべて対応済み。
+- 以降の差分で新たな指摘が出た場合は、このファイルに追記する。

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -22,7 +22,7 @@
 | `POST`   | `/step_windows/bulk`                                | ingest write   | implemented | ingest          | source: `db_api/app.py` | `StepWindow` を一括保存                      |
 | `POST`   | `/parameters/bulk`                                  | ingest write   | implemented | ingest          | source: `db_api/app.py` | `Parameter` を一括保存                       |
 | `POST`   | `/aggregate/write`                                  | ingest write   | implemented | ingest          | source: `db_api/app.py` | Process/StepWindow/Parameter を原子的に保存  |
-| `GET`    | `/charts`                                           | dashboard read | planned     | dashboard/judge | Issue #98               | chart 定義一覧                               |
+| `GET`    | `/charts`                                           | dashboard read | implemented | dashboard/judge | source: `db_api/app.py` | chart 定義一覧                               |
 | `GET`    | `/charts/active`                                    | dashboard read | planned     | dashboard/judge | Issue #98               | active chart set と閾値                      |
 | `GET`    | `/charts/history`                                   | dashboard read | planned     | dashboard/ops   | Issue #98               | chart 変更履歴                               |
 | `GET`    | `/judge/results`                                    | dashboard read | planned     | dashboard       | Issue #98               | 判定結果一覧                                 |

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -42,6 +42,8 @@
 - dashboard 実装前提の read endpoint は Issue #98 で追跡している。
 - 変更ガバナンス endpoint は Issue #102 の合意を前提に設計・実装する。
 - Phase 1 の最小 read 契約は `docs/db-api-minimum-contract.md` を実装基準とする。
+- `GET /charts` の文字列クエリ（`tool_id` 等）は `^[A-Za-z0-9_./:-]+$`（1..128 文字）を許可形式とする。
+- API の timestamp 正規化は UTC ISO 8601 ミリ秒固定で、マイクロ秒以下は切り捨てとする。
 
 ## Consumer Permission Scope
 

--- a/docs/db-api-minimum-contract.md
+++ b/docs/db-api-minimum-contract.md
@@ -81,6 +81,11 @@ dashboard read-only baseline と judge 最小実装に必要な API 契約を、
 - `feature_type`
 - `active_only` (bool)
 
+フィールド意味（互換注記）:
+
+- `lcl` / `ucl` は後方互換のための互換フィールドであり、現在は `critical_lcl` / `critical_ucl` と同値を返す
+- 新規実装では `warning_*` と `critical_*` の明示フィールド参照を優先する
+
 成功レスポンス例:
 
 ```json

--- a/docs/db-api-minimum-contract.md
+++ b/docs/db-api-minimum-contract.md
@@ -54,6 +54,7 @@ dashboard read-only baseline と judge 最小実装に必要な API 契約を、
 
 - 形式: `YYYY-MM-DDTHH:mm:ss.SSSZ`
 - 例: `2026-04-14T00:00:00.000Z`
+- ミリ秒化ルール: マイクロ秒以下は切り捨て（round half-up ではない）
 
 ### Status Code Policy
 
@@ -80,6 +81,12 @@ dashboard read-only baseline と judge 最小実装に必要な API 契約を、
 - `step_no`
 - `feature_type`
 - `active_only` (bool)
+
+クエリ検証ルール:
+
+- `step_no` は `>= 0`
+- 文字列フィルタ（`tool_id`, `chamber_id`, `recipe_id`, `parameter`, `feature_type`）は `1..128` 文字
+- 文字列フィルタは `^[A-Za-z0-9_./:-]+$` のみ許可（空白や制御文字は不可）
 
 フィールド意味（互換注記）:
 

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -43,6 +43,8 @@ logger = logging.getLogger(__name__)
 _runner_lock = Lock()
 LEGACY_DELETE_PROCESSES_SUNSET_AT = datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC)
 LEGACY_DELETE_PROCESSES_SUNSET = format_datetime(LEGACY_DELETE_PROCESSES_SUNSET_AT, usegmt=True)
+CHARTS_FILTER_PATTERN = r"^[A-Za-z0-9_./:-]+$"
+CHARTS_FILTER_MAX_LENGTH = 128
 
 
 def _legacy_delete_headers(process_id: str | None) -> dict[str, str]:
@@ -146,12 +148,37 @@ _chart_repository = ChartRepository()
 
 @app.get("/charts")
 def get_charts(
-    tool_id: str | None = None,
-    chamber_id: str | None = None,
-    recipe_id: str | None = None,
-    parameter: str | None = None,
+    tool_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
+    chamber_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
+    recipe_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
+    parameter: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
     step_no: int | None = Query(default=None, ge=0),
-    feature_type: str | None = None,
+    feature_type: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
     active_only: bool = False,
 ):
     """Chart 定義一覧を返す。"""

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from dataclasses import asdict
 from datetime import UTC, datetime
 from email.utils import format_datetime
 from threading import Lock
 from typing import Annotated, cast
 from urllib.parse import quote
 
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 
 from .aggregate_repository import (
     delete_process,
@@ -24,6 +25,7 @@ from .aggregate_repository import (
     write_process,
     write_step_windows_bulk,
 )
+from .chart_repository import ChartRepository, ChartsQueryCriteria
 from .db import MAIN_DB, TEMP_DB
 from .schemas import (
     AggregateWriteIn,
@@ -117,6 +119,34 @@ def get_runner(request: Request) -> DBTaskRunner:
 
 
 RunnerDep = Annotated[DBTaskRunner, Depends(get_runner)]
+_chart_repository = ChartRepository()
+
+
+@app.get("/charts")
+def get_charts(
+    tool_id: str | None = None,
+    chamber_id: str | None = None,
+    recipe_id: str | None = None,
+    parameter: str | None = None,
+    step_no: int | None = Query(default=None, ge=0),
+    feature_type: str | None = None,
+    active_only: bool = False,
+):
+    """Chart 定義一覧を返す。"""
+    criteria = ChartsQueryCriteria(
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter=parameter,
+        step_no=step_no,
+        feature_type=feature_type,
+        active_only=active_only,
+    )
+    try:
+        rows = _chart_repository.find_charts(criteria)
+        return {"ok": True, "data": [asdict(row) for row in rows]}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @app.post("/processes")

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -26,7 +26,7 @@ from .aggregate_repository import (
     write_step_windows_bulk,
 )
 from .chart_repository import ChartRepository, ChartsQueryCriteria
-from .db import MAIN_DB, TEMP_DB
+from .db import MAIN_DB, TEMP_DB, _init_schema
 from .schemas import (
     AggregateWriteIn,
     ParameterIn,
@@ -77,6 +77,7 @@ def _get_or_create_runner(app: FastAPI) -> DBTaskRunner:
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """FastAPI の起動/終了時に DBTaskRunner のライフサイクルを管理する。"""
     try:
+        _init_schema(MAIN_DB)
         yield
     finally:
         runner: DBTaskRunner | None = None
@@ -146,7 +147,8 @@ def get_charts(
         rows = _chart_repository.find_charts(criteria)
         return {"ok": True, "data": [asdict(row) for row in rows]}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        logger.exception("Failed to fetch charts")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @app.post("/processes")

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -17,6 +17,9 @@ from typing import Annotated, cast
 from urllib.parse import quote
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 from .aggregate_repository import (
     delete_process,
@@ -97,6 +100,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 
 app = FastAPI(title="db_api", version="0.1.0", lifespan=lifespan)
+
+
+@app.exception_handler(RequestValidationError)
+async def handle_request_validation_error(request: Request, exc: RequestValidationError):
+    """FastAPI の入力バリデーション例外を共通エラーフォーマットへ変換する。"""
+    logger.warning("Validation error on %s %s", request.method, request.url.path)
+    issues = jsonable_encoder(exc.errors())
+    return JSONResponse(
+        status_code=422,
+        content={
+            "ok": False,
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "Validation error",
+                "details": {"issues": issues},
+            },
+        },
+    )
 
 
 @app.middleware("http")

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -24,7 +24,12 @@ class ChartsQueryCriteria:
 
 @dataclass(frozen=True)
 class ChartView:
-    """`GET /charts` レスポンス 1 件分の DTO。"""
+    """`GET /charts` レスポンス 1 件分の DTO。
+
+    `lcl/ucl` は後方互換のために維持している互換フィールドで、
+    現在は `critical_lcl/critical_ucl` と同値を返す。
+    新規利用側は warning/critical の明示フィールド参照を優先する。
+    """
 
     chart_id: str
     chart_set_id: int
@@ -34,8 +39,8 @@ class ChartView:
     parameter: str
     step_no: int
     feature_type: str
-    lcl: float | None
-    ucl: float | None
+    lcl: float | None  # Compatibility alias of critical_lcl.
+    ucl: float | None  # Compatibility alias of critical_ucl.
     warning_lcl: float | None
     warning_ucl: float | None
     critical_lcl: float | None
@@ -199,6 +204,7 @@ class ChartRepository:
             version,
         ) = row
 
+        # Keep lcl/ucl as backward-compatible aliases of critical bounds.
         return ChartView(
             chart_id=f"CHART_{int(chart_pk)}",
             chart_set_id=int(chart_set_id),

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -1,0 +1,183 @@
+"""Chart read API 用のリポジトリ層。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from .db import MAIN_DB, _connect, _init_schema
+
+
+@dataclass(frozen=True)
+class ChartsQueryCriteria:
+    """`GET /charts` の検索条件を保持する DTO。"""
+
+    tool_id: str | None = None
+    chamber_id: str | None = None
+    recipe_id: str | None = None
+    parameter: str | None = None
+    step_no: int | None = None
+    feature_type: str | None = None
+    active_only: bool = False
+
+
+@dataclass(frozen=True)
+class ChartView:
+    """`GET /charts` レスポンス 1 件分の DTO。"""
+
+    chart_id: str
+    chart_set_id: int
+    tool_id: str
+    chamber_id: str
+    recipe_id: str
+    parameter: str
+    step_no: int
+    feature_type: str
+    lcl: float | None
+    ucl: float | None
+    warning_lcl: float | None
+    warning_ucl: float | None
+    critical_lcl: float | None
+    critical_ucl: float | None
+    updated_at: str
+    version: int
+    is_active: bool
+
+
+class ChartRepository:
+    """ChartsV2 から chart 一覧を取得するリポジトリ。"""
+
+    _BASE_SQL = """
+        SELECT
+            c.id,
+            c.chart_set_id,
+            c.tool_id,
+            c.chamber_id,
+            c.recipe_id,
+            c.parameter,
+            c.step_no,
+            c.feature_type,
+            c.warn_low,
+            c.warn_high,
+            c.crit_low,
+            c.crit_high,
+            c.updated_at,
+            CASE WHEN a.chart_set_id = c.chart_set_id THEN 1 ELSE 0 END AS is_active,
+            (
+                SELECT COUNT(*)
+                FROM ChartsHistory h
+                WHERE h.chart_set_id = c.chart_set_id
+                  AND h.tool_id = c.tool_id
+                  AND h.chamber_id = c.chamber_id
+                  AND h.recipe_id = c.recipe_id
+                  AND h.parameter = c.parameter
+                  AND h.step_no = c.step_no
+                  AND h.feature_type = c.feature_type
+            ) + 1 AS version
+        FROM ChartsV2 c
+        LEFT JOIN ActiveChartSet a ON a.id = 1
+    """
+
+    def find_charts(self, criteria: ChartsQueryCriteria) -> list[ChartView]:
+        """条件に一致する chart 一覧を返す。"""
+        _init_schema(MAIN_DB)
+        sql = self._BASE_SQL
+        where_clauses: list[str] = []
+        params: list[Any] = []
+
+        if criteria.tool_id is not None:
+            where_clauses.append("c.tool_id = ?")
+            params.append(criteria.tool_id)
+        if criteria.chamber_id is not None:
+            where_clauses.append("c.chamber_id = ?")
+            params.append(criteria.chamber_id)
+        if criteria.recipe_id is not None:
+            where_clauses.append("c.recipe_id = ?")
+            params.append(criteria.recipe_id)
+        if criteria.parameter is not None:
+            where_clauses.append("c.parameter = ?")
+            params.append(criteria.parameter)
+        if criteria.step_no is not None:
+            where_clauses.append("c.step_no = ?")
+            params.append(criteria.step_no)
+        if criteria.feature_type is not None:
+            where_clauses.append("c.feature_type = ?")
+            params.append(criteria.feature_type)
+        if criteria.active_only:
+            where_clauses.append("a.chart_set_id = c.chart_set_id")
+
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+
+        sql += (
+            " ORDER BY c.chart_set_id, c.tool_id, c.chamber_id, c.recipe_id,"
+            " c.parameter, c.step_no, c.feature_type"
+        )
+
+        con = _connect(MAIN_DB)
+        try:
+            rows = con.execute(sql, tuple(params)).fetchall()
+        finally:
+            con.close()
+
+        return [self._to_chart_view(row) for row in rows]
+
+    @staticmethod
+    def _to_chart_view(row: tuple[Any, ...]) -> ChartView:
+        """DB 行を `ChartView` へ変換する。"""
+        (
+            chart_pk,
+            chart_set_id,
+            tool_id,
+            chamber_id,
+            recipe_id,
+            parameter,
+            step_no,
+            feature_type,
+            warn_low,
+            warn_high,
+            crit_low,
+            crit_high,
+            updated_at,
+            is_active,
+            version,
+        ) = row
+
+        return ChartView(
+            chart_id=f"CHART_{int(chart_pk)}",
+            chart_set_id=int(chart_set_id),
+            tool_id=str(tool_id),
+            chamber_id=str(chamber_id),
+            recipe_id=str(recipe_id),
+            parameter=str(parameter),
+            step_no=int(step_no),
+            feature_type=str(feature_type),
+            lcl=_to_float_or_none(crit_low),
+            ucl=_to_float_or_none(crit_high),
+            warning_lcl=_to_float_or_none(warn_low),
+            warning_ucl=_to_float_or_none(warn_high),
+            critical_lcl=_to_float_or_none(crit_low),
+            critical_ucl=_to_float_or_none(crit_high),
+            updated_at=_to_utc_millis(str(updated_at)),
+            version=int(version),
+            is_active=bool(is_active),
+        )
+
+
+def _to_float_or_none(value: Any) -> float | None:
+    """SQLite 値を float または None へ変換する。"""
+    if value is None:
+        return None
+    return float(value)
+
+
+def _to_utc_millis(raw: str) -> str:
+    """任意の ISO 8601 文字列を UTC ミリ秒固定の文字列へ正規化する。"""
+    normalized = raw.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(normalized)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    else:
+        dt = dt.astimezone(UTC)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from .db import MAIN_DB, _connect, _init_schema
+from .db import MAIN_DB, _connect
 
 
 @dataclass(frozen=True)
@@ -81,7 +81,6 @@ class ChartRepository:
 
     def find_charts(self, criteria: ChartsQueryCriteria) -> list[ChartView]:
         """条件に一致する chart 一覧を返す。"""
-        _init_schema(MAIN_DB)
         sql = self._BASE_SQL
         where_clauses: list[str] = []
         params: list[Any] = []

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -146,24 +146,42 @@ class ChartRepository:
         where_clauses: list[str] = []
         params: list[Any] = []
 
-        if criteria.tool_id is not None:
-            where_clauses.append("c.tool_id = ?")
-            params.append(criteria.tool_id)
-        if criteria.chamber_id is not None:
-            where_clauses.append("c.chamber_id = ?")
-            params.append(criteria.chamber_id)
-        if criteria.recipe_id is not None:
-            where_clauses.append("c.recipe_id = ?")
-            params.append(criteria.recipe_id)
-        if criteria.parameter is not None:
-            where_clauses.append("c.parameter = ?")
-            params.append(criteria.parameter)
-        if criteria.step_no is not None:
-            where_clauses.append("c.step_no = ?")
-            params.append(criteria.step_no)
-        if criteria.feature_type is not None:
-            where_clauses.append("c.feature_type = ?")
-            params.append(criteria.feature_type)
+        self._append_filter_condition(
+            criteria.tool_id,
+            "c.tool_id = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.chamber_id,
+            "c.chamber_id = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.recipe_id,
+            "c.recipe_id = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.parameter,
+            "c.parameter = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.step_no,
+            "c.step_no = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.feature_type,
+            "c.feature_type = ?",
+            where_clauses,
+            params,
+        )
         if criteria.active_only:
             where_clauses.append(
                 "EXISTS ("
@@ -189,6 +207,19 @@ class ChartRepository:
             con.close()
 
         return [self._to_chart_view(row) for row in rows]
+
+    @staticmethod
+    def _append_filter_condition(
+        value: Any,
+        sql_fragment: str,
+        where_clauses: list[str],
+        params: list[Any],
+    ) -> None:
+        """値が存在する場合のみ WHERE 条件とパラメータを追加する。"""
+        if value is None:
+            return
+        where_clauses.append(sql_fragment)
+        params.append(value)
 
     @staticmethod
     def _to_chart_view(row: tuple[Any, ...]) -> ChartView:

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -119,10 +119,17 @@ class ChartRepository:
             fc.crit_low,
             fc.crit_high,
             fc.updated_at,
-            CASE WHEN a.chart_set_id = fc.chart_set_id THEN 1 ELSE 0 END AS is_active,
+            CASE
+                WHEN EXISTS (
+                    SELECT 1
+                    FROM ActiveChartSet active
+                    WHERE active.id = 1
+                      AND active.chart_set_id = fc.chart_set_id
+                ) THEN 1
+                ELSE 0
+            END AS is_active,
             COALESCE(hv.version, 1) AS version
         FROM filtered_charts fc
-        LEFT JOIN ActiveChartSet a ON a.id = 1
         LEFT JOIN history_versions hv
             ON hv.chart_set_id = fc.chart_set_id
            AND hv.tool_id = fc.tool_id

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -68,7 +68,16 @@ class ChartRepository:
                 c.warn_high,
                 c.crit_low,
                 c.crit_high,
-                c.updated_at
+                c.updated_at,
+                CASE
+                    WHEN EXISTS (
+                        SELECT 1
+                        FROM ActiveChartSet active
+                        WHERE active.id = 1
+                          AND active.chart_set_id = c.chart_set_id
+                    ) THEN 1
+                    ELSE 0
+                END AS is_active
             FROM ChartsV2 c
     """
 
@@ -119,15 +128,7 @@ class ChartRepository:
             fc.crit_low,
             fc.crit_high,
             fc.updated_at,
-            CASE
-                WHEN EXISTS (
-                    SELECT 1
-                    FROM ActiveChartSet active
-                    WHERE active.id = 1
-                      AND active.chart_set_id = fc.chart_set_id
-                ) THEN 1
-                ELSE 0
-            END AS is_active,
+            fc.is_active,
             COALESCE(hv.version, 1) AS version
         FROM filtered_charts fc
         LEFT JOIN history_versions hv
@@ -183,12 +184,7 @@ class ChartRepository:
             params,
         )
         if criteria.active_only:
-            where_clauses.append(
-                "EXISTS ("
-                "SELECT 1 FROM ActiveChartSet active "
-                "WHERE active.id = 1 AND active.chart_set_id = c.chart_set_id"
-                ")"
-            )
+            where_clauses.append("is_active = 1")
 
         if where_clauses:
             sql += " WHERE " + " AND ".join(where_clauses)

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -48,40 +48,89 @@ class ChartView:
 class ChartRepository:
     """ChartsV2 から chart 一覧を取得するリポジトリ。"""
 
-    _BASE_SQL = """
+    _FILTERED_CHARTS_CTE = """
+        WITH filtered_charts AS (
+            SELECT
+                c.id,
+                c.chart_set_id,
+                c.tool_id,
+                c.chamber_id,
+                c.recipe_id,
+                c.parameter,
+                c.step_no,
+                c.feature_type,
+                c.warn_low,
+                c.warn_high,
+                c.crit_low,
+                c.crit_high,
+                c.updated_at
+            FROM ChartsV2 c
+    """
+
+    _HISTORY_VERSIONS_CTE = """
+        ),
+        history_versions AS (
+            SELECT
+                h.chart_set_id,
+                h.tool_id,
+                h.chamber_id,
+                h.recipe_id,
+                h.parameter,
+                h.step_no,
+                h.feature_type,
+                COUNT(*) + 1 AS version
+            FROM ChartsHistory h
+            INNER JOIN filtered_charts fc
+                ON h.chart_set_id = fc.chart_set_id
+               AND h.tool_id = fc.tool_id
+               AND h.chamber_id = fc.chamber_id
+               AND h.recipe_id = fc.recipe_id
+               AND h.parameter = fc.parameter
+               AND h.step_no = fc.step_no
+               AND h.feature_type = fc.feature_type
+            GROUP BY
+                h.chart_set_id,
+                h.tool_id,
+                h.chamber_id,
+                h.recipe_id,
+                h.parameter,
+                h.step_no,
+                h.feature_type
+        )
+    """
+
+    _SELECT_SQL = """
         SELECT
-            c.id,
-            c.chart_set_id,
-            c.tool_id,
-            c.chamber_id,
-            c.recipe_id,
-            c.parameter,
-            c.step_no,
-            c.feature_type,
-            c.warn_low,
-            c.warn_high,
-            c.crit_low,
-            c.crit_high,
-            c.updated_at,
-            CASE WHEN a.chart_set_id = c.chart_set_id THEN 1 ELSE 0 END AS is_active,
-            (
-                SELECT COUNT(*)
-                FROM ChartsHistory h
-                WHERE h.chart_set_id = c.chart_set_id
-                  AND h.tool_id = c.tool_id
-                  AND h.chamber_id = c.chamber_id
-                  AND h.recipe_id = c.recipe_id
-                  AND h.parameter = c.parameter
-                  AND h.step_no = c.step_no
-                  AND h.feature_type = c.feature_type
-            ) + 1 AS version
-        FROM ChartsV2 c
+            fc.id,
+            fc.chart_set_id,
+            fc.tool_id,
+            fc.chamber_id,
+            fc.recipe_id,
+            fc.parameter,
+            fc.step_no,
+            fc.feature_type,
+            fc.warn_low,
+            fc.warn_high,
+            fc.crit_low,
+            fc.crit_high,
+            fc.updated_at,
+            CASE WHEN a.chart_set_id = fc.chart_set_id THEN 1 ELSE 0 END AS is_active,
+            COALESCE(hv.version, 1) AS version
+        FROM filtered_charts fc
         LEFT JOIN ActiveChartSet a ON a.id = 1
+        LEFT JOIN history_versions hv
+            ON hv.chart_set_id = fc.chart_set_id
+           AND hv.tool_id = fc.tool_id
+           AND hv.chamber_id = fc.chamber_id
+           AND hv.recipe_id = fc.recipe_id
+           AND hv.parameter = fc.parameter
+           AND hv.step_no = fc.step_no
+           AND hv.feature_type = fc.feature_type
     """
 
     def find_charts(self, criteria: ChartsQueryCriteria) -> list[ChartView]:
         """条件に一致する chart 一覧を返す。"""
-        sql = self._BASE_SQL
+        sql = self._FILTERED_CHARTS_CTE
         where_clauses: list[str] = []
         params: list[Any] = []
 
@@ -104,14 +153,21 @@ class ChartRepository:
             where_clauses.append("c.feature_type = ?")
             params.append(criteria.feature_type)
         if criteria.active_only:
-            where_clauses.append("a.chart_set_id = c.chart_set_id")
+            where_clauses.append(
+                "EXISTS ("
+                "SELECT 1 FROM ActiveChartSet active "
+                "WHERE active.id = 1 AND active.chart_set_id = c.chart_set_id"
+                ")"
+            )
 
         if where_clauses:
             sql += " WHERE " + " AND ".join(where_clauses)
 
+        sql += self._HISTORY_VERSIONS_CTE
+        sql += self._SELECT_SQL
         sql += (
-            " ORDER BY c.chart_set_id, c.tool_id, c.chamber_id, c.recipe_id,"
-            " c.parameter, c.step_no, c.feature_type"
+            " ORDER BY fc.chart_set_id, fc.tool_id, fc.chamber_id, fc.recipe_id,"
+            " fc.parameter, fc.step_no, fc.feature_type"
         )
 
         con = _connect(MAIN_DB)

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -528,6 +528,53 @@ def test_get_charts_supports_feature_type_filter(
     _assert_all_rows_match(data, "feature_type", "mean")
 
 
+def test_get_charts_supports_combined_chamber_and_recipe_filters(
+    client: TestClient,
+    seeded_chart_rows_for_filter_tests: SeededChartsContext,
+) -> None:
+    """chamber_id と recipe_id の同時指定で AND 条件が機能することを確認する。"""
+    seeded = seeded_chart_rows_for_filter_tests
+    tool_match = seeded.tool_primary
+    tool_other = seeded.tool_secondary
+
+    res = client.get(
+        "/charts",
+        params={
+            "chamber_id": "CH_FILTER_MATCH",
+            "recipe_id": "RECIPE_FILTER_MATCH",
+        },
+    )
+
+    assert res.status_code == 200
+    data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+    assert len(data) == 1
+    assert data[0]["tool_id"] == tool_match
+    assert data[0]["chamber_id"] == "CH_FILTER_MATCH"
+    assert data[0]["recipe_id"] == "RECIPE_FILTER_MATCH"
+
+
+def test_get_charts_returns_empty_for_non_matching_combined_filters(
+    client: TestClient,
+    seeded_chart_rows_for_filter_tests: SeededChartsContext,
+) -> None:
+    """同時指定条件が交差しない場合、該当データが返らないことを確認する。"""
+    seeded = seeded_chart_rows_for_filter_tests
+    tool_match = seeded.tool_primary
+    tool_other = seeded.tool_secondary
+
+    res = client.get(
+        "/charts",
+        params={
+            "chamber_id": "CH_FILTER_MATCH",
+            "recipe_id": "RECIPE_FILTER_OTHER",
+        },
+    )
+
+    assert res.status_code == 200
+    data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+    assert data == []
+
+
 def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:
     """step_no が負数のとき 422 を返すことを確認する。"""
     res = client.get("/charts", params={"step_no": -1})

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -585,6 +585,16 @@ def test_get_charts_returns_empty_envelope_when_no_match(client: TestClient) -> 
     assert body["data"] == []
 
 
+def test_get_charts_accepts_step_no_zero(client: TestClient) -> None:
+    """step_no=0 は ge=0 の境界値として 422 にならないことを確認する。"""
+    res = client.get("/charts", params={"step_no": 0})
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert isinstance(body["data"], list)
+
+
 def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:
     """step_no が負数のとき 422 を返すことを確認する。"""
     res = client.get("/charts", params={"step_no": -1})
@@ -605,3 +615,25 @@ def test_to_utc_millis_truncates_microseconds_not_rounds() -> None:
     """updated_at 正規化は四捨五入ではなくミリ秒切り捨てであることを確認する。"""
     assert _to_utc_millis("2026-04-14T00:00:00.123999+00:00") == "2026-04-14T00:00:00.123Z"
     assert _to_utc_millis("2026-04-14T00:00:00.123500+00:00") == "2026-04-14T00:00:00.123Z"
+
+
+def test_to_utc_millis_normalizes_year_boundary() -> None:
+    """年越し直前のタイムスタンプを UTC ミリ秒固定に正規化することを確認する。"""
+    assert _to_utc_millis("2025-12-31T23:59:59.999999+00:00") == "2025-12-31T23:59:59.999Z"
+
+
+def test_to_utc_millis_converts_positive_offset_to_utc() -> None:
+    """正のタイムゾーンオフセット（例: +09:00 JST）を UTC に変換することを確認する。"""
+    # 2026-04-14T10:00:00.500+09:00 == 2026-04-14T01:00:00.500Z
+    assert _to_utc_millis("2026-04-14T10:00:00.500000+09:00") == "2026-04-14T01:00:00.500Z"
+
+
+def test_to_utc_millis_converts_negative_offset_to_utc() -> None:
+    """負のタイムゾーンオフセット（例: -05:00 EST）を UTC に変換することを確認する。"""
+    # 2026-04-14T00:00:00.000-05:00 == 2026-04-14T05:00:00.000Z
+    assert _to_utc_millis("2026-04-14T00:00:00.000000-05:00") == "2026-04-14T05:00:00.000Z"
+
+
+def test_to_utc_millis_treats_naive_datetime_as_utc() -> None:
+    """タイムゾーン情報のない naive datetime は UTC として扱うことを確認する。"""
+    assert _to_utc_millis("2026-04-14T12:00:00.000000") == "2026-04-14T12:00:00.000Z"

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -420,6 +420,38 @@ def test_get_charts_supports_tool_filter_and_active_only(
     assert all(item["tool_id"] != tool_inactive for item in active_only_data)
 
 
+def test_get_charts_handles_missing_active_chart_set_row(
+    client: TestClient,
+    seeded_chart_rows_for_get_charts: SeededChartsContext,
+) -> None:
+    """ActiveChartSet 未設定時は is_active=False, active_onlyは空になることを確認する。"""
+    seeded = seeded_chart_rows_for_get_charts
+    tool_active = seeded.tool_primary
+    tool_inactive = seeded.tool_secondary
+
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        con.execute("DELETE FROM ActiveChartSet WHERE id = 1")
+        con.commit()
+    finally:
+        con.close()
+
+    res = client.get("/charts")
+    assert res.status_code == 200
+    data = [item for item in res.json()["data"] if item["tool_id"] in {tool_active, tool_inactive}]
+    assert len(data) == 2
+    assert all(item["is_active"] is False for item in data)
+
+    active_only = client.get("/charts", params={"active_only": True})
+    assert active_only.status_code == 200
+    active_only_data = [
+        item
+        for item in active_only.json()["data"]
+        if item["tool_id"] in {tool_active, tool_inactive}
+    ]
+    assert active_only_data == []
+
+
 def test_get_charts_supports_chamber_filter(
     client: TestClient,
     seeded_chart_rows_for_filter_tests: SeededChartsContext,

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -139,6 +139,101 @@ def _cleanup_seeded_chart_rows(
         con.close()
 
 
+def _seed_chart_rows_for_filter_tests() -> tuple[str, str, int]:
+    """各クエリフィルタ検証用に属性が異なる 2 chart を投入する。"""
+    _init_schema(MAIN_DB)
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        now = datetime.now(UTC).isoformat()
+        suffix = uuid4().hex
+        tool_match = f"TOOL_FILTER_MATCH_{suffix}"
+        tool_other = f"TOOL_FILTER_OTHER_{suffix}"
+
+        prev_active_row = con.execute(
+            "SELECT chart_set_id FROM ActiveChartSet WHERE id = 1"
+        ).fetchone()
+        if prev_active_row is None:
+            raise RuntimeError("ActiveChartSet row with id=1 is required")
+        prev_active_set_id = int(prev_active_row[0])
+
+        con.execute(
+            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
+            (f"filter_set_{suffix}", "test", now, "test"),
+        )
+        chart_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+        con.execute(
+            "INSERT OR REPLACE INTO ActiveChartSet(id, chart_set_id, updated_at, updated_by)"
+            " VALUES (1, ?, ?, ?)",
+            (chart_set_id, now, "test"),
+        )
+
+        con.execute(
+            """
+            INSERT INTO ChartsV2(
+                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                updated_at, updated_by, update_reason, update_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chart_set_id,
+                tool_match,
+                "CH_FILTER_MATCH",
+                "RECIPE_FILTER_MATCH",
+                "dc_bias",
+                2,
+                "mean",
+                1.4,
+                2.6,
+                1.2,
+                2.8,
+                "2026-04-14T00:00:00Z",
+                "tester",
+                "test-seed",
+                "test",
+            ),
+        )
+
+        con.execute(
+            """
+            INSERT INTO ChartsV2(
+                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                updated_at, updated_by, update_reason, update_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chart_set_id,
+                tool_other,
+                "CH_FILTER_OTHER",
+                "RECIPE_FILTER_OTHER",
+                "cl2_flow",
+                3,
+                "max",
+                10.0,
+                20.0,
+                9.0,
+                21.0,
+                "2026-04-14T00:00:00Z",
+                "tester",
+                "test-seed",
+                "test",
+            ),
+        )
+
+        con.commit()
+        return tool_match, tool_other, prev_active_set_id
+    finally:
+        con.close()
+
+
+def _assert_all_rows_match(data: list[dict[str, object]], key: str, expected: object) -> None:
+    """返却された全要素が指定キーの期待値を満たすことを確認する。"""
+    assert data
+    assert all(item.get(key) == expected for item in data)
+
+
 def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) -> None:
     """GET /charts が契約フィールドを返すことを確認する。"""
     tool_active, tool_inactive, restore_active_set_id = _seed_chart_rows_for_get_charts()
@@ -183,26 +278,78 @@ def test_get_charts_supports_tool_filter_and_active_only(client: TestClient) -> 
     try:
         filtered = client.get("/charts", params={"tool_id": tool_active})
         assert filtered.status_code == 200
-        filtered_data = [
-            item
-            for item in filtered.json()["data"]
-            if item["tool_id"] in {tool_active, tool_inactive}
-        ]
-        assert len(filtered_data) == 1
-        assert filtered_data[0]["tool_id"] == tool_active
+        filtered_data = filtered.json()["data"]
+        assert all(item["tool_id"] == tool_active for item in filtered_data)
+        assert all(item["tool_id"] != tool_inactive for item in filtered_data)
 
         active_only = client.get("/charts", params={"active_only": True})
         assert active_only.status_code == 200
-        active_only_data = [
-            item
-            for item in active_only.json()["data"]
-            if item["tool_id"] in {tool_active, tool_inactive}
-        ]
-        assert len(active_only_data) == 1
-        assert active_only_data[0]["tool_id"] == tool_active
-        assert active_only_data[0]["is_active"] is True
+        active_only_data = active_only.json()["data"]
+        assert all(item["is_active"] is True for item in active_only_data)
+        assert any(item["tool_id"] == tool_active for item in active_only_data)
+        assert all(item["tool_id"] != tool_inactive for item in active_only_data)
     finally:
         _cleanup_seeded_chart_rows(tool_active, tool_inactive, restore_active_set_id)
+
+
+def test_get_charts_supports_chamber_filter(client: TestClient) -> None:
+    """chamber_id フィルタが機能することを確認する。"""
+    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    try:
+        res = client.get("/charts", params={"chamber_id": "CH_FILTER_MATCH"})
+        assert res.status_code == 200
+        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+        _assert_all_rows_match(data, "chamber_id", "CH_FILTER_MATCH")
+    finally:
+        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+
+
+def test_get_charts_supports_recipe_filter(client: TestClient) -> None:
+    """recipe_id フィルタが機能することを確認する。"""
+    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    try:
+        res = client.get("/charts", params={"recipe_id": "RECIPE_FILTER_MATCH"})
+        assert res.status_code == 200
+        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+        _assert_all_rows_match(data, "recipe_id", "RECIPE_FILTER_MATCH")
+    finally:
+        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+
+
+def test_get_charts_supports_parameter_filter(client: TestClient) -> None:
+    """parameter フィルタが機能することを確認する。"""
+    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    try:
+        res = client.get("/charts", params={"parameter": "dc_bias"})
+        assert res.status_code == 200
+        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+        _assert_all_rows_match(data, "parameter", "dc_bias")
+    finally:
+        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+
+
+def test_get_charts_supports_positive_step_no_filter(client: TestClient) -> None:
+    """step_no 正数フィルタが機能することを確認する。"""
+    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    try:
+        res = client.get("/charts", params={"step_no": 2})
+        assert res.status_code == 200
+        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+        _assert_all_rows_match(data, "step_no", 2)
+    finally:
+        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+
+
+def test_get_charts_supports_feature_type_filter(client: TestClient) -> None:
+    """feature_type フィルタが機能することを確認する。"""
+    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    try:
+        res = client.get("/charts", params={"feature_type": "mean"})
+        assert res.status_code == 200
+        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+        _assert_all_rows_match(data, "feature_type", "mean")
+    finally:
+        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
 
 
 def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
+
+
+def _seed_chart_rows_for_get_charts() -> tuple[str, str, int]:
+    """GET /charts テスト用に active/inactive の 2 chart を投入する。"""
+    _init_schema(MAIN_DB)
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        now = datetime.now(UTC).isoformat()
+        suffix = uuid4().hex
+        tool_active = f"TOOL_GET_CHARTS_ACTIVE_{suffix}"
+        tool_inactive = f"TOOL_GET_CHARTS_INACTIVE_{suffix}"
+
+        prev_active_row = con.execute(
+            "SELECT chart_set_id FROM ActiveChartSet WHERE id = 1"
+        ).fetchone()
+        if prev_active_row is None:
+            raise RuntimeError("ActiveChartSet row with id=1 is required")
+        prev_active_set_id = int(prev_active_row[0])
+
+        con.execute(
+            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
+            (f"active_set_{suffix}", "test", now, "test"),
+        )
+        active_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+        con.execute(
+            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
+            (f"inactive_set_{suffix}", "test", now, "test"),
+        )
+        inactive_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+        con.execute(
+            "INSERT OR REPLACE INTO ActiveChartSet(id, chart_set_id, updated_at, updated_by)"
+            " VALUES (1, ?, ?, ?)",
+            (active_set_id, now, "test"),
+        )
+
+        con.execute(
+            """
+            INSERT INTO ChartsV2(
+                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                updated_at, updated_by, update_reason, update_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                active_set_id,
+                tool_active,
+                "CH1",
+                "RECIPE_A",
+                "dc_bias",
+                1,
+                "mean",
+                1.4,
+                2.6,
+                1.2,
+                2.8,
+                "2026-04-14T09:00:00+09:00",
+                "tester",
+                "test-seed",
+                "test",
+            ),
+        )
+
+        con.execute(
+            """
+            INSERT INTO ChartsV2(
+                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                updated_at, updated_by, update_reason, update_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                inactive_set_id,
+                tool_inactive,
+                "CH1",
+                "RECIPE_A",
+                "dc_bias",
+                1,
+                "mean",
+                1.0,
+                2.0,
+                0.8,
+                2.2,
+                "2026-04-14T00:00:00Z",
+                "tester",
+                "test-seed",
+                "test",
+            ),
+        )
+
+        con.commit()
+        return tool_active, tool_inactive, prev_active_set_id
+    finally:
+        con.close()
+
+
+def _cleanup_seeded_chart_rows(
+    tool_active: str, tool_inactive: str, restore_active_set_id: int
+) -> None:
+    """テスト投入した chart データを後片付けする。"""
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        con.execute(
+            "INSERT OR REPLACE INTO ActiveChartSet(id, chart_set_id, updated_at, updated_by)"
+            " VALUES (1, ?, ?, ?)",
+            (restore_active_set_id, datetime.now(UTC).isoformat(), "test-cleanup"),
+        )
+
+        chart_set_rows = con.execute(
+            "SELECT DISTINCT chart_set_id FROM ChartsV2 WHERE tool_id IN (?, ?)",
+            (tool_active, tool_inactive),
+        ).fetchall()
+        chart_set_ids = [int(row[0]) for row in chart_set_rows]
+
+        con.execute(
+            "DELETE FROM ChartsV2 WHERE tool_id IN (?, ?)",
+            (tool_active, tool_inactive),
+        )
+
+        for chart_set_id in chart_set_ids:
+            con.execute(
+                "DELETE FROM ChartSet WHERE chart_set_id = ? AND chart_set_id != ?",
+                (chart_set_id, restore_active_set_id),
+            )
+
+        con.commit()
+    finally:
+        con.close()
+
+
+def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) -> None:
+    """GET /charts が契約フィールドを返すことを確認する。"""
+    tool_active, tool_inactive, restore_active_set_id = _seed_chart_rows_for_get_charts()
+    try:
+        res = client.get("/charts")
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+
+        rows = [item for item in body["data"] if item["tool_id"] in {tool_active, tool_inactive}]
+        assert len(rows) == 2
+
+        for row in rows:
+            assert re.fullmatch(r"CHART_\d+", row["chart_id"])
+            assert isinstance(row["chart_set_id"], int)
+            assert row["chamber_id"] == "CH1"
+            assert row["recipe_id"] == "RECIPE_A"
+            assert row["parameter"] == "dc_bias"
+            assert row["step_no"] == 1
+            assert row["feature_type"] == "mean"
+            assert row["lcl"] == row["critical_lcl"]
+            assert row["ucl"] == row["critical_ucl"]
+            assert isinstance(row["version"], int)
+            assert row["version"] >= 1
+            assert re.fullmatch(
+                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z",
+                row["updated_at"],
+            )
+
+        active_row = next(item for item in rows if item["tool_id"] == tool_active)
+        inactive_row = next(item for item in rows if item["tool_id"] == tool_inactive)
+        assert active_row["is_active"] is True
+        assert inactive_row["is_active"] is False
+    finally:
+        _cleanup_seeded_chart_rows(tool_active, tool_inactive, restore_active_set_id)
+
+
+def test_get_charts_supports_tool_filter_and_active_only(client: TestClient) -> None:
+    """tool_id フィルタと active_only フィルタが機能することを確認する。"""
+    tool_active, tool_inactive, restore_active_set_id = _seed_chart_rows_for_get_charts()
+    try:
+        filtered = client.get("/charts", params={"tool_id": tool_active})
+        assert filtered.status_code == 200
+        filtered_data = [
+            item
+            for item in filtered.json()["data"]
+            if item["tool_id"] in {tool_active, tool_inactive}
+        ]
+        assert len(filtered_data) == 1
+        assert filtered_data[0]["tool_id"] == tool_active
+
+        active_only = client.get("/charts", params={"active_only": True})
+        assert active_only.status_code == 200
+        active_only_data = [
+            item
+            for item in active_only.json()["data"]
+            if item["tool_id"] in {tool_active, tool_inactive}
+        ]
+        assert len(active_only_data) == 1
+        assert active_only_data[0]["tool_id"] == tool_active
+        assert active_only_data[0]["is_active"] is True
+    finally:
+        _cleanup_seeded_chart_rows(tool_active, tool_inactive, restore_active_set_id)
+
+
+def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:
+    """step_no が負数のとき 422 を返すことを確認する。"""
+    res = client.get("/charts", params={"step_no": -1})
+
+    assert res.status_code == 422

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from uuid import uuid4
@@ -32,6 +32,12 @@ class SeededChartsContext:
     chart_set_ids: tuple[int, ...]
 
 
+SeedBuilder = Callable[
+    [sqlite3.Connection, str, str],
+    tuple[str, str, tuple[int, ...], int],
+]
+
+
 def _create_chart_set_with_charts(
     con: sqlite3.Connection,
     *,
@@ -55,20 +61,14 @@ def _create_chart_set_with_charts(
 @pytest.fixture
 def seeded_chart_rows_for_get_charts() -> Iterator[SeededChartsContext]:
     """GET /charts テスト用に active/inactive の 2 chart を投入する。"""
-    _init_schema(MAIN_DB)
-    con = sqlite3.connect(MAIN_DB.as_posix())
-    try:
-        now = datetime.now(UTC).isoformat()
-        suffix = uuid4().hex
+
+    def _build_seed(
+        con: sqlite3.Connection,
+        now: str,
+        suffix: str,
+    ) -> tuple[str, str, tuple[int, ...], int]:
         tool_active = f"TOOL_GET_CHARTS_ACTIVE_{suffix}"
         tool_inactive = f"TOOL_GET_CHARTS_INACTIVE_{suffix}"
-
-        prev_active_row = con.execute(
-            "SELECT chart_set_id FROM ActiveChartSet WHERE id = 1"
-        ).fetchone()
-        if prev_active_row is None:
-            raise RuntimeError("ActiveChartSet row with id=1 is required")
-        prev_active_set_id = int(prev_active_row[0])
 
         active_set_id = _create_chart_set_with_charts(
             con,
@@ -116,25 +116,9 @@ def seeded_chart_rows_for_get_charts() -> Iterator[SeededChartsContext]:
                 )
             ],
         )
+        return tool_active, tool_inactive, (active_set_id, inactive_set_id), active_set_id
 
-        con.execute(
-            "INSERT OR REPLACE INTO ActiveChartSet(id, chart_set_id, updated_at, updated_by)"
-            " VALUES (1, ?, ?, ?)",
-            (active_set_id, now, "test"),
-        )
-
-        con.commit()
-        context = SeededChartsContext(
-            tool_primary=tool_active,
-            tool_secondary=tool_inactive,
-            restore_active_set_id=prev_active_set_id,
-            chart_set_ids=(active_set_id, inactive_set_id),
-        )
-        yield context
-    finally:
-        con.close()
-        if "context" in locals():
-            _cleanup_seeded_chart_rows(context)
+    yield from _seed_chart_rows_fixture(_build_seed)
 
 
 def _cleanup_seeded_chart_rows(context: SeededChartsContext) -> None:
@@ -169,20 +153,14 @@ def _cleanup_seeded_chart_rows(context: SeededChartsContext) -> None:
 @pytest.fixture
 def seeded_chart_rows_for_filter_tests() -> Iterator[SeededChartsContext]:
     """各クエリフィルタ検証用に属性が異なる 2 chart を投入する。"""
-    _init_schema(MAIN_DB)
-    con = sqlite3.connect(MAIN_DB.as_posix())
-    try:
-        now = datetime.now(UTC).isoformat()
-        suffix = uuid4().hex
+
+    def _build_seed(
+        con: sqlite3.Connection,
+        now: str,
+        suffix: str,
+    ) -> tuple[str, str, tuple[int, ...], int]:
         tool_match = f"TOOL_FILTER_MATCH_{suffix}"
         tool_other = f"TOOL_FILTER_OTHER_{suffix}"
-
-        prev_active_row = con.execute(
-            "SELECT chart_set_id FROM ActiveChartSet WHERE id = 1"
-        ).fetchone()
-        if prev_active_row is None:
-            raise RuntimeError("ActiveChartSet row with id=1 is required")
-        prev_active_set_id = int(prev_active_row[0])
 
         chart_set_id = _create_chart_set_with_charts(
             con,
@@ -223,24 +201,52 @@ def seeded_chart_rows_for_filter_tests() -> Iterator[SeededChartsContext]:
                 ),
             ],
         )
+        return tool_match, tool_other, (chart_set_id,), chart_set_id
+
+    yield from _seed_chart_rows_fixture(_build_seed)
+
+
+def _seed_chart_rows_fixture(seed_builder: SeedBuilder) -> Iterator[SeededChartsContext]:
+    """Chart seed fixture の共通セットアップ/teardown を提供する。"""
+    _init_schema(MAIN_DB)
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    context: SeededChartsContext | None = None
+    try:
+        now = datetime.now(UTC).isoformat()
+        suffix = uuid4().hex
+
+        prev_active_row = con.execute(
+            "SELECT chart_set_id FROM ActiveChartSet WHERE id = 1"
+        ).fetchone()
+        if prev_active_row is None:
+            raise RuntimeError("ActiveChartSet row with id=1 is required")
+        prev_active_set_id = int(prev_active_row[0])
+
+        (
+            tool_primary,
+            tool_secondary,
+            chart_set_ids,
+            active_chart_set_id,
+        ) = seed_builder(con, now, suffix)
 
         con.execute(
             "INSERT OR REPLACE INTO ActiveChartSet(id, chart_set_id, updated_at, updated_by)"
             " VALUES (1, ?, ?, ?)",
-            (chart_set_id, now, "test"),
+            (active_chart_set_id, now, "test"),
+        )
+
+        context = SeededChartsContext(
+            tool_primary=tool_primary,
+            tool_secondary=tool_secondary,
+            restore_active_set_id=prev_active_set_id,
+            chart_set_ids=chart_set_ids,
         )
 
         con.commit()
-        context = SeededChartsContext(
-            tool_primary=tool_match,
-            tool_secondary=tool_other,
-            restore_active_set_id=prev_active_set_id,
-            chart_set_ids=(chart_set_id,),
-        )
         yield context
     finally:
         con.close()
-        if "context" in locals():
+        if context is not None:
             _cleanup_seeded_chart_rows(context)
 
 

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -142,6 +142,10 @@ def _cleanup_seeded_chart_rows(context: SeededChartsContext) -> None:
 
         for chart_set_id in context.chart_set_ids:
             con.execute(
+                "DELETE FROM ChartsHistory WHERE chart_set_id = ?",
+                (chart_set_id,),
+            )
+            con.execute(
                 "DELETE FROM ChartsV2 WHERE chart_set_id = ?",
                 (chart_set_id,),
             )
@@ -235,6 +239,58 @@ def _assert_all_rows_match(data: list[dict[str, object]], key: str, expected: ob
     assert all(item.get(key) == expected for item in data)
 
 
+def _insert_chart_history(
+    chart_set_id: int,
+    *,
+    tool_id: str,
+    chamber_id: str,
+    recipe_id: str,
+    parameter: str,
+    step_no: int,
+    feature_type: str,
+    count: int,
+) -> None:
+    """指定 chart key に対応する履歴レコードを件数分だけ投入する。"""
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        for index in range(count):
+            con.execute(
+                """
+                INSERT INTO ChartsHistory(
+                    chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                    step_no, feature_type, old_warn_low, old_warn_high,
+                    old_crit_low, old_crit_high, new_warn_low, new_warn_high,
+                    new_crit_low, new_crit_high, changed_at, changed_by,
+                    change_reason, change_source
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    chart_set_id,
+                    tool_id,
+                    chamber_id,
+                    recipe_id,
+                    parameter,
+                    step_no,
+                    feature_type,
+                    1.0,
+                    2.0,
+                    0.8,
+                    2.2,
+                    1.1,
+                    2.1,
+                    0.9,
+                    2.3,
+                    f"2026-04-14T00:00:0{index}Z",
+                    "tester",
+                    "history-seed",
+                    "test",
+                ),
+            )
+        con.commit()
+    finally:
+        con.close()
+
+
 def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) -> None:
     """GET /charts が契約フィールドを返すことを確認する。"""
     seeded = _seed_chart_rows_for_get_charts()
@@ -271,6 +327,34 @@ def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) 
         inactive_row = next(item for item in rows if item["tool_id"] == tool_inactive)
         assert active_row["is_active"] is True
         assert inactive_row["is_active"] is False
+    finally:
+        _cleanup_seeded_chart_rows(seeded)
+
+
+def test_get_charts_computes_version_from_history_count(client: TestClient) -> None:
+    """version が履歴件数 + 1 で返ることを確認する。"""
+    seeded = _seed_chart_rows_for_get_charts()
+    tool_active = seeded.tool_primary
+    active_set_id = seeded.chart_set_ids[0]
+    try:
+        _insert_chart_history(
+            active_set_id,
+            tool_id=tool_active,
+            chamber_id="CH1",
+            recipe_id="RECIPE_A",
+            parameter="dc_bias",
+            step_no=1,
+            feature_type="mean",
+            count=2,
+        )
+
+        res = client.get("/charts", params={"tool_id": tool_active})
+
+        assert res.status_code == 200
+        data = res.json()["data"]
+        assert data
+        assert all(item["tool_id"] == tool_active for item in data)
+        assert any(item["version"] == 3 for item in data)
     finally:
         _cleanup_seeded_chart_rows(seeded)
 

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -9,8 +10,46 @@ from fastapi.testclient import TestClient
 
 from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
 
+_INSERT_CHART_SQL = """
+    INSERT INTO ChartsV2(
+        chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+        step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+        updated_at, updated_by, update_reason, update_source
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
 
-def _seed_chart_rows_for_get_charts() -> tuple[str, str, int]:
+
+@dataclass(frozen=True)
+class SeededChartsContext:
+    """seed された chart テストデータの後処理用コンテキスト。"""
+
+    tool_primary: str
+    tool_secondary: str
+    restore_active_set_id: int
+    chart_set_ids: tuple[int, ...]
+
+
+def _create_chart_set_with_charts(
+    con: sqlite3.Connection,
+    *,
+    set_name: str,
+    now: str,
+    chart_rows: list[tuple[object, ...]],
+) -> int:
+    """ChartSet を作成し、紐づく ChartsV2 レコードを投入する。"""
+    con.execute(
+        "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
+        (set_name, "test", now, "test"),
+    )
+    chart_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+    for row in chart_rows:
+        con.execute(_INSERT_CHART_SQL, (chart_set_id, *row))
+
+    return chart_set_id
+
+
+def _seed_chart_rows_for_get_charts() -> SeededChartsContext:
     """GET /charts テスト用に active/inactive の 2 chart を投入する。"""
     _init_schema(MAIN_DB)
     con = sqlite3.connect(MAIN_DB.as_posix())
@@ -27,17 +66,52 @@ def _seed_chart_rows_for_get_charts() -> tuple[str, str, int]:
             raise RuntimeError("ActiveChartSet row with id=1 is required")
         prev_active_set_id = int(prev_active_row[0])
 
-        con.execute(
-            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
-            (f"active_set_{suffix}", "test", now, "test"),
+        active_set_id = _create_chart_set_with_charts(
+            con,
+            set_name=f"active_set_{suffix}",
+            now=now,
+            chart_rows=[
+                (
+                    tool_active,
+                    "CH1",
+                    "RECIPE_A",
+                    "dc_bias",
+                    1,
+                    "mean",
+                    1.4,
+                    2.6,
+                    1.2,
+                    2.8,
+                    "2026-04-14T09:00:00+09:00",
+                    "tester",
+                    "test-seed",
+                    "test",
+                )
+            ],
         )
-        active_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
-
-        con.execute(
-            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
-            (f"inactive_set_{suffix}", "test", now, "test"),
+        inactive_set_id = _create_chart_set_with_charts(
+            con,
+            set_name=f"inactive_set_{suffix}",
+            now=now,
+            chart_rows=[
+                (
+                    tool_inactive,
+                    "CH1",
+                    "RECIPE_A",
+                    "dc_bias",
+                    1,
+                    "mean",
+                    1.0,
+                    2.0,
+                    0.8,
+                    2.2,
+                    "2026-04-14T00:00:00Z",
+                    "tester",
+                    "test-seed",
+                    "test",
+                )
+            ],
         )
-        inactive_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
 
         con.execute(
             "INSERT OR REPLACE INTO ActiveChartSet(id, chart_set_id, updated_at, updated_by)"
@@ -45,93 +119,35 @@ def _seed_chart_rows_for_get_charts() -> tuple[str, str, int]:
             (active_set_id, now, "test"),
         )
 
-        con.execute(
-            """
-            INSERT INTO ChartsV2(
-                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
-                updated_at, updated_by, update_reason, update_source
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                active_set_id,
-                tool_active,
-                "CH1",
-                "RECIPE_A",
-                "dc_bias",
-                1,
-                "mean",
-                1.4,
-                2.6,
-                1.2,
-                2.8,
-                "2026-04-14T09:00:00+09:00",
-                "tester",
-                "test-seed",
-                "test",
-            ),
-        )
-
-        con.execute(
-            """
-            INSERT INTO ChartsV2(
-                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
-                updated_at, updated_by, update_reason, update_source
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                inactive_set_id,
-                tool_inactive,
-                "CH1",
-                "RECIPE_A",
-                "dc_bias",
-                1,
-                "mean",
-                1.0,
-                2.0,
-                0.8,
-                2.2,
-                "2026-04-14T00:00:00Z",
-                "tester",
-                "test-seed",
-                "test",
-            ),
-        )
-
         con.commit()
-        return tool_active, tool_inactive, prev_active_set_id
+        return SeededChartsContext(
+            tool_primary=tool_active,
+            tool_secondary=tool_inactive,
+            restore_active_set_id=prev_active_set_id,
+            chart_set_ids=(active_set_id, inactive_set_id),
+        )
     finally:
         con.close()
 
 
-def _cleanup_seeded_chart_rows(
-    tool_active: str, tool_inactive: str, restore_active_set_id: int
-) -> None:
+def _cleanup_seeded_chart_rows(context: SeededChartsContext) -> None:
     """テスト投入した chart データを後片付けする。"""
     con = sqlite3.connect(MAIN_DB.as_posix())
     try:
         con.execute(
             "INSERT OR REPLACE INTO ActiveChartSet(id, chart_set_id, updated_at, updated_by)"
             " VALUES (1, ?, ?, ?)",
-            (restore_active_set_id, datetime.now(UTC).isoformat(), "test-cleanup"),
+            (context.restore_active_set_id, datetime.now(UTC).isoformat(), "test-cleanup"),
         )
 
-        chart_set_rows = con.execute(
-            "SELECT DISTINCT chart_set_id FROM ChartsV2 WHERE tool_id IN (?, ?)",
-            (tool_active, tool_inactive),
-        ).fetchall()
-        chart_set_ids = [int(row[0]) for row in chart_set_rows]
-
-        con.execute(
-            "DELETE FROM ChartsV2 WHERE tool_id IN (?, ?)",
-            (tool_active, tool_inactive),
-        )
-
-        for chart_set_id in chart_set_ids:
+        for chart_set_id in context.chart_set_ids:
+            con.execute(
+                "DELETE FROM ChartsV2 WHERE chart_set_id = ?",
+                (chart_set_id,),
+            )
             con.execute(
                 "DELETE FROM ChartSet WHERE chart_set_id = ? AND chart_set_id != ?",
-                (chart_set_id, restore_active_set_id),
+                (chart_set_id, context.restore_active_set_id),
             )
 
         con.commit()
@@ -139,7 +155,7 @@ def _cleanup_seeded_chart_rows(
         con.close()
 
 
-def _seed_chart_rows_for_filter_tests() -> tuple[str, str, int]:
+def _seed_chart_rows_for_filter_tests() -> SeededChartsContext:
     """各クエリフィルタ検証用に属性が異なる 2 chart を投入する。"""
     _init_schema(MAIN_DB)
     con = sqlite3.connect(MAIN_DB.as_posix())
@@ -156,11 +172,45 @@ def _seed_chart_rows_for_filter_tests() -> tuple[str, str, int]:
             raise RuntimeError("ActiveChartSet row with id=1 is required")
         prev_active_set_id = int(prev_active_row[0])
 
-        con.execute(
-            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
-            (f"filter_set_{suffix}", "test", now, "test"),
+        chart_set_id = _create_chart_set_with_charts(
+            con,
+            set_name=f"filter_set_{suffix}",
+            now=now,
+            chart_rows=[
+                (
+                    tool_match,
+                    "CH_FILTER_MATCH",
+                    "RECIPE_FILTER_MATCH",
+                    "dc_bias",
+                    2,
+                    "mean",
+                    1.4,
+                    2.6,
+                    1.2,
+                    2.8,
+                    "2026-04-14T00:00:00Z",
+                    "tester",
+                    "test-seed",
+                    "test",
+                ),
+                (
+                    tool_other,
+                    "CH_FILTER_OTHER",
+                    "RECIPE_FILTER_OTHER",
+                    "cl2_flow",
+                    3,
+                    "max",
+                    10.0,
+                    20.0,
+                    9.0,
+                    21.0,
+                    "2026-04-14T00:00:00Z",
+                    "tester",
+                    "test-seed",
+                    "test",
+                ),
+            ],
         )
-        chart_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
 
         con.execute(
             "INSERT OR REPLACE INTO ActiveChartSet(id, chart_set_id, updated_at, updated_by)"
@@ -168,62 +218,13 @@ def _seed_chart_rows_for_filter_tests() -> tuple[str, str, int]:
             (chart_set_id, now, "test"),
         )
 
-        con.execute(
-            """
-            INSERT INTO ChartsV2(
-                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
-                updated_at, updated_by, update_reason, update_source
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                chart_set_id,
-                tool_match,
-                "CH_FILTER_MATCH",
-                "RECIPE_FILTER_MATCH",
-                "dc_bias",
-                2,
-                "mean",
-                1.4,
-                2.6,
-                1.2,
-                2.8,
-                "2026-04-14T00:00:00Z",
-                "tester",
-                "test-seed",
-                "test",
-            ),
-        )
-
-        con.execute(
-            """
-            INSERT INTO ChartsV2(
-                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
-                updated_at, updated_by, update_reason, update_source
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                chart_set_id,
-                tool_other,
-                "CH_FILTER_OTHER",
-                "RECIPE_FILTER_OTHER",
-                "cl2_flow",
-                3,
-                "max",
-                10.0,
-                20.0,
-                9.0,
-                21.0,
-                "2026-04-14T00:00:00Z",
-                "tester",
-                "test-seed",
-                "test",
-            ),
-        )
-
         con.commit()
-        return tool_match, tool_other, prev_active_set_id
+        return SeededChartsContext(
+            tool_primary=tool_match,
+            tool_secondary=tool_other,
+            restore_active_set_id=prev_active_set_id,
+            chart_set_ids=(chart_set_id,),
+        )
     finally:
         con.close()
 
@@ -236,7 +237,9 @@ def _assert_all_rows_match(data: list[dict[str, object]], key: str, expected: ob
 
 def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) -> None:
     """GET /charts が契約フィールドを返すことを確認する。"""
-    tool_active, tool_inactive, restore_active_set_id = _seed_chart_rows_for_get_charts()
+    seeded = _seed_chart_rows_for_get_charts()
+    tool_active = seeded.tool_primary
+    tool_inactive = seeded.tool_secondary
     try:
         res = client.get("/charts")
 
@@ -269,16 +272,19 @@ def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) 
         assert active_row["is_active"] is True
         assert inactive_row["is_active"] is False
     finally:
-        _cleanup_seeded_chart_rows(tool_active, tool_inactive, restore_active_set_id)
+        _cleanup_seeded_chart_rows(seeded)
 
 
 def test_get_charts_supports_tool_filter_and_active_only(client: TestClient) -> None:
     """tool_id フィルタと active_only フィルタが機能することを確認する。"""
-    tool_active, tool_inactive, restore_active_set_id = _seed_chart_rows_for_get_charts()
+    seeded = _seed_chart_rows_for_get_charts()
+    tool_active = seeded.tool_primary
+    tool_inactive = seeded.tool_secondary
     try:
         filtered = client.get("/charts", params={"tool_id": tool_active})
         assert filtered.status_code == 200
         filtered_data = filtered.json()["data"]
+        assert filtered_data
         assert all(item["tool_id"] == tool_active for item in filtered_data)
         assert all(item["tool_id"] != tool_inactive for item in filtered_data)
 
@@ -289,67 +295,77 @@ def test_get_charts_supports_tool_filter_and_active_only(client: TestClient) -> 
         assert any(item["tool_id"] == tool_active for item in active_only_data)
         assert all(item["tool_id"] != tool_inactive for item in active_only_data)
     finally:
-        _cleanup_seeded_chart_rows(tool_active, tool_inactive, restore_active_set_id)
+        _cleanup_seeded_chart_rows(seeded)
 
 
 def test_get_charts_supports_chamber_filter(client: TestClient) -> None:
     """chamber_id フィルタが機能することを確認する。"""
-    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    seeded = _seed_chart_rows_for_filter_tests()
+    tool_match = seeded.tool_primary
+    tool_other = seeded.tool_secondary
     try:
         res = client.get("/charts", params={"chamber_id": "CH_FILTER_MATCH"})
         assert res.status_code == 200
         data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
         _assert_all_rows_match(data, "chamber_id", "CH_FILTER_MATCH")
     finally:
-        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+        _cleanup_seeded_chart_rows(seeded)
 
 
 def test_get_charts_supports_recipe_filter(client: TestClient) -> None:
     """recipe_id フィルタが機能することを確認する。"""
-    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    seeded = _seed_chart_rows_for_filter_tests()
+    tool_match = seeded.tool_primary
+    tool_other = seeded.tool_secondary
     try:
         res = client.get("/charts", params={"recipe_id": "RECIPE_FILTER_MATCH"})
         assert res.status_code == 200
         data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
         _assert_all_rows_match(data, "recipe_id", "RECIPE_FILTER_MATCH")
     finally:
-        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+        _cleanup_seeded_chart_rows(seeded)
 
 
 def test_get_charts_supports_parameter_filter(client: TestClient) -> None:
     """parameter フィルタが機能することを確認する。"""
-    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    seeded = _seed_chart_rows_for_filter_tests()
+    tool_match = seeded.tool_primary
+    tool_other = seeded.tool_secondary
     try:
         res = client.get("/charts", params={"parameter": "dc_bias"})
         assert res.status_code == 200
         data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
         _assert_all_rows_match(data, "parameter", "dc_bias")
     finally:
-        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+        _cleanup_seeded_chart_rows(seeded)
 
 
 def test_get_charts_supports_positive_step_no_filter(client: TestClient) -> None:
     """step_no 正数フィルタが機能することを確認する。"""
-    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    seeded = _seed_chart_rows_for_filter_tests()
+    tool_match = seeded.tool_primary
+    tool_other = seeded.tool_secondary
     try:
         res = client.get("/charts", params={"step_no": 2})
         assert res.status_code == 200
         data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
         _assert_all_rows_match(data, "step_no", 2)
     finally:
-        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+        _cleanup_seeded_chart_rows(seeded)
 
 
 def test_get_charts_supports_feature_type_filter(client: TestClient) -> None:
     """feature_type フィルタが機能することを確認する。"""
-    tool_match, tool_other, restore_active_set_id = _seed_chart_rows_for_filter_tests()
+    seeded = _seed_chart_rows_for_filter_tests()
+    tool_match = seeded.tool_primary
+    tool_other = seeded.tool_secondary
     try:
         res = client.get("/charts", params={"feature_type": "mean"})
         assert res.status_code == 200
         data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
         _assert_all_rows_match(data, "feature_type", "mean")
     finally:
-        _cleanup_seeded_chart_rows(tool_match, tool_other, restore_active_set_id)
+        _cleanup_seeded_chart_rows(seeded)
 
 
 def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -575,6 +575,16 @@ def test_get_charts_returns_empty_for_non_matching_combined_filters(
     assert data == []
 
 
+def test_get_charts_returns_empty_envelope_when_no_match(client: TestClient) -> None:
+    """一致するチャートがない場合に ok:true / data:[] を返すことを確認する。"""
+    res = client.get("/charts", params={"tool_id": "TOOL_NONEXISTENT_BOUNDARY"})
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"] == []
+
+
 def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:
     """step_no が負数のとき 422 を返すことを確認する。"""
     res = client.get("/charts", params={"step_no": -1})

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -166,7 +166,8 @@ def _cleanup_seeded_chart_rows(context: SeededChartsContext) -> None:
         con.close()
 
 
-def _seed_chart_rows_for_filter_tests() -> SeededChartsContext:
+@pytest.fixture
+def seeded_chart_rows_for_filter_tests() -> Iterator[SeededChartsContext]:
     """各クエリフィルタ検証用に属性が異なる 2 chart を投入する。"""
     _init_schema(MAIN_DB)
     con = sqlite3.connect(MAIN_DB.as_posix())
@@ -230,14 +231,17 @@ def _seed_chart_rows_for_filter_tests() -> SeededChartsContext:
         )
 
         con.commit()
-        return SeededChartsContext(
+        context = SeededChartsContext(
             tool_primary=tool_match,
             tool_secondary=tool_other,
             restore_active_set_id=prev_active_set_id,
             chart_set_ids=(chart_set_id,),
         )
+        yield context
     finally:
         con.close()
+        if "context" in locals():
+            _cleanup_seeded_chart_rows(context)
 
 
 def _assert_all_rows_match(data: list[dict[str, object]], key: str, expected: object) -> None:
@@ -410,74 +414,79 @@ def test_get_charts_supports_tool_filter_and_active_only(
     assert all(item["tool_id"] != tool_inactive for item in active_only_data)
 
 
-def test_get_charts_supports_chamber_filter(client: TestClient) -> None:
+def test_get_charts_supports_chamber_filter(
+    client: TestClient,
+    seeded_chart_rows_for_filter_tests: SeededChartsContext,
+) -> None:
     """chamber_id フィルタが機能することを確認する。"""
-    seeded = _seed_chart_rows_for_filter_tests()
+    seeded = seeded_chart_rows_for_filter_tests
     tool_match = seeded.tool_primary
     tool_other = seeded.tool_secondary
-    try:
-        res = client.get("/charts", params={"chamber_id": "CH_FILTER_MATCH"})
-        assert res.status_code == 200
-        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
-        _assert_all_rows_match(data, "chamber_id", "CH_FILTER_MATCH")
-    finally:
-        _cleanup_seeded_chart_rows(seeded)
+
+    res = client.get("/charts", params={"chamber_id": "CH_FILTER_MATCH"})
+    assert res.status_code == 200
+    data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+    _assert_all_rows_match(data, "chamber_id", "CH_FILTER_MATCH")
 
 
-def test_get_charts_supports_recipe_filter(client: TestClient) -> None:
+def test_get_charts_supports_recipe_filter(
+    client: TestClient,
+    seeded_chart_rows_for_filter_tests: SeededChartsContext,
+) -> None:
     """recipe_id フィルタが機能することを確認する。"""
-    seeded = _seed_chart_rows_for_filter_tests()
+    seeded = seeded_chart_rows_for_filter_tests
     tool_match = seeded.tool_primary
     tool_other = seeded.tool_secondary
-    try:
-        res = client.get("/charts", params={"recipe_id": "RECIPE_FILTER_MATCH"})
-        assert res.status_code == 200
-        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
-        _assert_all_rows_match(data, "recipe_id", "RECIPE_FILTER_MATCH")
-    finally:
-        _cleanup_seeded_chart_rows(seeded)
+
+    res = client.get("/charts", params={"recipe_id": "RECIPE_FILTER_MATCH"})
+    assert res.status_code == 200
+    data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+    _assert_all_rows_match(data, "recipe_id", "RECIPE_FILTER_MATCH")
 
 
-def test_get_charts_supports_parameter_filter(client: TestClient) -> None:
+def test_get_charts_supports_parameter_filter(
+    client: TestClient,
+    seeded_chart_rows_for_filter_tests: SeededChartsContext,
+) -> None:
     """parameter フィルタが機能することを確認する。"""
-    seeded = _seed_chart_rows_for_filter_tests()
+    seeded = seeded_chart_rows_for_filter_tests
     tool_match = seeded.tool_primary
     tool_other = seeded.tool_secondary
-    try:
-        res = client.get("/charts", params={"parameter": "dc_bias"})
-        assert res.status_code == 200
-        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
-        _assert_all_rows_match(data, "parameter", "dc_bias")
-    finally:
-        _cleanup_seeded_chart_rows(seeded)
+
+    res = client.get("/charts", params={"parameter": "dc_bias"})
+    assert res.status_code == 200
+    data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+    _assert_all_rows_match(data, "parameter", "dc_bias")
 
 
-def test_get_charts_supports_positive_step_no_filter(client: TestClient) -> None:
+def test_get_charts_supports_positive_step_no_filter(
+    client: TestClient,
+    seeded_chart_rows_for_filter_tests: SeededChartsContext,
+) -> None:
     """step_no 正数フィルタが機能することを確認する。"""
-    seeded = _seed_chart_rows_for_filter_tests()
+    seeded = seeded_chart_rows_for_filter_tests
     tool_match = seeded.tool_primary
     tool_other = seeded.tool_secondary
-    try:
-        res = client.get("/charts", params={"step_no": 2})
-        assert res.status_code == 200
-        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
-        _assert_all_rows_match(data, "step_no", 2)
-    finally:
-        _cleanup_seeded_chart_rows(seeded)
+
+    res = client.get("/charts", params={"step_no": 2})
+    assert res.status_code == 200
+    data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+    _assert_all_rows_match(data, "step_no", 2)
 
 
-def test_get_charts_supports_feature_type_filter(client: TestClient) -> None:
+def test_get_charts_supports_feature_type_filter(
+    client: TestClient,
+    seeded_chart_rows_for_filter_tests: SeededChartsContext,
+) -> None:
     """feature_type フィルタが機能することを確認する。"""
-    seeded = _seed_chart_rows_for_filter_tests()
+    seeded = seeded_chart_rows_for_filter_tests
     tool_match = seeded.tool_primary
     tool_other = seeded.tool_secondary
-    try:
-        res = client.get("/charts", params={"feature_type": "mean"})
-        assert res.status_code == 200
-        data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
-        _assert_all_rows_match(data, "feature_type", "mean")
-    finally:
-        _cleanup_seeded_chart_rows(seeded)
+
+    res = client.get("/charts", params={"feature_type": "mean"})
+    assert res.status_code == 200
+    data = [item for item in res.json()["data"] if item["tool_id"] in {tool_match, tool_other}]
+    _assert_all_rows_match(data, "feature_type", "mean")
 
 
 def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import re
 import sqlite3
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
+from tests.test_utils import assert_validation_error_envelope
 
 _INSERT_CHART_SQL = """
     INSERT INTO ChartsV2(
@@ -49,7 +52,8 @@ def _create_chart_set_with_charts(
     return chart_set_id
 
 
-def _seed_chart_rows_for_get_charts() -> SeededChartsContext:
+@pytest.fixture
+def seeded_chart_rows_for_get_charts() -> Iterator[SeededChartsContext]:
     """GET /charts テスト用に active/inactive の 2 chart を投入する。"""
     _init_schema(MAIN_DB)
     con = sqlite3.connect(MAIN_DB.as_posix())
@@ -120,14 +124,17 @@ def _seed_chart_rows_for_get_charts() -> SeededChartsContext:
         )
 
         con.commit()
-        return SeededChartsContext(
+        context = SeededChartsContext(
             tool_primary=tool_active,
             tool_secondary=tool_inactive,
             restore_active_set_id=prev_active_set_id,
             chart_set_ids=(active_set_id, inactive_set_id),
         )
+        yield context
     finally:
         con.close()
+        if "context" in locals():
+            _cleanup_seeded_chart_rows(context)
 
 
 def _cleanup_seeded_chart_rows(context: SeededChartsContext) -> None:
@@ -239,24 +246,6 @@ def _assert_all_rows_match(data: list[dict[str, object]], key: str, expected: ob
     assert all(item.get(key) == expected for item in data)
 
 
-def _assert_validation_error_envelope(
-    response_body: dict[str, object],
-    *,
-    expected_loc_fragment: str,
-) -> None:
-    """共通 422 エラーフォーマットを検証する。"""
-    assert response_body["ok"] is False
-    error = response_body["error"]
-    assert isinstance(error, dict)
-    assert error["code"] == "VALIDATION_ERROR"
-    assert error["message"] == "Validation error"
-    details = error["details"]
-    assert isinstance(details, dict)
-    issues = details["issues"]
-    assert isinstance(issues, list)
-    assert any(expected_loc_fragment in str(issue.get("loc", [])) for issue in issues)
-
-
 def _insert_chart_history(
     chart_set_id: int,
     *,
@@ -312,9 +301,12 @@ def _insert_chart_history(
         con.close()
 
 
-def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) -> None:
+def test_get_charts_returns_chart_rows_with_contract_fields(
+    client: TestClient,
+    seeded_chart_rows_for_get_charts: SeededChartsContext,
+) -> None:
     """GET /charts が契約フィールドを返すことを確認する。"""
-    seeded = _seed_chart_rows_for_get_charts()
+    seeded = seeded_chart_rows_for_get_charts
     tool_active = seeded.tool_primary
     tool_inactive = seeded.tool_secondary
     expected_warning_ranges = {
@@ -329,95 +321,93 @@ def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) 
         tool_active: "2026-04-14T00:00:00.000Z",
         tool_inactive: "2026-04-14T00:00:00.000Z",
     }
-    try:
-        res = client.get("/charts")
+    res = client.get("/charts")
 
-        assert res.status_code == 200
-        body = res.json()
-        assert body["ok"] is True
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
 
-        rows = [item for item in body["data"] if item["tool_id"] in {tool_active, tool_inactive}]
-        assert len(rows) == 2
+    rows = [item for item in body["data"] if item["tool_id"] in {tool_active, tool_inactive}]
+    assert len(rows) == 2
 
-        for row in rows:
-            assert re.fullmatch(r"CHART_\d+", row["chart_id"])
-            assert isinstance(row["chart_set_id"], int)
-            assert row["chamber_id"] == "CH1"
-            assert row["recipe_id"] == "RECIPE_A"
-            assert row["parameter"] == "dc_bias"
-            assert row["step_no"] == 1
-            assert row["feature_type"] == "mean"
-            expected_warning_lcl, expected_warning_ucl = expected_warning_ranges[row["tool_id"]]
-            expected_critical_lcl, expected_critical_ucl = expected_critical_ranges[row["tool_id"]]
-            assert isinstance(row["warning_lcl"], float)
-            assert isinstance(row["warning_ucl"], float)
-            assert row["warning_lcl"] == expected_warning_lcl
-            assert row["warning_ucl"] == expected_warning_ucl
-            assert row["critical_lcl"] == expected_critical_lcl
-            assert row["critical_ucl"] == expected_critical_ucl
-            assert row["lcl"] == expected_critical_lcl
-            assert row["ucl"] == expected_critical_ucl
-            assert isinstance(row["version"], int)
-            assert row["version"] >= 1
-            assert row["updated_at"] == expected_updated_at[row["tool_id"]]
+    for row in rows:
+        assert re.fullmatch(r"CHART_\d+", row["chart_id"])
+        assert isinstance(row["chart_set_id"], int)
+        assert row["chamber_id"] == "CH1"
+        assert row["recipe_id"] == "RECIPE_A"
+        assert row["parameter"] == "dc_bias"
+        assert row["step_no"] == 1
+        assert row["feature_type"] == "mean"
+        expected_warning_lcl, expected_warning_ucl = expected_warning_ranges[row["tool_id"]]
+        expected_critical_lcl, expected_critical_ucl = expected_critical_ranges[row["tool_id"]]
+        assert isinstance(row["warning_lcl"], float)
+        assert isinstance(row["warning_ucl"], float)
+        assert row["warning_lcl"] == expected_warning_lcl
+        assert row["warning_ucl"] == expected_warning_ucl
+        assert row["critical_lcl"] == expected_critical_lcl
+        assert row["critical_ucl"] == expected_critical_ucl
+        assert row["lcl"] == expected_critical_lcl
+        assert row["ucl"] == expected_critical_ucl
+        assert isinstance(row["version"], int)
+        assert row["version"] >= 1
+        assert row["updated_at"] == expected_updated_at[row["tool_id"]]
 
-        active_row = next(item for item in rows if item["tool_id"] == tool_active)
-        inactive_row = next(item for item in rows if item["tool_id"] == tool_inactive)
-        assert active_row["is_active"] is True
-        assert inactive_row["is_active"] is False
-    finally:
-        _cleanup_seeded_chart_rows(seeded)
+    active_row = next(item for item in rows if item["tool_id"] == tool_active)
+    inactive_row = next(item for item in rows if item["tool_id"] == tool_inactive)
+    assert active_row["is_active"] is True
+    assert inactive_row["is_active"] is False
 
 
-def test_get_charts_computes_version_from_history_count(client: TestClient) -> None:
+def test_get_charts_computes_version_from_history_count(
+    client: TestClient,
+    seeded_chart_rows_for_get_charts: SeededChartsContext,
+) -> None:
     """version が履歴件数 + 1 で返ることを確認する。"""
-    seeded = _seed_chart_rows_for_get_charts()
+    seeded = seeded_chart_rows_for_get_charts
     tool_active = seeded.tool_primary
     active_set_id = seeded.chart_set_ids[0]
-    try:
-        _insert_chart_history(
-            active_set_id,
-            tool_id=tool_active,
-            chamber_id="CH1",
-            recipe_id="RECIPE_A",
-            parameter="dc_bias",
-            step_no=1,
-            feature_type="mean",
-            count=2,
-        )
+    _insert_chart_history(
+        active_set_id,
+        tool_id=tool_active,
+        chamber_id="CH1",
+        recipe_id="RECIPE_A",
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        count=2,
+    )
 
-        res = client.get("/charts", params={"tool_id": tool_active})
+    res = client.get("/charts", params={"tool_id": tool_active})
 
-        assert res.status_code == 200
-        data = res.json()["data"]
-        assert len(data) == 1
-        assert all(item["tool_id"] == tool_active for item in data)
-        assert data[0]["version"] == 3
-    finally:
-        _cleanup_seeded_chart_rows(seeded)
+    assert res.status_code == 200
+    data = res.json()["data"]
+    assert len(data) == 1
+    assert all(item["tool_id"] == tool_active for item in data)
+    assert data[0]["version"] == 3
 
 
-def test_get_charts_supports_tool_filter_and_active_only(client: TestClient) -> None:
+def test_get_charts_supports_tool_filter_and_active_only(
+    client: TestClient,
+    seeded_chart_rows_for_get_charts: SeededChartsContext,
+) -> None:
     """tool_id フィルタと active_only フィルタが機能することを確認する。"""
-    seeded = _seed_chart_rows_for_get_charts()
+    seeded = seeded_chart_rows_for_get_charts
     tool_active = seeded.tool_primary
     tool_inactive = seeded.tool_secondary
-    try:
-        filtered = client.get("/charts", params={"tool_id": tool_active})
-        assert filtered.status_code == 200
-        filtered_data = filtered.json()["data"]
-        assert filtered_data
-        assert all(item["tool_id"] == tool_active for item in filtered_data)
-        assert all(item["tool_id"] != tool_inactive for item in filtered_data)
 
-        active_only = client.get("/charts", params={"active_only": True})
-        assert active_only.status_code == 200
-        active_only_data = active_only.json()["data"]
-        assert all(item["is_active"] is True for item in active_only_data)
-        assert any(item["tool_id"] == tool_active for item in active_only_data)
-        assert all(item["tool_id"] != tool_inactive for item in active_only_data)
-    finally:
-        _cleanup_seeded_chart_rows(seeded)
+    filtered = client.get("/charts", params={"tool_id": tool_active})
+    assert filtered.status_code == 200
+    filtered_data = filtered.json()["data"]
+    assert filtered_data
+    assert all(item["tool_id"] == tool_active for item in filtered_data)
+    assert all(item["tool_id"] != tool_inactive for item in filtered_data)
+
+    active_only = client.get("/charts", params={"active_only": True})
+    assert active_only.status_code == 200
+    active_only_data = active_only.json()["data"]
+    assert all(item["is_active"] is True for item in active_only_data)
+    assert any(item["tool_id"] == tool_active for item in active_only_data)
+    assert all(item["tool_id"] != tool_inactive for item in active_only_data)
 
 
 def test_get_charts_supports_chamber_filter(client: TestClient) -> None:
@@ -495,4 +485,4 @@ def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:
     res = client.get("/charts", params={"step_no": -1})
 
     assert res.status_code == 422
-    _assert_validation_error_envelope(res.json(), expected_loc_fragment="step_no")
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="step_no")

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 
+from portfolio_fdc.db_api.chart_repository import _to_utc_millis
 from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
 from tests.test_utils import assert_validation_error_envelope
 
@@ -533,3 +534,17 @@ def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:
 
     assert res.status_code == 422
     assert_validation_error_envelope(res.json(), expected_loc_fragment="step_no")
+
+
+def test_get_charts_rejects_invalid_tool_id_pattern(client: TestClient) -> None:
+    """tool_id が許可されない形式のとき 422 を返すことを確認する。"""
+    res = client.get("/charts", params={"tool_id": "TOOL INVALID"})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="tool_id")
+
+
+def test_to_utc_millis_truncates_microseconds_not_rounds() -> None:
+    """updated_at 正規化は四捨五入ではなくミリ秒切り捨てであることを確認する。"""
+    assert _to_utc_millis("2026-04-14T00:00:00.123999+00:00") == "2026-04-14T00:00:00.123Z"
+    assert _to_utc_millis("2026-04-14T00:00:00.123500+00:00") == "2026-04-14T00:00:00.123Z"

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -239,6 +239,24 @@ def _assert_all_rows_match(data: list[dict[str, object]], key: str, expected: ob
     assert all(item.get(key) == expected for item in data)
 
 
+def _assert_validation_error_envelope(
+    response_body: dict[str, object],
+    *,
+    expected_loc_fragment: str,
+) -> None:
+    """共通 422 エラーフォーマットを検証する。"""
+    assert response_body["ok"] is False
+    error = response_body["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "VALIDATION_ERROR"
+    assert error["message"] == "Validation error"
+    details = error["details"]
+    assert isinstance(details, dict)
+    issues = details["issues"]
+    assert isinstance(issues, list)
+    assert any(expected_loc_fragment in str(issue.get("loc", [])) for issue in issues)
+
+
 def _insert_chart_history(
     chart_set_id: int,
     *,
@@ -303,6 +321,10 @@ def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) 
         tool_active: (1.4, 2.6),
         tool_inactive: (1.0, 2.0),
     }
+    expected_critical_ranges = {
+        tool_active: (1.2, 2.8),
+        tool_inactive: (0.8, 2.2),
+    }
     expected_updated_at = {
         tool_active: "2026-04-14T00:00:00.000Z",
         tool_inactive: "2026-04-14T00:00:00.000Z",
@@ -326,12 +348,15 @@ def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) 
             assert row["step_no"] == 1
             assert row["feature_type"] == "mean"
             expected_warning_lcl, expected_warning_ucl = expected_warning_ranges[row["tool_id"]]
+            expected_critical_lcl, expected_critical_ucl = expected_critical_ranges[row["tool_id"]]
             assert isinstance(row["warning_lcl"], float)
             assert isinstance(row["warning_ucl"], float)
             assert row["warning_lcl"] == expected_warning_lcl
             assert row["warning_ucl"] == expected_warning_ucl
-            assert row["lcl"] == row["critical_lcl"]
-            assert row["ucl"] == row["critical_ucl"]
+            assert row["critical_lcl"] == expected_critical_lcl
+            assert row["critical_ucl"] == expected_critical_ucl
+            assert row["lcl"] == expected_critical_lcl
+            assert row["ucl"] == expected_critical_ucl
             assert isinstance(row["version"], int)
             assert row["version"] >= 1
             assert row["updated_at"] == expected_updated_at[row["tool_id"]]
@@ -365,9 +390,9 @@ def test_get_charts_computes_version_from_history_count(client: TestClient) -> N
 
         assert res.status_code == 200
         data = res.json()["data"]
-        assert data
+        assert len(data) == 1
         assert all(item["tool_id"] == tool_active for item in data)
-        assert any(item["version"] == 3 for item in data)
+        assert data[0]["version"] == 3
     finally:
         _cleanup_seeded_chart_rows(seeded)
 
@@ -470,3 +495,4 @@ def test_get_charts_rejects_negative_step_no(client: TestClient) -> None:
     res = client.get("/charts", params={"step_no": -1})
 
     assert res.status_code == 422
+    _assert_validation_error_envelope(res.json(), expected_loc_fragment="step_no")

--- a/tests/test_db_api_charts_endpoint.py
+++ b/tests/test_db_api_charts_endpoint.py
@@ -254,6 +254,9 @@ def _insert_chart_history(
     con = sqlite3.connect(MAIN_DB.as_posix())
     try:
         for index in range(count):
+            changed_at = (
+                datetime(2026, 4, 14, 0, 0, index, tzinfo=UTC).isoformat().replace("+00:00", "Z")
+            )
             con.execute(
                 """
                 INSERT INTO ChartsHistory(
@@ -280,7 +283,7 @@ def _insert_chart_history(
                     2.1,
                     0.9,
                     2.3,
-                    f"2026-04-14T00:00:0{index}Z",
+                    changed_at,
                     "tester",
                     "history-seed",
                     "test",
@@ -296,6 +299,14 @@ def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) 
     seeded = _seed_chart_rows_for_get_charts()
     tool_active = seeded.tool_primary
     tool_inactive = seeded.tool_secondary
+    expected_warning_ranges = {
+        tool_active: (1.4, 2.6),
+        tool_inactive: (1.0, 2.0),
+    }
+    expected_updated_at = {
+        tool_active: "2026-04-14T00:00:00.000Z",
+        tool_inactive: "2026-04-14T00:00:00.000Z",
+    }
     try:
         res = client.get("/charts")
 
@@ -314,14 +325,16 @@ def test_get_charts_returns_chart_rows_with_contract_fields(client: TestClient) 
             assert row["parameter"] == "dc_bias"
             assert row["step_no"] == 1
             assert row["feature_type"] == "mean"
+            expected_warning_lcl, expected_warning_ucl = expected_warning_ranges[row["tool_id"]]
+            assert isinstance(row["warning_lcl"], float)
+            assert isinstance(row["warning_ucl"], float)
+            assert row["warning_lcl"] == expected_warning_lcl
+            assert row["warning_ucl"] == expected_warning_ucl
             assert row["lcl"] == row["critical_lcl"]
             assert row["ucl"] == row["critical_ucl"]
             assert isinstance(row["version"], int)
             assert row["version"] >= 1
-            assert re.fullmatch(
-                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z",
-                row["updated_at"],
-            )
+            assert row["updated_at"] == expected_updated_at[row["tool_id"]]
 
         active_row = next(item for item in rows if item["tool_id"] == tool_active)
         inactive_row = next(item for item in rows if item["tool_id"] == tool_inactive)

--- a/tests/test_db_api_integration.py
+++ b/tests/test_db_api_integration.py
@@ -51,6 +51,28 @@ def assert_legacy_migration_headers(
     assert response_headers.get("Link") == expected_link
 
 
+def assert_validation_error_envelope(
+    response_body: dict[str, object],
+    *,
+    expected_loc_fragment: str | None = None,
+    expected_message_fragment: str | None = None,
+) -> None:
+    """共通 422 エラーフォーマットを検証する。"""
+    assert response_body["ok"] is False
+    error = response_body["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "VALIDATION_ERROR"
+    assert error["message"] == "Validation error"
+    details = error["details"]
+    assert isinstance(details, dict)
+    issues = details["issues"]
+    assert isinstance(issues, list)
+    if expected_loc_fragment is not None:
+        assert any(expected_loc_fragment in str(issue.get("loc", [])) for issue in issues)
+    if expected_message_fragment is not None:
+        assert any(expected_message_fragment in str(issue.get("msg", "")) for issue in issues)
+
+
 def test_db_api_minimum_flow_for_aggregate_contract(
     client: TestClient,
     count_rows: Callable[[str], tuple[int, int, int]],
@@ -176,8 +198,7 @@ def test_db_api_parameters_bulk_rejects_negative_step_no(client: TestClient) -> 
     res = client.post("/parameters/bulk", json=payload)
 
     assert res.status_code == 422
-    details = res.json()["detail"]
-    assert any("step_no" in item.get("loc", []) for item in details)
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="step_no")
 
 
 def test_parameter_in_rejects_non_finite_feature_value() -> None:
@@ -378,9 +399,9 @@ def test_db_api_aggregate_write_rejects_mismatched_process_id(client: TestClient
     res = client.post("/aggregate/write", json=payload)
 
     assert res.status_code == 422
-    details = res.json()["detail"]
-    assert any(
-        "process_id must match process.process_id" in item.get("msg", "") for item in details
+    assert_validation_error_envelope(
+        res.json(),
+        expected_message_fragment="process_id must match process.process_id",
     )
 
 

--- a/tests/test_db_api_integration.py
+++ b/tests/test_db_api_integration.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 from portfolio_fdc.db_api import app as db_app
 from portfolio_fdc.db_api.db import MAIN_DB
 from portfolio_fdc.db_api.schemas import ParameterIn
+from tests.test_utils import assert_validation_error_envelope
 
 pytestmark = pytest.mark.integration
 
@@ -49,28 +50,6 @@ def assert_legacy_migration_headers(
     else:
         expected_link = f'</processes/{quote(process_id, safe="")}>; rel="successor-version"'
     assert response_headers.get("Link") == expected_link
-
-
-def assert_validation_error_envelope(
-    response_body: dict[str, object],
-    *,
-    expected_loc_fragment: str | None = None,
-    expected_message_fragment: str | None = None,
-) -> None:
-    """共通 422 エラーフォーマットを検証する。"""
-    assert response_body["ok"] is False
-    error = response_body["error"]
-    assert isinstance(error, dict)
-    assert error["code"] == "VALIDATION_ERROR"
-    assert error["message"] == "Validation error"
-    details = error["details"]
-    assert isinstance(details, dict)
-    issues = details["issues"]
-    assert isinstance(issues, list)
-    if expected_loc_fragment is not None:
-        assert any(expected_loc_fragment in str(issue.get("loc", [])) for issue in issues)
-    if expected_message_fragment is not None:
-        assert any(expected_message_fragment in str(issue.get("msg", "")) for issue in issues)
 
 
 def test_db_api_minimum_flow_for_aggregate_contract(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+def assert_validation_error_envelope(
+    response_body: dict[str, object],
+    *,
+    expected_loc_fragment: str | None = None,
+    expected_message_fragment: str | None = None,
+) -> None:
+    """共通 422 エラーフォーマットを検証する。"""
+    assert response_body["ok"] is False
+    error = response_body["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "VALIDATION_ERROR"
+    assert error["message"] == "Validation error"
+    details = error["details"]
+    assert isinstance(details, dict)
+    issues = details["issues"]
+    assert isinstance(issues, list)
+    if expected_loc_fragment is not None:
+        assert any(expected_loc_fragment in str(issue.get("loc", [])) for issue in issues)
+    if expected_message_fragment is not None:
+        assert any(expected_message_fragment in str(issue.get("msg", "")) for issue in issues)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,18 @@ def assert_validation_error_envelope(
     assert isinstance(details, dict)
     issues = details["issues"]
     assert isinstance(issues, list)
+    assert issues
+
+    for issue in issues:
+        assert isinstance(issue, dict)
+        assert "loc" in issue
+        assert "msg" in issue
+        loc = issue["loc"]
+        msg = issue["msg"]
+        assert isinstance(loc, (list, tuple))
+        assert isinstance(msg, str)
+
     if expected_loc_fragment is not None:
-        assert any(expected_loc_fragment in str(issue.get("loc", [])) for issue in issues)
+        assert any(expected_loc_fragment in str(issue["loc"]) for issue in issues)
     if expected_message_fragment is not None:
-        assert any(expected_message_fragment in str(issue.get("msg", "")) for issue in issues)
+        assert any(expected_message_fragment in issue["msg"] for issue in issues)


### PR DESCRIPTION
## 概要

Issue #129 の `GET /charts` を実装しました。実装方針は Python で Java 的な OOP スタイル（Criteria DTO + View DTO + Repository class）です。

Closes #129

## 変更内容

- `src/portfolio_fdc/db_api/chart_repository.py` を新規追加
  - `ChartsQueryCriteria`（検索条件 DTO）
  - `ChartView`（レスポンス DTO）
  - `ChartRepository`（読取責務）
- `src/portfolio_fdc/db_api/app.py`
  - `GET /charts` endpoint を追加
  - optional query: `tool_id`, `chamber_id`, `recipe_id`, `parameter`, `step_no`, `feature_type`, `active_only`
  - `{ok: true, data: [...]}` envelope で返却
- `tests/test_db_api_charts_endpoint.py` を新規追加
  - 契約フィールドの返却
  - `tool_id` フィルタ
  - `active_only` フィルタ
  - `step_no < 0` の 422
  - `updated_at` の UTC ISO8601 ミリ秒形式
- `docs/db-api-endpoints.md`
  - `GET /charts` を `implemented` に更新

## 実装メモ

- `chart_id` は `ChartsV2.id` から `CHART_<id>` 形式で生成
- `lcl/ucl` は現行スキーマ上 `crit_low/crit_high` をマップ
- `version` は `ChartsHistory` 同一キー件数 + 1 で算出

## 検証

- `E:/work/python/logger/.venv/Scripts/python.exe -m pytest tests/test_db_api_charts_endpoint.py tests/test_db_api_integration.py -q`
- pre-commit hooks（ruff/mypy/import-linter）通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## GET /charts エンドポイント実装（更新版）

- 概要
  - GET /charts を実装。オプショナルクエリ: tool_id, chamber_id, recipe_id, parameter, step_no（ge=0）、feature_type、active_only。成功応答は { "ok": true, "data": [...] }。RequestValidationError 用の標準 422 エンベロープを追加。エンドポイントは例外をログし、起動時にスキーマ初期化を呼ぶ変更あり。
  - 追加コード: src/portfolio_fdc/db_api/chart_repository.py（ChartsQueryCriteria, ChartView, ChartRepository.find_charts）、および src/portfolio_fdc/db_api/app.py にエンドポイント登録と例外ハンドラ。

- マッピング・正規化・実装上の注記
  - chart_id は "CHART_<ChartsV2.id>" として生成。
  - warning_lcl/ warning_ucl は warn_low/warn_high、critical_lcl/ critical_ucl は crit_low/crit_high からマップ。lcl/ucl は互換エイリアスとして critical_lcl/critical_ucl を返す（ドキュメント注記あり）。
  - updated_at は UTC ISO8601 ミリ秒精度（マイクロ秒以下を切り捨て）で返却。ナイーブ日時は UTC 扱い、タイムゾーン正規化テストあり。
  - is_active は ActiveChartSet の存在を EXISTS で判定（NULL 安全）するロジックに変更。
  - version は ChartsHistory の同一キー件数 + 1 と定義。従来の行毎相関 COUNT を排し、filtered_charts と history_versions の CTE を用いることで相関 COUNT の CPU 負荷を低減。

- 入力検証
  - 文字列フィルタに正規表現制約を追加: ^[A-Za-z0-9_./:-]+$、長さ 1..128。step_no は ge=0。無効クエリは 422 を返し、エラーエンベロープに loc/msg が含まれる。

- テスト・検証
  - tests/test_db_api_charts_endpoint.py を追加：契約フィールド検証、tool_id/chamber/recipe/parameter/step_no（正値・0 の境界）/feature_type フィルタ、active_only フィルタ、step_no<0 と無効パターンでの 422、updated_at 形式（UTC ミリ秒・トランケート）、version == ChartsHistory 件数+1、ActiveChartSet 欠損時の is_active == False、複合フィルタ・空結果ケース等を網羅。シード/クリーンナップ実装あり。
  - tests/test_utils.py に検証エンベロープ検査ヘルパを追加し、既存統合テストで利用するよう更新。
  - _to_utc_millis の単体テスト（マイクロ秒切り捨て＝トランケート、タイムゾーン変換、年境界、ナイーブ日時扱い）あり。
  - 作者報告ではブランチ上でユニット／統合テストおよび pre-commit（ruff/mypy/import-linter）が通過。

- ドキュメント
  - docs/db-api-endpoints.md と docs/db-api-minimum-contract.md を更新（GET /charts を実装済みに変更、クエリ検証ルール・タイムスタンプミリ秒化ルール・lcl/ucl 互換注記を追記）。
  - docs/coderabbit-pr135-findings.md を追加し、CodeRabbit 所見と対応状況を記録。

- リスク
  - パフォーマンス: per-row 相関 COUNT を除去して改善したが、filtered_charts／history_versions の集約自体はコストが残る。ページング未実装のため大結果セットでメモリ消費・遅延が懸念。大規模負荷試験は未実施。
  - is_active の想定: 実装は単一の ActiveChartSet を前提。複数アクティブセットや優先ルールがある運用では誤判定の可能性があり、該当ケースの仕様化と追加テストが必要。
  - 互換フィールド運用: lcl/ucl を critical_* の互換エイリアスとして提供しているため、将来仕様変更時に混乱が生じるリスク（ドキュメントで注記済みだが周知が必要）。

- テストギャップ・推奨追加
  - 大規模データに対する負荷試験（レスポンス遅延、メモリ、CPU、DB負荷）およびページング/制限導入の検討とテスト。
  - ActiveChartSet の多重化や優先ルールを想定した仕様化とその挙動テスト。
  - クエリ組合せの網羅的テスト拡張（多条件 AND/OR の組み合わせ）、最大長/境界文字列ケース、許容外文字、タイムゾーン極端ケースのさらなる検証。
  - 将来的に version をデノーマライズして保持する設計への移行計画と整合性テスト。

- 追記事項
  - 本 PR は Issue #129 の要件を満たす実装であり、該当テストと静的チェックがブランチ上で通過したとの報告あり。以上を踏まえ、性能・運用前提に関する追加評価とドキュメント周知を推奨する。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->