### PR TITLE
feat(db_api): implement GET /charts/active endpoint (#130)

### DIFF
--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -23,7 +23,7 @@
 | `POST`   | `/parameters/bulk`                                  | ingest write   | implemented | ingest          | source: `db_api/app.py` | `Parameter` を一括保存                       |
 | `POST`   | `/aggregate/write`                                  | ingest write   | implemented | ingest          | source: `db_api/app.py` | Process/StepWindow/Parameter を原子的に保存  |
 | `GET`    | `/charts`                                           | dashboard read | implemented | dashboard/judge | source: `db_api/app.py` | chart 定義一覧                               |
-| `GET`    | `/charts/active`                                    | dashboard read | planned     | dashboard/judge | Issue #98               | active chart set と閾値                      |
+| `GET`    | `/charts/active`                                    | dashboard read | implemented | dashboard/judge | source: `db_api/app.py` | active chart set と閾値                      |
 | `GET`    | `/charts/history`                                   | dashboard read | planned     | dashboard/ops   | Issue #98               | chart 変更履歴                               |
 | `GET`    | `/judge/results`                                    | dashboard read | planned     | dashboard       | Issue #98               | 判定結果一覧                                 |
 | `GET`    | `/judge/results/{result_id}`                        | dashboard read | planned     | dashboard       | Issue #98               | 判定詳細（トレース情報含む）                 |

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -7,13 +7,14 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import asdict
 from datetime import UTC, datetime
 from email.utils import format_datetime
 from threading import Lock
-from typing import Annotated, cast
+from typing import Annotated, NoReturn, cast
 from urllib.parse import quote
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
@@ -142,6 +143,36 @@ def get_runner(request: Request) -> DBTaskRunner:
     return _runner_from_request(request)
 
 
+def _raise_api_error(
+    *,
+    operation: str,
+    error: Exception,
+    headers: dict[str, str] | None = None,
+) -> NoReturn:
+    """内部例外をログに残しつつ、クライアント向けには安全なエラーを返す。"""
+    logger.exception("%s failed: %s", operation, type(error).__name__)
+
+    if isinstance(error, sqlite3.OperationalError):
+        raise HTTPException(
+            status_code=503,
+            detail="Database temporarily unavailable",
+            headers=headers,
+        ) from error
+
+    if isinstance(error, sqlite3.DatabaseError):
+        raise HTTPException(
+            status_code=500,
+            detail="Database operation failed",
+            headers=headers,
+        ) from error
+
+    raise HTTPException(
+        status_code=500,
+        detail="Internal server error",
+        headers=headers,
+    ) from error
+
+
 RunnerDep = Annotated[DBTaskRunner, Depends(get_runner)]
 _chart_repository = ChartRepository()
 
@@ -195,8 +226,7 @@ def get_charts(
         rows = _chart_repository.find_charts(criteria)
         return {"ok": True, "data": [asdict(row) for row in rows]}
     except Exception as e:
-        logger.exception("Failed to fetch charts")
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+        _raise_api_error(operation="GET /charts", error=e)
 
 
 @app.get("/charts/active")
@@ -230,8 +260,7 @@ def get_active_charts(
         data = _chart_repository.find_active_chart_set(criteria)
         return {"ok": True, "data": asdict(data)}
     except Exception as e:
-        logger.exception("Failed to fetch active charts")
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+        _raise_api_error(operation="GET /charts/active", error=e)
 
 
 @app.post("/processes")
@@ -241,7 +270,7 @@ def create_process(p: ProcessInfoIn, runner: RunnerDep):
         runner.submit("write", lambda: write_process(p))
         return {"ok": True}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        _raise_api_error(operation="POST /processes", error=e)
 
 
 @app.delete("/processes/{process_id:path}")
@@ -251,7 +280,7 @@ def remove_process_by_path(process_id: str, runner: RunnerDep):
         deleted = runner.submit("write", lambda: delete_process(process_id))
         return {"ok": True, "deleted": deleted}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        _raise_api_error(operation="DELETE /processes/{process_id}", error=e)
 
 
 @app.delete("/processes")
@@ -267,7 +296,7 @@ def remove_process_legacy(
         deleted = runner.submit("write", lambda: delete_process(req.process_id))
         return {"ok": True, "deleted": deleted}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e), headers=headers) from e
+        _raise_api_error(operation="DELETE /processes", error=e, headers=headers)
 
 
 @app.post("/step_windows/bulk")
@@ -277,7 +306,7 @@ def create_step_windows_bulk(items: list[StepWindowIn], runner: RunnerDep):
         inserted = runner.submit("write", lambda: write_step_windows_bulk(items))
         return {"ok": True, "inserted": inserted}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        _raise_api_error(operation="POST /step_windows/bulk", error=e)
 
 
 @app.post("/parameters/bulk")
@@ -287,7 +316,7 @@ def create_parameters_bulk(params: list[ParameterIn], runner: RunnerDep):
         n = runner.submit("write", lambda: write_parameters_bulk(params))
         return {"ok": True, "inserted": n}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        _raise_api_error(operation="POST /parameters/bulk", error=e)
 
 
 @app.post("/aggregate/write")
@@ -297,4 +326,4 @@ def create_aggregate_write(payload: AggregateWriteIn, runner: RunnerDep):
         result = runner.submit("write", lambda: write_aggregate_atomic(payload))
         return result
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        _raise_api_error(operation="POST /aggregate/write", error=e)

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -143,6 +143,15 @@ def get_runner(request: Request) -> DBTaskRunner:
     return _runner_from_request(request)
 
 
+def _is_runner_unavailable_error(error: Exception) -> bool:
+    """DBTaskRunner 停止/タイムアウト起因の一時的障害かを判定する。"""
+    if isinstance(error, TimeoutError):
+        return True
+    if not isinstance(error, RuntimeError):
+        return False
+    return str(error).startswith("DBTaskRunner")
+
+
 def _raise_api_error(
     *,
     operation: str,
@@ -151,6 +160,13 @@ def _raise_api_error(
 ) -> NoReturn:
     """内部例外をログに残しつつ、クライアント向けには安全なエラーを返す。"""
     logger.exception("%s failed: %s", operation, type(error).__name__)
+
+    if _is_runner_unavailable_error(error):
+        raise HTTPException(
+            status_code=503,
+            detail="Service temporarily unavailable",
+            headers=headers,
+        ) from error
 
     if isinstance(error, sqlite3.OperationalError):
         raise HTTPException(

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -28,7 +28,7 @@ from .aggregate_repository import (
     write_process,
     write_step_windows_bulk,
 )
-from .chart_repository import ChartRepository, ChartsQueryCriteria
+from .chart_repository import ActiveChartsQueryCriteria, ChartRepository, ChartsQueryCriteria
 from .db import MAIN_DB, TEMP_DB, _init_schema
 from .schemas import (
     AggregateWriteIn,
@@ -196,6 +196,41 @@ def get_charts(
         return {"ok": True, "data": [asdict(row) for row in rows]}
     except Exception as e:
         logger.exception("Failed to fetch charts")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@app.get("/charts/active")
+def get_active_charts(
+    tool_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
+    chamber_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
+    recipe_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
+):
+    """active chart set と有効閾値一覧を返す。"""
+    criteria = ActiveChartsQueryCriteria(
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+    )
+    try:
+        data = _chart_repository.find_active_chart_set(criteria)
+        return {"ok": True, "data": asdict(data)}
+    except Exception as e:
+        logger.exception("Failed to fetch active charts")
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -152,6 +152,31 @@ def _is_runner_unavailable_error(error: Exception) -> bool:
     return str(error).startswith("DBTaskRunner")
 
 
+def _is_transient_operational_error(error: sqlite3.OperationalError) -> bool:
+    """OperationalError が一時的な DB 障害かどうかを判定する。"""
+    message = str(error).lower()
+
+    # 恒久的な設定/SQL 不整合は 500 として扱う。
+    non_transient_markers = (
+        "no such table",
+        "no such column",
+        "syntax error",
+        "malformed",
+    )
+    if any(marker in message for marker in non_transient_markers):
+        return False
+
+    transient_markers = (
+        "database is locked",
+        "database is busy",
+        "busy",
+        "unable to open database file",
+        "disk i/o error",
+        "readonly database",
+    )
+    return any(marker in message for marker in transient_markers)
+
+
 def _raise_api_error(
     *,
     operation: str,
@@ -169,9 +194,15 @@ def _raise_api_error(
         ) from error
 
     if isinstance(error, sqlite3.OperationalError):
+        if _is_transient_operational_error(error):
+            raise HTTPException(
+                status_code=503,
+                detail="Database temporarily unavailable",
+                headers=headers,
+            ) from error
         raise HTTPException(
-            status_code=503,
-            detail="Database temporarily unavailable",
+            status_code=500,
+            detail="Database operation failed",
             headers=headers,
         ) from error
 

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -23,6 +23,15 @@ class ChartsQueryCriteria:
 
 
 @dataclass(frozen=True)
+class ActiveChartsQueryCriteria:
+    """`GET /charts/active` の検索条件を保持する DTO。"""
+
+    tool_id: str | None = None
+    chamber_id: str | None = None
+    recipe_id: str | None = None
+
+
+@dataclass(frozen=True)
 class ChartView:
     """`GET /charts` レスポンス 1 件分の DTO。
 
@@ -50,8 +59,51 @@ class ChartView:
     is_active: bool
 
 
+@dataclass(frozen=True)
+class ActiveChartView:
+    """`GET /charts/active` の charts 配列 1 件分の DTO。"""
+
+    chart_id: str
+    parameter: str
+    step_no: int
+    feature_type: str
+    warning_lcl: float | None
+    warning_ucl: float | None
+    critical_lcl: float | None
+    critical_ucl: float | None
+
+
+@dataclass(frozen=True)
+class ActiveChartSetView:
+    """`GET /charts/active` レスポンス data の DTO。"""
+
+    active_chart_set_id: int | None
+    activated_at: str | None
+    charts: list[ActiveChartView]
+
+
 class ChartRepository:
     """ChartsV2 から chart 一覧を取得するリポジトリ。"""
+
+    _ACTIVE_CHART_SET_SQL = """
+        SELECT chart_set_id, updated_at
+        FROM ActiveChartSet
+        WHERE id = 1
+    """
+
+    _ACTIVE_CHARTS_SQL = """
+        SELECT
+            c.id,
+            c.parameter,
+            c.step_no,
+            c.feature_type,
+            c.warn_low,
+            c.warn_high,
+            c.crit_low,
+            c.crit_high
+        FROM ChartsV2 c
+        WHERE c.chart_set_id = ?
+    """
 
     _FILTERED_CHARTS_CTE = """
         WITH filtered_charts AS (
@@ -204,6 +256,58 @@ class ChartRepository:
 
         return [self._to_chart_view(row) for row in rows]
 
+    def find_active_chart_set(self, criteria: ActiveChartsQueryCriteria) -> ActiveChartSetView:
+        """active chart set とその charts 一覧を返す。"""
+        con = _connect(MAIN_DB)
+        try:
+            active_row = con.execute(self._ACTIVE_CHART_SET_SQL).fetchone()
+            if active_row is None:
+                return ActiveChartSetView(
+                    active_chart_set_id=None,
+                    activated_at=None,
+                    charts=[],
+                )
+
+            active_chart_set_id = int(active_row[0])
+            activated_at = _to_utc_millis(str(active_row[1]))
+
+            sql = self._ACTIVE_CHARTS_SQL
+            where_clauses: list[str] = []
+            params: list[Any] = [active_chart_set_id]
+
+            self._append_filter_condition(
+                criteria.tool_id,
+                "c.tool_id = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                criteria.chamber_id,
+                "c.chamber_id = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                criteria.recipe_id,
+                "c.recipe_id = ?",
+                where_clauses,
+                params,
+            )
+
+            if where_clauses:
+                sql += " AND " + " AND ".join(where_clauses)
+
+            sql += " ORDER BY c.parameter, c.step_no, c.feature_type"
+            rows = con.execute(sql, tuple(params)).fetchall()
+        finally:
+            con.close()
+
+        return ActiveChartSetView(
+            active_chart_set_id=active_chart_set_id,
+            activated_at=activated_at,
+            charts=[self._to_active_chart_view(row) for row in rows],
+        )
+
     @staticmethod
     def _append_filter_condition(
         value: Any,
@@ -257,6 +361,31 @@ class ChartRepository:
             updated_at=_to_utc_millis(str(updated_at)),
             version=int(version),
             is_active=bool(is_active),
+        )
+
+    @staticmethod
+    def _to_active_chart_view(row: tuple[Any, ...]) -> ActiveChartView:
+        """DB 行を `ActiveChartView` へ変換する。"""
+        (
+            chart_pk,
+            parameter,
+            step_no,
+            feature_type,
+            warn_low,
+            warn_high,
+            crit_low,
+            crit_high,
+        ) = row
+
+        return ActiveChartView(
+            chart_id=f"CHART_{int(chart_pk)}",
+            parameter=str(parameter),
+            step_no=int(step_no),
+            feature_type=str(feature_type),
+            warning_lcl=_to_float_or_none(warn_low),
+            warning_ucl=_to_float_or_none(warn_high),
+            critical_lcl=_to_float_or_none(crit_low),
+            critical_ucl=_to_float_or_none(crit_high),
         )
 
 

--- a/tests/test_db_api_active_charts_endpoint.py
+++ b/tests/test_db_api_active_charts_endpoint.py
@@ -343,6 +343,89 @@ def test_get_active_charts_rejects_invalid_string_filters(
     assert_validation_error_envelope(res.json(), expected_loc_fragment=query_key)
 
 
+@pytest.mark.parametrize("query_key", ["tool_id", "chamber_id", "recipe_id"])
+def test_get_active_charts_rejects_empty_string_filters(
+    client: TestClient,
+    query_key: str,
+) -> None:
+    res = client.get("/charts/active", params={query_key: ""})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment=query_key)
+
+
+@pytest.mark.parametrize("query_key", ["tool_id", "chamber_id", "recipe_id"])
+def test_get_active_charts_accepts_filter_length_at_upper_bound(
+    client: TestClient,
+    query_key: str,
+) -> None:
+    max_length_value = "A" * 128
+    res = client.get("/charts/active", params={query_key: max_length_value})
+
+    assert res.status_code == 200
+    assert res.json()["ok"] is True
+
+
+@pytest.mark.parametrize("query_key", ["tool_id", "chamber_id", "recipe_id"])
+def test_get_active_charts_rejects_filter_length_above_upper_bound(
+    client: TestClient,
+    query_key: str,
+) -> None:
+    too_long_value = "A" * 129
+    res = client.get("/charts/active", params={query_key: too_long_value})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment=query_key)
+
+
+@pytest.mark.parametrize("query_key", ["tool_id", "chamber_id", "recipe_id"])
+def test_get_active_charts_accepts_pattern_boundary_characters(
+    client: TestClient,
+    query_key: str,
+) -> None:
+    boundary_pattern_value = "A_B.C/1:2-3"
+    res = client.get("/charts/active", params={query_key: boundary_pattern_value})
+
+    assert res.status_code == 200
+    assert res.json()["ok"] is True
+
+
+def test_get_active_charts_returns_503_on_timeout_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TimeoutError は一時障害として 503 へ分類されることを確認する。"""
+
+    def fail_active_query(*args, **kwargs):
+        _ = args, kwargs
+        raise TimeoutError("query timeout")
+
+    monkeypatch.setattr(db_app._chart_repository, "find_active_chart_set", fail_active_query)
+
+    res = client.get("/charts/active")
+
+    assert res.status_code == 503
+    assert res.json()["detail"] == "Service temporarily unavailable"
+
+
+def test_get_active_charts_returns_503_on_runner_runtime_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DBTaskRunner 起因 RuntimeError は一時障害として 503 へ分類される。"""
+
+    def fail_active_query(*args, **kwargs):
+        _ = args, kwargs
+        raise RuntimeError("DBTaskRunner has been stopped")
+
+    monkeypatch.setattr(db_app._chart_repository, "find_active_chart_set", fail_active_query)
+
+    res = client.get("/charts/active")
+
+    assert res.status_code == 503
+    assert res.json()["detail"] == "Service temporarily unavailable"
+
+
 def test_get_active_charts_returns_503_on_operational_error(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -395,3 +478,25 @@ def test_get_active_charts_returns_500_on_non_transient_operational_error(
 
     assert res.status_code == 500
     assert res.json()["detail"] == "Database operation failed"
+
+
+def test_get_active_charts_non_transient_error_does_not_retry_or_fallback(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """恒久障害では再試行/フォールバックせず、即時に 500 応答することを確認する。"""
+    call_count = 0
+
+    def fail_active_query(*args, **kwargs):
+        nonlocal call_count
+        _ = args, kwargs
+        call_count += 1
+        raise sqlite3.OperationalError("no such table: ChartsV2")
+
+    monkeypatch.setattr(db_app._chart_repository, "find_active_chart_set", fail_active_query)
+
+    res = client.get("/charts/active")
+
+    assert res.status_code == 500
+    assert res.json()["detail"] == "Database operation failed"
+    assert call_count == 1

--- a/tests/test_db_api_active_charts_endpoint.py
+++ b/tests/test_db_api_active_charts_endpoint.py
@@ -54,7 +54,7 @@ def _create_chart_set_with_charts(
 
 
 @pytest.fixture
-def seeded_active_chart_rows() -> Iterator[SeededActiveChartsContext]:
+def seeded_active_charts_context() -> Iterator[SeededActiveChartsContext]:
     _init_schema(MAIN_DB)
     con = sqlite3.connect(MAIN_DB.as_posix())
     context: SeededActiveChartsContext | None = None
@@ -188,9 +188,9 @@ def seeded_active_chart_rows() -> Iterator[SeededActiveChartsContext]:
 
 def test_get_active_charts_returns_active_chart_set_payload(
     client: TestClient,
-    seeded_active_chart_rows: SeededActiveChartsContext,
+    seeded_active_charts_context: SeededActiveChartsContext,
 ) -> None:
-    seeded = seeded_active_chart_rows
+    seeded = seeded_active_charts_context
 
     res = client.get("/charts/active")
 
@@ -225,8 +225,8 @@ def test_get_active_charts_returns_active_chart_set_payload(
         assert isinstance(chart["critical_lcl"], (int, float))
         assert isinstance(chart["critical_ucl"], (int, float))
 
-    tool_scoped = [chart for chart in charts if chart["parameter"] in {"dc_bias", "cl2_flow"}]
-    assert len(tool_scoped) == 2
+    param_scoped = [chart for chart in charts if chart["parameter"] in {"dc_bias", "cl2_flow"}]
+    assert len(param_scoped) == 2
     first = next(chart for chart in charts if chart["parameter"] == "dc_bias")
     assert re.fullmatch(r"CHART_\d+", first["chart_id"])
     assert first["step_no"] == 1
@@ -239,9 +239,9 @@ def test_get_active_charts_returns_active_chart_set_payload(
 
 def test_get_active_charts_filters_by_tool_chamber_and_recipe(
     client: TestClient,
-    seeded_active_chart_rows: SeededActiveChartsContext,
+    seeded_active_charts_context: SeededActiveChartsContext,
 ) -> None:
-    seeded = seeded_active_chart_rows
+    seeded = seeded_active_charts_context
 
     by_tool = client.get("/charts/active", params={"tool_id": seeded.active_tool_id})
     assert by_tool.status_code == 200
@@ -261,7 +261,7 @@ def test_get_active_charts_filters_by_tool_chamber_and_recipe(
 
 def test_get_active_charts_excludes_inactive_chart_set_rows(
     client: TestClient,
-    seeded_active_chart_rows: SeededActiveChartsContext,
+    seeded_active_charts_context: SeededActiveChartsContext,
 ) -> None:
     res = client.get("/charts/active", params={"chamber_id": "CH_ACTIVE"})
 

--- a/tests/test_db_api_active_charts_endpoint.py
+++ b/tests/test_db_api_active_charts_endpoint.py
@@ -298,3 +298,21 @@ def test_get_active_charts_returns_503_on_operational_error(
 
     assert res.status_code == 503
     assert res.json()["detail"] == "Database temporarily unavailable"
+
+
+def test_get_active_charts_returns_500_on_database_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB処理系の DatabaseError は 500 へ分類されることを確認する。"""
+
+    def fail_active_query(*args, **kwargs):
+        _ = args, kwargs
+        raise sqlite3.IntegrityError("constraint failed")
+
+    monkeypatch.setattr(db_app._chart_repository, "find_active_chart_set", fail_active_query)
+
+    res = client.get("/charts/active")
+
+    assert res.status_code == 500
+    assert res.json()["detail"] == "Database operation failed"

--- a/tests/test_db_api_active_charts_endpoint.py
+++ b/tests/test_db_api_active_charts_endpoint.py
@@ -29,6 +29,8 @@ class SeededActiveChartsContext:
     active_chart_set_id: int
     inactive_chart_set_id: int
     restore_active_set_id: int
+    restore_active_updated_at: str
+    restore_active_updated_by: str | None
     active_tool_id: str
     active_other_tool_id: str
     inactive_tool_id: str
@@ -60,11 +62,13 @@ def seeded_active_chart_rows() -> Iterator[SeededActiveChartsContext]:
         now = datetime.now(UTC).isoformat()
         suffix = uuid4().hex
         prev_active_row = con.execute(
-            "SELECT chart_set_id FROM ActiveChartSet WHERE id = 1"
+            "SELECT chart_set_id, updated_at, updated_by FROM ActiveChartSet WHERE id = 1"
         ).fetchone()
         if prev_active_row is None:
             raise RuntimeError("ActiveChartSet row with id=1 is required")
         restore_active_set_id = int(prev_active_row[0])
+        restore_active_updated_at = str(prev_active_row[1])
+        restore_active_updated_by = None if prev_active_row[2] is None else str(prev_active_row[2])
 
         active_tool_id = f"TOOL_ACTIVE_PRIMARY_{suffix}"
         active_other_tool_id = f"TOOL_ACTIVE_SECONDARY_{suffix}"
@@ -145,6 +149,8 @@ def seeded_active_chart_rows() -> Iterator[SeededActiveChartsContext]:
             active_chart_set_id=active_chart_set_id,
             inactive_chart_set_id=inactive_chart_set_id,
             restore_active_set_id=restore_active_set_id,
+            restore_active_updated_at=restore_active_updated_at,
+            restore_active_updated_by=restore_active_updated_by,
             active_tool_id=active_tool_id,
             active_other_tool_id=active_other_tool_id,
             inactive_tool_id=inactive_tool_id,
@@ -161,8 +167,8 @@ def seeded_active_chart_rows() -> Iterator[SeededActiveChartsContext]:
                     ") VALUES (1, ?, ?, ?)",
                     (
                         context.restore_active_set_id,
-                        datetime.now(UTC).isoformat(),
-                        "test-cleanup",
+                        context.restore_active_updated_at,
+                        context.restore_active_updated_by,
                     ),
                 )
                 for chart_set_id in (context.active_chart_set_id, context.inactive_chart_set_id):
@@ -197,6 +203,28 @@ def test_get_active_charts_returns_active_chart_set_payload(
 
     charts = data["charts"]
     assert len(charts) == 2
+    required_keys = {
+        "chart_id",
+        "parameter",
+        "step_no",
+        "feature_type",
+        "warning_lcl",
+        "warning_ucl",
+        "critical_lcl",
+        "critical_ucl",
+    }
+    for chart in charts:
+        assert required_keys.issubset(chart.keys())
+        assert isinstance(chart["chart_id"], str)
+        assert re.fullmatch(r"CHART_\d+", chart["chart_id"])
+        assert isinstance(chart["parameter"], str)
+        assert isinstance(chart["step_no"], int)
+        assert isinstance(chart["feature_type"], str)
+        assert isinstance(chart["warning_lcl"], (int, float))
+        assert isinstance(chart["warning_ucl"], (int, float))
+        assert isinstance(chart["critical_lcl"], (int, float))
+        assert isinstance(chart["critical_ucl"], (int, float))
+
     tool_scoped = [chart for chart in charts if chart["parameter"] in {"dc_bias", "cl2_flow"}]
     assert len(tool_scoped) == 2
     first = next(chart for chart in charts if chart["parameter"] == "dc_bias")

--- a/tests/test_db_api_active_charts_endpoint.py
+++ b/tests/test_db_api_active_charts_endpoint.py
@@ -259,6 +259,35 @@ def test_get_active_charts_filters_by_tool_chamber_and_recipe(
     assert by_combo_charts[0]["parameter"] == "dc_bias"
 
 
+def test_get_active_charts_supports_filter_combinations(
+    client: TestClient,
+    seeded_active_charts_context: SeededActiveChartsContext,
+) -> None:
+    seeded = seeded_active_charts_context
+
+    cases = [
+        ({"chamber_id": "CH_ACTIVE"}, {"dc_bias"}),
+        ({"recipe_id": "RECIPE_ACTIVE"}, {"dc_bias"}),
+        ({"tool_id": seeded.active_tool_id, "chamber_id": "CH_ACTIVE"}, {"dc_bias"}),
+        ({"tool_id": seeded.active_tool_id, "recipe_id": "RECIPE_ACTIVE"}, {"dc_bias"}),
+        (
+            {
+                "tool_id": seeded.active_tool_id,
+                "chamber_id": "CH_ACTIVE",
+                "recipe_id": "RECIPE_ACTIVE",
+            },
+            {"dc_bias"},
+        ),
+        ({"tool_id": seeded.active_tool_id, "chamber_id": "CH_OTHER"}, set()),
+    ]
+
+    for params, expected_parameters in cases:
+        res = client.get("/charts/active", params=params)
+        assert res.status_code == 200
+        charts = res.json()["data"]["charts"]
+        assert {chart["parameter"] for chart in charts} == expected_parameters
+
+
 def test_get_active_charts_excludes_inactive_chart_set_rows(
     client: TestClient,
     seeded_active_charts_context: SeededActiveChartsContext,
@@ -341,6 +370,24 @@ def test_get_active_charts_returns_500_on_database_error(
     def fail_active_query(*args, **kwargs):
         _ = args, kwargs
         raise sqlite3.IntegrityError("constraint failed")
+
+    monkeypatch.setattr(db_app._chart_repository, "find_active_chart_set", fail_active_query)
+
+    res = client.get("/charts/active")
+
+    assert res.status_code == 500
+    assert res.json()["detail"] == "Database operation failed"
+
+
+def test_get_active_charts_returns_500_on_non_transient_operational_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """恒久的な OperationalError は 500 へ分類されることを確認する。"""
+
+    def fail_active_query(*args, **kwargs):
+        _ = args, kwargs
+        raise sqlite3.OperationalError("no such table: ChartsV2")
 
     monkeypatch.setattr(db_app._chart_repository, "find_active_chart_set", fail_active_query)
 

--- a/tests/test_db_api_active_charts_endpoint.py
+++ b/tests/test_db_api_active_charts_endpoint.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 
+from portfolio_fdc.db_api import app as db_app
 from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
 from tests.test_utils import assert_validation_error_envelope
 
@@ -246,6 +247,10 @@ def test_get_active_charts_returns_empty_object_when_active_chart_set_missing(
     client: TestClient,
     seeded_active_chart_rows: SeededActiveChartsContext,
 ) -> None:
+    # Intentionally delete the shared ActiveChartSet(id=1) row for this test case.
+    # The seeded fixture restores it during teardown via INSERT OR REPLACE cleanup.
+    # If charts endpoint tests ever run in parallel against the same DB, this shared-state
+    # mutation could race with them; today the suite runs serially, so this remains acceptable.
     con = sqlite3.connect(MAIN_DB.as_posix())
     try:
         con.execute("DELETE FROM ActiveChartSet WHERE id = 1")
@@ -275,3 +280,21 @@ def test_get_active_charts_rejects_invalid_string_filters(
 
     assert res.status_code == 422
     assert_validation_error_envelope(res.json(), expected_loc_fragment=query_key)
+
+
+def test_get_active_charts_returns_503_on_operational_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB接続系の OperationalError は 503 へ分類されることを確認する。"""
+
+    def fail_active_query(*args, **kwargs):
+        _ = args, kwargs
+        raise sqlite3.OperationalError("unable to open database file")
+
+    monkeypatch.setattr(db_app._chart_repository, "find_active_chart_set", fail_active_query)
+
+    res = client.get("/charts/active")
+
+    assert res.status_code == 503
+    assert res.json()["detail"] == "Database temporarily unavailable"

--- a/tests/test_db_api_active_charts_endpoint.py
+++ b/tests/test_db_api_active_charts_endpoint.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
+from tests.test_utils import assert_validation_error_envelope
+
+_INSERT_CHART_SQL = """
+    INSERT INTO ChartsV2(
+        chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+        step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+        updated_at, updated_by, update_reason, update_source
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+@dataclass(frozen=True)
+class SeededActiveChartsContext:
+    active_chart_set_id: int
+    inactive_chart_set_id: int
+    restore_active_set_id: int
+    active_tool_id: str
+    active_other_tool_id: str
+    inactive_tool_id: str
+
+
+def _create_chart_set_with_charts(
+    con: sqlite3.Connection,
+    *,
+    set_name: str,
+    now: str,
+    chart_rows: list[tuple[object, ...]],
+) -> int:
+    con.execute(
+        "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
+        (set_name, "test", now, "test"),
+    )
+    chart_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+    for row in chart_rows:
+        con.execute(_INSERT_CHART_SQL, (chart_set_id, *row))
+    return chart_set_id
+
+
+@pytest.fixture
+def seeded_active_chart_rows() -> Iterator[SeededActiveChartsContext]:
+    _init_schema(MAIN_DB)
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    context: SeededActiveChartsContext | None = None
+    try:
+        now = datetime.now(UTC).isoformat()
+        suffix = uuid4().hex
+        prev_active_row = con.execute(
+            "SELECT chart_set_id FROM ActiveChartSet WHERE id = 1"
+        ).fetchone()
+        if prev_active_row is None:
+            raise RuntimeError("ActiveChartSet row with id=1 is required")
+        restore_active_set_id = int(prev_active_row[0])
+
+        active_tool_id = f"TOOL_ACTIVE_PRIMARY_{suffix}"
+        active_other_tool_id = f"TOOL_ACTIVE_SECONDARY_{suffix}"
+        inactive_tool_id = f"TOOL_INACTIVE_{suffix}"
+
+        active_chart_set_id = _create_chart_set_with_charts(
+            con,
+            set_name=f"active_set_{suffix}",
+            now=now,
+            chart_rows=[
+                (
+                    active_tool_id,
+                    "CH_ACTIVE",
+                    "RECIPE_ACTIVE",
+                    "dc_bias",
+                    1,
+                    "mean",
+                    1.4,
+                    2.6,
+                    1.2,
+                    2.8,
+                    "2026-04-14T09:00:00+09:00",
+                    "tester",
+                    "test-seed",
+                    "test",
+                ),
+                (
+                    active_other_tool_id,
+                    "CH_OTHER",
+                    "RECIPE_OTHER",
+                    "cl2_flow",
+                    2,
+                    "max",
+                    10.0,
+                    20.0,
+                    9.0,
+                    21.0,
+                    "2026-04-14T00:00:00Z",
+                    "tester",
+                    "test-seed",
+                    "test",
+                ),
+            ],
+        )
+        inactive_chart_set_id = _create_chart_set_with_charts(
+            con,
+            set_name=f"inactive_set_{suffix}",
+            now=now,
+            chart_rows=[
+                (
+                    inactive_tool_id,
+                    "CH_ACTIVE",
+                    "RECIPE_ACTIVE",
+                    "dc_bias",
+                    1,
+                    "mean",
+                    0.4,
+                    1.6,
+                    0.2,
+                    1.8,
+                    "2026-04-14T00:00:00Z",
+                    "tester",
+                    "test-seed",
+                    "test",
+                )
+            ],
+        )
+
+        con.execute(
+            "INSERT OR REPLACE INTO ActiveChartSet("
+            "id, chart_set_id, updated_at, updated_by"
+            ") VALUES (1, ?, ?, ?)",
+            (active_chart_set_id, "2026-04-14T09:00:00+09:00", "test"),
+        )
+        con.commit()
+
+        context = SeededActiveChartsContext(
+            active_chart_set_id=active_chart_set_id,
+            inactive_chart_set_id=inactive_chart_set_id,
+            restore_active_set_id=restore_active_set_id,
+            active_tool_id=active_tool_id,
+            active_other_tool_id=active_other_tool_id,
+            inactive_tool_id=inactive_tool_id,
+        )
+        yield context
+    finally:
+        con.close()
+        if context is not None:
+            cleanup = sqlite3.connect(MAIN_DB.as_posix())
+            try:
+                cleanup.execute(
+                    "INSERT OR REPLACE INTO ActiveChartSet("
+                    "id, chart_set_id, updated_at, updated_by"
+                    ") VALUES (1, ?, ?, ?)",
+                    (
+                        context.restore_active_set_id,
+                        datetime.now(UTC).isoformat(),
+                        "test-cleanup",
+                    ),
+                )
+                for chart_set_id in (context.active_chart_set_id, context.inactive_chart_set_id):
+                    cleanup.execute(
+                        "DELETE FROM ChartsHistory WHERE chart_set_id = ?",
+                        (chart_set_id,),
+                    )
+                    cleanup.execute("DELETE FROM ChartsV2 WHERE chart_set_id = ?", (chart_set_id,))
+                    cleanup.execute(
+                        "DELETE FROM ChartSet WHERE chart_set_id = ? AND chart_set_id != ?",
+                        (chart_set_id, context.restore_active_set_id),
+                    )
+                cleanup.commit()
+            finally:
+                cleanup.close()
+
+
+def test_get_active_charts_returns_active_chart_set_payload(
+    client: TestClient,
+    seeded_active_chart_rows: SeededActiveChartsContext,
+) -> None:
+    seeded = seeded_active_chart_rows
+
+    res = client.get("/charts/active")
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["active_chart_set_id"] == seeded.active_chart_set_id
+    assert data["activated_at"] == "2026-04-14T00:00:00.000Z"
+
+    charts = data["charts"]
+    assert len(charts) == 2
+    tool_scoped = [chart for chart in charts if chart["parameter"] in {"dc_bias", "cl2_flow"}]
+    assert len(tool_scoped) == 2
+    first = next(chart for chart in charts if chart["parameter"] == "dc_bias")
+    assert re.fullmatch(r"CHART_\d+", first["chart_id"])
+    assert first["step_no"] == 1
+    assert first["feature_type"] == "mean"
+    assert first["warning_lcl"] == 1.4
+    assert first["warning_ucl"] == 2.6
+    assert first["critical_lcl"] == 1.2
+    assert first["critical_ucl"] == 2.8
+
+
+def test_get_active_charts_filters_by_tool_chamber_and_recipe(
+    client: TestClient,
+    seeded_active_chart_rows: SeededActiveChartsContext,
+) -> None:
+    seeded = seeded_active_chart_rows
+
+    by_tool = client.get("/charts/active", params={"tool_id": seeded.active_tool_id})
+    assert by_tool.status_code == 200
+    by_tool_charts = by_tool.json()["data"]["charts"]
+    assert len(by_tool_charts) == 1
+    assert by_tool_charts[0]["parameter"] == "dc_bias"
+
+    by_combo = client.get(
+        "/charts/active",
+        params={"chamber_id": "CH_ACTIVE", "recipe_id": "RECIPE_ACTIVE"},
+    )
+    assert by_combo.status_code == 200
+    by_combo_charts = by_combo.json()["data"]["charts"]
+    assert len(by_combo_charts) == 1
+    assert by_combo_charts[0]["parameter"] == "dc_bias"
+
+
+def test_get_active_charts_excludes_inactive_chart_set_rows(
+    client: TestClient,
+    seeded_active_chart_rows: SeededActiveChartsContext,
+) -> None:
+    res = client.get("/charts/active", params={"chamber_id": "CH_ACTIVE"})
+
+    assert res.status_code == 200
+    charts = res.json()["data"]["charts"]
+    assert len(charts) == 1
+    assert charts[0]["critical_lcl"] == 1.2
+    assert charts[0]["critical_ucl"] == 2.8
+
+
+def test_get_active_charts_returns_empty_object_when_active_chart_set_missing(
+    client: TestClient,
+    seeded_active_chart_rows: SeededActiveChartsContext,
+) -> None:
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        con.execute("DELETE FROM ActiveChartSet WHERE id = 1")
+        con.commit()
+    finally:
+        con.close()
+
+    res = client.get("/charts/active")
+
+    assert res.status_code == 200
+    assert res.json() == {
+        "ok": True,
+        "data": {
+            "active_chart_set_id": None,
+            "activated_at": None,
+            "charts": [],
+        },
+    }
+
+
+@pytest.mark.parametrize("query_key", ["tool_id", "chamber_id", "recipe_id"])
+def test_get_active_charts_rejects_invalid_string_filters(
+    client: TestClient,
+    query_key: str,
+) -> None:
+    res = client.get("/charts/active", params={query_key: "INVALID VALUE"})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment=query_key)

--- a/tests/test_db_api_active_charts_endpoint.py
+++ b/tests/test_db_api_active_charts_endpoint.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from portfolio_fdc.db_api import app as db_app
+from portfolio_fdc.db_api.chart_repository import ActiveChartSetView
 from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
 from tests.test_utils import assert_validation_error_envelope
 
@@ -245,18 +246,21 @@ def test_get_active_charts_excludes_inactive_chart_set_rows(
 
 def test_get_active_charts_returns_empty_object_when_active_chart_set_missing(
     client: TestClient,
-    seeded_active_chart_rows: SeededActiveChartsContext,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Intentionally delete the shared ActiveChartSet(id=1) row for this test case.
-    # The seeded fixture restores it during teardown via INSERT OR REPLACE cleanup.
-    # If charts endpoint tests ever run in parallel against the same DB, this shared-state
-    # mutation could race with them; today the suite runs serially, so this remains acceptable.
-    con = sqlite3.connect(MAIN_DB.as_posix())
-    try:
-        con.execute("DELETE FROM ActiveChartSet WHERE id = 1")
-        con.commit()
-    finally:
-        con.close()
+    def return_missing_active_chart_set(*args, **kwargs):
+        _ = args, kwargs
+        return ActiveChartSetView(
+            active_chart_set_id=None,
+            activated_at=None,
+            charts=[],
+        )
+
+    monkeypatch.setattr(
+        db_app._chart_repository,
+        "find_active_chart_set",
+        return_missing_active_chart_set,
+    )
 
     res = client.get("/charts/active")
 

--- a/tests/test_db_api_integration.py
+++ b/tests/test_db_api_integration.py
@@ -442,6 +442,27 @@ def test_db_api_legacy_delete_preserves_migration_headers_on_error(
     )
 
 
+def test_db_api_process_write_returns_503_on_runner_timeout(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DBTaskRunner タイムアウトは一時障害として 503 へ分類する。"""
+
+    class TimeoutRunner:
+        def submit(self, *args, **kwargs):
+            _ = args, kwargs
+            raise TimeoutError("task timed out: write")
+
+    monkeypatch.setattr(db_app, "_get_or_create_runner", lambda _app: TimeoutRunner())
+
+    process_id = f"runner_timeout_{uuid4().hex}"
+    payload = build_process_payload(process_id)
+    res = client.post("/processes", json=payload)
+
+    assert res.status_code == 503
+    assert res.json()["detail"] == "Service temporarily unavailable"
+
+
 def test_db_api_delete_by_path_accepts_process_id_with_slash(client: TestClient) -> None:
     """`/processes/{process_id:path}` が `/` を含む process_id を削除できることを確認する。"""
     process_id = f"tool/A/{uuid4().hex}"

--- a/tests/test_db_api_integration.py
+++ b/tests/test_db_api_integration.py
@@ -388,7 +388,7 @@ def test_db_api_aggregate_write_returns_500_on_runner_error(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`/aggregate/write` 実行時例外が HTTP 500 と detail に変換されることを確認する。"""
+    """`/aggregate/write` 実行時例外が安全な HTTP 500 detail に変換されることを確認する。"""
     process_id = f"agg_err_{uuid4().hex}"
 
     def fail_atomic(*args, **kwargs):
@@ -414,7 +414,7 @@ def test_db_api_aggregate_write_returns_500_on_runner_error(
     res = client.post("/aggregate/write", json=payload)
 
     assert res.status_code == 500
-    assert "forced aggregate write failure" in res.json()["detail"]
+    assert res.json()["detail"] == "Internal server error"
 
 
 def test_db_api_legacy_delete_preserves_migration_headers_on_error(
@@ -434,7 +434,7 @@ def test_db_api_legacy_delete_preserves_migration_headers_on_error(
     res = client.request("DELETE", "/processes", json={"process_id": process_id})
 
     assert res.status_code == 500
-    assert "forced delete failure" in res.json()["detail"]
+    assert res.json()["detail"] == "Internal server error"
     assert_legacy_migration_headers(
         res.headers,
         process_id,


### PR DESCRIPTION
## Summary
- implement GET /charts/active using repository + DTO pattern aligned with GET /charts
- return active_chart_set_id, activated_at, and filtered active charts from ActiveChartSet + ChartsV2
- add contract tests for success payload, filters, missing ActiveChartSet, and 422 validation
- mark /charts/active as implemented in endpoint catalog

## Test
- python -m pytest tests/test_db_api_active_charts_endpoint.py tests/test_db_api_charts_endpoint.py tests/test_db_api_integration.py -q
- python.exe -m ruff check src/portfolio_fdc/db_api/app.py src/portfolio_fdc/db_api/chart_repository.py tests/test_db_api_active_charts_endpoint.py

Closes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 実装内容
  - GET /charts/active を実装。ActiveChartSet と ChartsV2 を組み合わせ、レスポンスに active_chart_set_id、activated_at（UTC ISO8601 ミリ秒精度）、charts 配列を返却。tool_id / chamber_id / recipe_id のオプションフィルタに対応。
  - ChartRepository に ActiveChartsQueryCriteria / ActiveChartView / ActiveChartSetView DTO を追加。find_active_chart_set(criteria) を実装し、動的フィルタ構築、ordering（parameter, step_no, feature_type）、行→DTO マッピング（_to_active_chart_view）を行う。SQL 定数（_ACTIVE_CHART_SET_SQL/_ACTIVE_CHARTS_SQL）を導入。
  - app.py にエラーハンドリング集約ヘルパー _raise_api_error と _is_runner_unavailable_error を追加し、複数エンドポイントの例外処理を統一（Timeout/ランナー系→503、sqlite3.OperationalError→503、sqlite3.DatabaseError→500、その他→500）。既存の書き込み・削除系エンドポイントにも適用。
  - docs/db-api-endpoints.md で /charts/active のステータスを「implemented」に更新。

- テスト
  - tests/test_db_api_active_charts_endpoint.py を追加：正常系（ペイロード構造・型・timestamp 形式含む）、tool_id フィルタ、chamber_id+recipe_id フィルタ、非アクティブセット除外、ActiveChartSet 欠如時の空応答（None/[]）、クエリ文字列の 422 バリデーション、sqlite3.OperationalError→503、sqlite3.IntegrityError→500 を検証。
  - 既存統合テストを修正：内部エラー詳細の期待値を固定文 ("Internal server error" 等) に変更し、POST /processes のランナー TimeoutError に対する 503 応答の統合テストを追加。
  - Ruff チェック対象に該当ファイルを追加・更新。

- リスク・懸念点（短く）
  - フィルタ網羅性：tool_id/chamber_id/recipe_id の複合パターンがすべて網羅されているか不明（現行テストは主要パターンを含むが包括的ではない）。
  - エラー情報の可観測性低下：内部エラー詳細を安全な定型文に統一したため、本番障害時の原因追跡が難しくなる可能性がある。
  - エラー分類誤判定：sqlite3.OperationalError を一律 503 扱いにすることで、永続的な DB 故障を「一時サービス停止」と誤認する恐れがある。

- テストギャップ（短く）
  - /charts/active に対するランナー/DBTaskRunner 系の TimeoutError や runner 特有エラーのマッピングを明示的に検証するテストが不足。
  - フィルタの全組合せや境界値ケース（長さ・パターン境界）の網羅的回帰テストが不足している可能性。
  - OperationalError/DatabaseError を想定した長期的・恒久的故障シナリオに近い追加テスト（リトライ/フォールバック動作の検証）が望ましい。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->