### PR TITLE
feat(db_api): implement GET /charts/history

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ dashboard judge  (future: exporter)
 
 ## セットアップ
 
+**前提: SQLite >= 3.38**
+
+`db_api` の `chart_repository.py` は `datetime(h.changed_at)` 比較を使用しており、ISO 8601 のパース動作が
+SQLite 3.38（2022-02-22 リリース）で安定化されています。
+`_normalize_query_datetime`（`db_api/app.py`）がクエリ日時を UTC ISO 8601 に正規化してから
+この比較に渡しますが、SQLite < 3.38 では期間フィルタが誤動作する可能性があります。
+Python 3.11 に同梱される SQLite は通常 3.39 以上ですが、自前でビルドした環境では
+`python -c "import sqlite3; print(sqlite3.sqlite_version)"` で確認してください。
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -24,7 +24,7 @@
 | `POST`   | `/aggregate/write`                                  | ingest write   | implemented | ingest          | source: `db_api/app.py` | Process/StepWindow/Parameter を原子的に保存  |
 | `GET`    | `/charts`                                           | dashboard read | implemented | dashboard/judge | source: `db_api/app.py` | chart 定義一覧                               |
 | `GET`    | `/charts/active`                                    | dashboard read | implemented | dashboard/judge | source: `db_api/app.py` | active chart set と閾値                      |
-| `GET`    | `/charts/history`                                   | dashboard read | planned     | dashboard/ops   | Issue #98               | chart 変更履歴                               |
+| `GET`    | `/charts/history`                                   | dashboard read | implemented | dashboard/ops   | source: `db_api/app.py` | chart 変更履歴                               |
 | `GET`    | `/judge/results`                                    | dashboard read | planned     | dashboard       | Issue #98               | 判定結果一覧                                 |
 | `GET`    | `/judge/results/{result_id}`                        | dashboard read | planned     | dashboard       | Issue #98               | 判定詳細（トレース情報含む）                 |
 | `POST`   | `/governance/change-requests`                       | governance     | planned     | dashboard/ops   | Issue #102              | 通常変更の申請作成                           |

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -44,6 +44,8 @@
 - Phase 1 の最小 read 契約は `docs/db-api-minimum-contract.md` を実装基準とする。
 - `GET /charts` の文字列クエリ（`tool_id` 等）は `^[A-Za-z0-9_./:-]+$`（1..128 文字）を許可形式とする。
 - API の timestamp 正規化は UTC ISO 8601 ミリ秒固定で、マイクロ秒以下は切り捨てとする。
+- `GET /charts/history` の `from_ts` / `to_ts` は timezone-aware datetime のみ受け付ける。
+- `GET /charts/history` の `chart_id` フィルタは現在 `ChartsV2` に存在する chart にのみ有効で、削除済み chart 履歴の `chart_id` 解決は行わない。
 
 ## Read-only Endpoint Access Pattern
 

--- a/docs/db-api-minimum-contract.md
+++ b/docs/db-api-minimum-contract.md
@@ -174,6 +174,12 @@ dashboard read-only baseline と judge 最小実装に必要な API 契約を、
 - `limit` (default: 100, max: 500)
 - `offset` (default: 0)
 
+クエリ検証ルール:
+
+- `from_ts` / `to_ts` は timezone-aware な ISO 8601 datetime のみ受け付ける
+- `chart_id` フィルタは現在 `ChartsV2` に存在する chart のみ解決対象とする
+- 削除済み chart の履歴は `chart_id` では取得不可で、`chart_set_id` など別条件で参照する
+
 成功レスポンス例:
 
 ```json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 description = "Portfolio-friendly FDC toolkit (logger stream → segmentation → features → SPC dashboard)"
 readme = "README.md"
 requires-python = ">=3.11"
+# Runtime requirement: SQLite >= 3.38 is required.
+# chart_repository.py uses datetime(h.changed_at) comparisons that rely on
+# SQLite's ISO 8601 datetime parsing, which was stabilised in 3.38 (2022-02-22).
+# _normalize_query_datetime (db_api/app.py) normalises all query timestamps to
+# UTC ISO 8601 before they reach these comparisons; SQLite < 3.38 may parse
+# those strings incorrectly and silently produce wrong filter results.
 dependencies = [
   "fastapi>=0.115",
   "numpy>=2.4.2",

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -29,7 +29,12 @@ from .aggregate_repository import (
     write_process,
     write_step_windows_bulk,
 )
-from .chart_repository import ActiveChartsQueryCriteria, ChartRepository, ChartsQueryCriteria
+from .chart_repository import (
+    ActiveChartsQueryCriteria,
+    ChartRepository,
+    ChartsHistoryQueryCriteria,
+    ChartsQueryCriteria,
+)
 from .db import MAIN_DB, TEMP_DB, _init_schema
 from .schemas import (
     AggregateWriteIn,
@@ -37,6 +42,7 @@ from .schemas import (
     ProcessDeleteIn,
     ProcessInfoIn,
     StepWindowIn,
+    validate_timestamp_range,
 )
 from .task_runner import DBTaskRunner
 
@@ -46,6 +52,7 @@ LEGACY_DELETE_PROCESSES_SUNSET_AT = datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC
 LEGACY_DELETE_PROCESSES_SUNSET = format_datetime(LEGACY_DELETE_PROCESSES_SUNSET_AT, usegmt=True)
 CHARTS_FILTER_PATTERN = r"^[A-Za-z0-9_./:-]+$"
 CHARTS_FILTER_MAX_LENGTH = 128
+CHART_ID_PATTERN = r"^CHART_[0-9]+$"
 
 
 def _legacy_delete_headers(process_id: str | None) -> dict[str, str]:
@@ -308,6 +315,60 @@ def get_active_charts(
         return {"ok": True, "data": asdict(data)}
     except Exception as e:
         _raise_api_error(operation="GET /charts/active", error=e)
+
+
+def _normalize_query_datetime(raw: datetime | None) -> str | None:
+    """履歴検索用の datetime クエリを SQLite 比較用 ISO 文字列へ変換する。"""
+    if raw is None:
+        return None
+    if raw.tzinfo is None:
+        return raw.replace(tzinfo=UTC).isoformat()
+    return raw.astimezone(UTC).isoformat()
+
+
+@app.get("/charts/history")
+def get_charts_history(
+    chart_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=64,
+        pattern=CHART_ID_PATTERN,
+    ),
+    chart_set_id: int | None = Query(default=None, ge=1),
+    change_source: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=CHARTS_FILTER_MAX_LENGTH,
+        pattern=CHARTS_FILTER_PATTERN,
+    ),
+    from_ts: datetime | None = None,
+    to_ts: datetime | None = None,
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    """Chart 閾値変更履歴を返す。"""
+    if from_ts is not None and to_ts is not None:
+        try:
+            validate_timestamp_range(from_ts, to_ts)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    chart_pk = None if chart_id is None else int(chart_id.split("_", maxsplit=1)[1])
+    criteria = ChartsHistoryQueryCriteria(
+        chart_pk=chart_pk,
+        chart_set_id=chart_set_id,
+        change_source=change_source,
+        from_ts=_normalize_query_datetime(from_ts),
+        to_ts=_normalize_query_datetime(to_ts),
+        limit=limit,
+        offset=offset,
+    )
+
+    try:
+        rows = _chart_repository.find_chart_history(criteria)
+        return {"ok": True, "data": [asdict(row) for row in rows]}
+    except Exception as e:
+        _raise_api_error(operation="GET /charts/history", error=e)
 
 
 @app.post("/processes")

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -358,10 +358,13 @@ def get_charts_history(
         try:
             numeric_part = chart_id.split("_", maxsplit=1)[1]
             chart_pk = int(numeric_part)
+            # Validate int64 range (signed 64-bit: -(2**63) to 2**63-1)
+            if not (-(2**63) <= chart_pk <= 2**63 - 1):
+                raise ValueError(f"chart_pk {chart_pk} out of int64 range")
         except (ValueError, OverflowError, IndexError) as exc:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid chart_id format: {str(exc)}",
+                detail=f"Invalid chart_id: {str(exc)}",
             ) from exc
     criteria = ChartsHistoryQueryCriteria(
         chart_pk=chart_pk,

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -336,6 +336,8 @@ def _parse_chart_pk(chart_id: str | None) -> int | None:
         if not numeric_part.isdigit():
             raise ValueError("chart_id numeric part must contain only digits")
         chart_pk = int(numeric_part)
+        if chart_pk < 1:
+            raise ValueError("chart_id must be greater than or equal to 1")
         if not (-(2**63) <= chart_pk <= 2**63 - 1):
             raise ValueError("chart_id out of int64 range")
         return chart_pk
@@ -358,8 +360,8 @@ def get_charts_history(
         max_length=CHARTS_FILTER_MAX_LENGTH,
         pattern=CHARTS_FILTER_PATTERN,
     ),
-    from_ts: datetime | None = None,
-    to_ts: datetime | None = None,
+    from_ts: Annotated[datetime | None, Query()] = None,
+    to_ts: Annotated[datetime | None, Query()] = None,
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ):

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -333,6 +333,8 @@ def _parse_chart_pk(chart_id: str | None) -> int | None:
 
     try:
         numeric_part = chart_id.split("_", maxsplit=1)[1]
+        if not numeric_part.isdigit():
+            raise ValueError("chart_id numeric part must contain only digits")
         chart_pk = int(numeric_part)
         if not (-(2**63) <= chart_pk <= 2**63 - 1):
             raise ValueError("chart_id out of int64 range")

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -364,7 +364,7 @@ def get_charts_history(
         except (ValueError, OverflowError, IndexError) as exc:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid chart_id: {str(exc)}",
+                detail="Invalid chart_id",
             ) from exc
     criteria = ChartsHistoryQueryCriteria(
         chart_pk=chart_pk,

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -326,6 +326,21 @@ def _normalize_query_datetime(raw: datetime | None) -> str | None:
     return raw.astimezone(UTC).isoformat()
 
 
+def _parse_chart_pk(chart_id: str | None) -> int | None:
+    """`CHART_<id>` 形式の chart_id を int PK へ変換する。"""
+    if chart_id is None:
+        return None
+
+    try:
+        numeric_part = chart_id.split("_", maxsplit=1)[1]
+        chart_pk = int(numeric_part)
+        if not (-(2**63) <= chart_pk <= 2**63 - 1):
+            raise ValueError("chart_id out of int64 range")
+        return chart_pk
+    except (ValueError, OverflowError, IndexError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid chart_id") from exc
+
+
 @app.get("/charts/history")
 def get_charts_history(
     chart_id: str | None = Query(
@@ -353,19 +368,7 @@ def get_charts_history(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    chart_pk = None
-    if chart_id is not None:
-        try:
-            numeric_part = chart_id.split("_", maxsplit=1)[1]
-            chart_pk = int(numeric_part)
-            # Validate int64 range (signed 64-bit: -(2**63) to 2**63-1)
-            if not (-(2**63) <= chart_pk <= 2**63 - 1):
-                raise ValueError(f"chart_pk {chart_pk} out of int64 range")
-        except (ValueError, OverflowError, IndexError) as exc:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid chart_id",
-            ) from exc
+    chart_pk = _parse_chart_pk(chart_id)
     criteria = ChartsHistoryQueryCriteria(
         chart_pk=chart_pk,
         chart_set_id=chart_set_id,

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -353,7 +353,16 @@ def get_charts_history(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    chart_pk = None if chart_id is None else int(chart_id.split("_", maxsplit=1)[1])
+    chart_pk = None
+    if chart_id is not None:
+        try:
+            numeric_part = chart_id.split("_", maxsplit=1)[1]
+            chart_pk = int(numeric_part)
+        except (ValueError, OverflowError, IndexError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid chart_id format: {str(exc)}",
+            ) from exc
     criteria = ChartsHistoryQueryCriteria(
         chart_pk=chart_pk,
         chart_set_id=chart_set_id,

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -322,7 +322,10 @@ def _normalize_query_datetime(raw: datetime | None) -> str | None:
     if raw is None:
         return None
     if raw.tzinfo is None:
-        return raw.replace(tzinfo=UTC).isoformat()
+        raise HTTPException(
+            status_code=400,
+            detail="from_ts and to_ts must be timezone-aware datetimes",
+        )
     return raw.astimezone(UTC).isoformat()
 
 

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -43,19 +42,6 @@ class ChartsHistoryQueryCriteria:
     to_ts: str | None = None
     limit: int = 100
     offset: int = 0
-
-
-@dataclass(frozen=True)
-class ChartHistoryFilterKey:
-    """ChartsHistory を一意に絞り込む複合キー。"""
-
-    chart_set_id: int
-    tool_id: str
-    chamber_id: str
-    recipe_id: str
-    parameter: str
-    step_no: int
-    feature_type: str
 
 
 @dataclass(frozen=True)
@@ -175,19 +161,6 @@ class ChartRepository:
             h.changed_by,
             h.changed_at
         FROM ChartsHistory h
-    """
-
-    _CHART_HISTORY_FILTER_KEY_SQL = """
-        SELECT
-            chart_set_id,
-            tool_id,
-            chamber_id,
-            recipe_id,
-            parameter,
-            step_no,
-            feature_type
-        FROM ChartsV2
-        WHERE id = ?
     """
 
     _FILTERED_CHARTS_CTE = """
@@ -398,122 +371,51 @@ class ChartRepository:
         sql = self._CHARTS_HISTORY_SQL
         where_clauses: list[str] = []
         params: list[Any] = []
+        self._append_filter_condition(
+            criteria.chart_pk,
+            "h.chart_id = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.chart_set_id,
+            "h.chart_set_id = ?",
+            where_clauses,
+            params,
+        )
+
+        self._append_filter_condition(
+            criteria.change_source,
+            "h.change_source = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.from_ts,
+            "datetime(h.changed_at) >= datetime(?)",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.to_ts,
+            "datetime(h.changed_at) <= datetime(?)",
+            where_clauses,
+            params,
+        )
+
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+
+        sql += " ORDER BY datetime(h.changed_at) DESC, h.id DESC LIMIT ? OFFSET ?"
+        params.extend([criteria.limit, criteria.offset])
+
         con = _connect(MAIN_DB)
-
         try:
-            chart_filter_key = self._find_chart_history_filter_key(con, criteria.chart_pk)
-            if criteria.chart_pk is not None and chart_filter_key is None:
-                return []
-
-            if chart_filter_key is not None:
-                self._append_filter_condition(
-                    chart_filter_key.chart_set_id,
-                    "h.chart_set_id = ?",
-                    where_clauses,
-                    params,
-                )
-                self._append_filter_condition(
-                    chart_filter_key.tool_id,
-                    "h.tool_id = ?",
-                    where_clauses,
-                    params,
-                )
-                self._append_filter_condition(
-                    chart_filter_key.chamber_id,
-                    "h.chamber_id = ?",
-                    where_clauses,
-                    params,
-                )
-                self._append_filter_condition(
-                    chart_filter_key.recipe_id,
-                    "h.recipe_id = ?",
-                    where_clauses,
-                    params,
-                )
-                self._append_filter_condition(
-                    chart_filter_key.parameter,
-                    "h.parameter = ?",
-                    where_clauses,
-                    params,
-                )
-                self._append_filter_condition(
-                    chart_filter_key.step_no,
-                    "h.step_no = ?",
-                    where_clauses,
-                    params,
-                )
-                self._append_filter_condition(
-                    chart_filter_key.feature_type,
-                    "h.feature_type = ?",
-                    where_clauses,
-                    params,
-                )
-
-            should_add_chart_set_id = criteria.chart_set_id is not None and (
-                chart_filter_key is None or criteria.chart_set_id != chart_filter_key.chart_set_id
-            )
-            if should_add_chart_set_id:
-                self._append_filter_condition(
-                    criteria.chart_set_id,
-                    "h.chart_set_id = ?",
-                    where_clauses,
-                    params,
-                )
-
-            self._append_filter_condition(
-                criteria.change_source,
-                "h.change_source = ?",
-                where_clauses,
-                params,
-            )
-            self._append_filter_condition(
-                criteria.from_ts,
-                "datetime(h.changed_at) >= datetime(?)",
-                where_clauses,
-                params,
-            )
-            self._append_filter_condition(
-                criteria.to_ts,
-                "datetime(h.changed_at) <= datetime(?)",
-                where_clauses,
-                params,
-            )
-
-            if where_clauses:
-                sql += " WHERE " + " AND ".join(where_clauses)
-
-            sql += " ORDER BY datetime(h.changed_at) DESC, h.id DESC LIMIT ? OFFSET ?"
-            params.extend([criteria.limit, criteria.offset])
-
             rows = con.execute(sql, tuple(params)).fetchall()
         finally:
             con.close()
 
         return [self._to_chart_history_view(row) for row in rows]
-
-    def _find_chart_history_filter_key(
-        self,
-        con: sqlite3.Connection,
-        chart_pk: int | None,
-    ) -> ChartHistoryFilterKey | None:
-        """chart_id から現在の ChartsV2 上の複合キーを解決する。"""
-        if chart_pk is None:
-            return None
-
-        row = con.execute(self._CHART_HISTORY_FILTER_KEY_SQL, (chart_pk,)).fetchone()
-
-        if row is None:
-            return None
-
-        return ChartHistoryFilterKey(
-            chart_set_id=int(row[0]),
-            tool_id=str(row[1]),
-            chamber_id=str(row[2]),
-            recipe_id=str(row[3]),
-            parameter=str(row[4]),
-            step_no=int(row[5]),
-            feature_type=str(row[6]),
-        )
 
     @staticmethod
     def _append_filter_condition(

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -32,6 +32,19 @@ class ActiveChartsQueryCriteria:
 
 
 @dataclass(frozen=True)
+class ChartsHistoryQueryCriteria:
+    """`GET /charts/history` の検索条件を保持する DTO。"""
+
+    chart_pk: int | None = None
+    chart_set_id: int | None = None
+    change_source: str | None = None
+    from_ts: str | None = None
+    to_ts: str | None = None
+    limit: int = 100
+    offset: int = 0
+
+
+@dataclass(frozen=True)
 class ChartView:
     """`GET /charts` レスポンス 1 件分の DTO。
 
@@ -82,6 +95,31 @@ class ActiveChartSetView:
     charts: list[ActiveChartView]
 
 
+@dataclass(frozen=True)
+class ChartThresholdSnapshot:
+    """履歴上のしきい値スナップショット。"""
+
+    warning_lcl: float | None
+    warning_ucl: float | None
+    critical_lcl: float | None
+    critical_ucl: float | None
+
+
+@dataclass(frozen=True)
+class ChartHistoryView:
+    """`GET /charts/history` レスポンス 1 件分の DTO。"""
+
+    history_id: str
+    chart_id: str | None
+    chart_set_id: int
+    change_source: str | None
+    change_reason: str | None
+    before: ChartThresholdSnapshot
+    after: ChartThresholdSnapshot
+    changed_by: str | None
+    changed_at: str
+
+
 class ChartRepository:
     """ChartsV2 から chart 一覧を取得するリポジトリ。"""
 
@@ -103,6 +141,34 @@ class ChartRepository:
             c.crit_high
         FROM ChartsV2 c
         WHERE c.chart_set_id = ?
+    """
+
+    _CHARTS_HISTORY_SQL = """
+        SELECT
+            h.id,
+            h.chart_set_id,
+            c.id,
+            h.change_source,
+            h.change_reason,
+            h.old_warn_low,
+            h.old_warn_high,
+            h.old_crit_low,
+            h.old_crit_high,
+            h.new_warn_low,
+            h.new_warn_high,
+            h.new_crit_low,
+            h.new_crit_high,
+            h.changed_by,
+            h.changed_at
+        FROM ChartsHistory h
+        LEFT JOIN ChartsV2 c
+            ON c.chart_set_id = h.chart_set_id
+           AND c.tool_id = h.tool_id
+           AND c.chamber_id = h.chamber_id
+           AND c.recipe_id = h.recipe_id
+           AND c.parameter = h.parameter
+           AND c.step_no = h.step_no
+           AND c.feature_type = h.feature_type
     """
 
     _FILTERED_CHARTS_CTE = """
@@ -308,6 +374,57 @@ class ChartRepository:
             charts=[self._to_active_chart_view(row) for row in rows],
         )
 
+    def find_chart_history(self, criteria: ChartsHistoryQueryCriteria) -> list[ChartHistoryView]:
+        """条件に一致する chart 閾値変更履歴を返す。"""
+        sql = self._CHARTS_HISTORY_SQL
+        where_clauses: list[str] = []
+        params: list[Any] = []
+
+        self._append_filter_condition(
+            criteria.chart_pk,
+            "c.id = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.chart_set_id,
+            "h.chart_set_id = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.change_source,
+            "h.change_source = ?",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.from_ts,
+            "datetime(h.changed_at) >= datetime(?)",
+            where_clauses,
+            params,
+        )
+        self._append_filter_condition(
+            criteria.to_ts,
+            "datetime(h.changed_at) <= datetime(?)",
+            where_clauses,
+            params,
+        )
+
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+
+        sql += " ORDER BY datetime(h.changed_at) DESC, h.id DESC LIMIT ? OFFSET ?"
+        params.extend([criteria.limit, criteria.offset])
+
+        con = _connect(MAIN_DB)
+        try:
+            rows = con.execute(sql, tuple(params)).fetchall()
+        finally:
+            con.close()
+
+        return [self._to_chart_history_view(row) for row in rows]
+
     @staticmethod
     def _append_filter_condition(
         value: Any,
@@ -386,6 +503,49 @@ class ChartRepository:
             warning_ucl=_to_float_or_none(warn_high),
             critical_lcl=_to_float_or_none(crit_low),
             critical_ucl=_to_float_or_none(crit_high),
+        )
+
+    @staticmethod
+    def _to_chart_history_view(row: tuple[Any, ...]) -> ChartHistoryView:
+        """DB 行を `ChartHistoryView` へ変換する。"""
+        (
+            history_pk,
+            chart_set_id,
+            chart_pk,
+            change_source,
+            change_reason,
+            old_warn_low,
+            old_warn_high,
+            old_crit_low,
+            old_crit_high,
+            new_warn_low,
+            new_warn_high,
+            new_crit_low,
+            new_crit_high,
+            changed_by,
+            changed_at,
+        ) = row
+
+        return ChartHistoryView(
+            history_id=f"HIS_{int(history_pk)}",
+            chart_id=None if chart_pk is None else f"CHART_{int(chart_pk)}",
+            chart_set_id=int(chart_set_id),
+            change_source=None if change_source is None else str(change_source),
+            change_reason=None if change_reason is None else str(change_reason),
+            before=ChartThresholdSnapshot(
+                warning_lcl=_to_float_or_none(old_warn_low),
+                warning_ucl=_to_float_or_none(old_warn_high),
+                critical_lcl=_to_float_or_none(old_crit_low),
+                critical_ucl=_to_float_or_none(old_crit_high),
+            ),
+            after=ChartThresholdSnapshot(
+                warning_lcl=_to_float_or_none(new_warn_low),
+                warning_ucl=_to_float_or_none(new_warn_high),
+                critical_lcl=_to_float_or_none(new_crit_low),
+                critical_ucl=_to_float_or_none(new_crit_high),
+            ),
+            changed_by=None if changed_by is None else str(changed_by),
+            changed_at=_to_utc_millis(str(changed_at)),
         )
 
 

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -397,103 +398,109 @@ class ChartRepository:
         sql = self._CHARTS_HISTORY_SQL
         where_clauses: list[str] = []
         params: list[Any] = []
-
-        chart_filter_key = self._find_chart_history_filter_key(criteria.chart_pk)
-        if criteria.chart_pk is not None and chart_filter_key is None:
-            return []
-
-        if chart_filter_key is not None:
-            self._append_filter_condition(
-                chart_filter_key.chart_set_id,
-                "h.chart_set_id = ?",
-                where_clauses,
-                params,
-            )
-            self._append_filter_condition(
-                chart_filter_key.tool_id,
-                "h.tool_id = ?",
-                where_clauses,
-                params,
-            )
-            self._append_filter_condition(
-                chart_filter_key.chamber_id,
-                "h.chamber_id = ?",
-                where_clauses,
-                params,
-            )
-            self._append_filter_condition(
-                chart_filter_key.recipe_id,
-                "h.recipe_id = ?",
-                where_clauses,
-                params,
-            )
-            self._append_filter_condition(
-                chart_filter_key.parameter,
-                "h.parameter = ?",
-                where_clauses,
-                params,
-            )
-            self._append_filter_condition(
-                chart_filter_key.step_no,
-                "h.step_no = ?",
-                where_clauses,
-                params,
-            )
-            self._append_filter_condition(
-                chart_filter_key.feature_type,
-                "h.feature_type = ?",
-                where_clauses,
-                params,
-            )
-        self._append_filter_condition(
-            criteria.chart_set_id,
-            "h.chart_set_id = ?",
-            where_clauses,
-            params,
-        )
-        self._append_filter_condition(
-            criteria.change_source,
-            "h.change_source = ?",
-            where_clauses,
-            params,
-        )
-        self._append_filter_condition(
-            criteria.from_ts,
-            "datetime(h.changed_at) >= datetime(?)",
-            where_clauses,
-            params,
-        )
-        self._append_filter_condition(
-            criteria.to_ts,
-            "datetime(h.changed_at) <= datetime(?)",
-            where_clauses,
-            params,
-        )
-
-        if where_clauses:
-            sql += " WHERE " + " AND ".join(where_clauses)
-
-        sql += " ORDER BY datetime(h.changed_at) DESC, h.id DESC LIMIT ? OFFSET ?"
-        params.extend([criteria.limit, criteria.offset])
-
         con = _connect(MAIN_DB)
+
         try:
+            chart_filter_key = self._find_chart_history_filter_key(con, criteria.chart_pk)
+            if criteria.chart_pk is not None and chart_filter_key is None:
+                return []
+
+            if chart_filter_key is not None:
+                self._append_filter_condition(
+                    chart_filter_key.chart_set_id,
+                    "h.chart_set_id = ?",
+                    where_clauses,
+                    params,
+                )
+                self._append_filter_condition(
+                    chart_filter_key.tool_id,
+                    "h.tool_id = ?",
+                    where_clauses,
+                    params,
+                )
+                self._append_filter_condition(
+                    chart_filter_key.chamber_id,
+                    "h.chamber_id = ?",
+                    where_clauses,
+                    params,
+                )
+                self._append_filter_condition(
+                    chart_filter_key.recipe_id,
+                    "h.recipe_id = ?",
+                    where_clauses,
+                    params,
+                )
+                self._append_filter_condition(
+                    chart_filter_key.parameter,
+                    "h.parameter = ?",
+                    where_clauses,
+                    params,
+                )
+                self._append_filter_condition(
+                    chart_filter_key.step_no,
+                    "h.step_no = ?",
+                    where_clauses,
+                    params,
+                )
+                self._append_filter_condition(
+                    chart_filter_key.feature_type,
+                    "h.feature_type = ?",
+                    where_clauses,
+                    params,
+                )
+
+            should_add_chart_set_id = criteria.chart_set_id is not None and (
+                chart_filter_key is None or criteria.chart_set_id != chart_filter_key.chart_set_id
+            )
+            if should_add_chart_set_id:
+                self._append_filter_condition(
+                    criteria.chart_set_id,
+                    "h.chart_set_id = ?",
+                    where_clauses,
+                    params,
+                )
+
+            self._append_filter_condition(
+                criteria.change_source,
+                "h.change_source = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                criteria.from_ts,
+                "datetime(h.changed_at) >= datetime(?)",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                criteria.to_ts,
+                "datetime(h.changed_at) <= datetime(?)",
+                where_clauses,
+                params,
+            )
+
+            if where_clauses:
+                sql += " WHERE " + " AND ".join(where_clauses)
+
+            sql += " ORDER BY datetime(h.changed_at) DESC, h.id DESC LIMIT ? OFFSET ?"
+            params.extend([criteria.limit, criteria.offset])
+
             rows = con.execute(sql, tuple(params)).fetchall()
         finally:
             con.close()
 
         return [self._to_chart_history_view(row) for row in rows]
 
-    def _find_chart_history_filter_key(self, chart_pk: int | None) -> ChartHistoryFilterKey | None:
+    def _find_chart_history_filter_key(
+        self,
+        con: sqlite3.Connection,
+        chart_pk: int | None,
+    ) -> ChartHistoryFilterKey | None:
         """chart_id から現在の ChartsV2 上の複合キーを解決する。"""
         if chart_pk is None:
             return None
 
-        con = _connect(MAIN_DB)
-        try:
-            row = con.execute(self._CHART_HISTORY_FILTER_KEY_SQL, (chart_pk,)).fetchone()
-        finally:
-            con.close()
+        row = con.execute(self._CHART_HISTORY_FILTER_KEY_SQL, (chart_pk,)).fetchone()
 
         if row is None:
             return None

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -45,6 +45,19 @@ class ChartsHistoryQueryCriteria:
 
 
 @dataclass(frozen=True)
+class ChartHistoryFilterKey:
+    """ChartsHistory を一意に絞り込む複合キー。"""
+
+    chart_set_id: int
+    tool_id: str
+    chamber_id: str
+    recipe_id: str
+    parameter: str
+    step_no: int
+    feature_type: str
+
+
+@dataclass(frozen=True)
 class ChartView:
     """`GET /charts` レスポンス 1 件分の DTO。
 
@@ -169,6 +182,19 @@ class ChartRepository:
            AND c.parameter = h.parameter
            AND c.step_no = h.step_no
            AND c.feature_type = h.feature_type
+    """
+
+    _CHART_HISTORY_FILTER_KEY_SQL = """
+        SELECT
+            chart_set_id,
+            tool_id,
+            chamber_id,
+            recipe_id,
+            parameter,
+            step_no,
+            feature_type
+        FROM ChartsV2
+        WHERE id = ?
     """
 
     _FILTERED_CHARTS_CTE = """
@@ -380,12 +406,53 @@ class ChartRepository:
         where_clauses: list[str] = []
         params: list[Any] = []
 
-        self._append_filter_condition(
-            criteria.chart_pk,
-            "c.id = ?",
-            where_clauses,
-            params,
-        )
+        chart_filter_key = self._find_chart_history_filter_key(criteria.chart_pk)
+        if criteria.chart_pk is not None and chart_filter_key is None:
+            return []
+
+        if chart_filter_key is not None:
+            self._append_filter_condition(
+                chart_filter_key.chart_set_id,
+                "h.chart_set_id = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                chart_filter_key.tool_id,
+                "h.tool_id = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                chart_filter_key.chamber_id,
+                "h.chamber_id = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                chart_filter_key.recipe_id,
+                "h.recipe_id = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                chart_filter_key.parameter,
+                "h.parameter = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                chart_filter_key.step_no,
+                "h.step_no = ?",
+                where_clauses,
+                params,
+            )
+            self._append_filter_condition(
+                chart_filter_key.feature_type,
+                "h.feature_type = ?",
+                where_clauses,
+                params,
+            )
         self._append_filter_condition(
             criteria.chart_set_id,
             "h.chart_set_id = ?",
@@ -424,6 +491,30 @@ class ChartRepository:
             con.close()
 
         return [self._to_chart_history_view(row) for row in rows]
+
+    def _find_chart_history_filter_key(self, chart_pk: int | None) -> ChartHistoryFilterKey | None:
+        """chart_id から現在の ChartsV2 上の複合キーを解決する。"""
+        if chart_pk is None:
+            return None
+
+        con = _connect(MAIN_DB)
+        try:
+            row = con.execute(self._CHART_HISTORY_FILTER_KEY_SQL, (chart_pk,)).fetchone()
+        finally:
+            con.close()
+
+        if row is None:
+            return None
+
+        return ChartHistoryFilterKey(
+            chart_set_id=int(row[0]),
+            tool_id=str(row[1]),
+            chamber_id=str(row[2]),
+            recipe_id=str(row[3]),
+            parameter=str(row[4]),
+            step_no=int(row[5]),
+            feature_type=str(row[6]),
+        )
 
     @staticmethod
     def _append_filter_condition(

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -160,7 +160,7 @@ class ChartRepository:
         SELECT
             h.id,
             h.chart_set_id,
-            c.id,
+            h.chart_id,
             h.change_source,
             h.change_reason,
             h.old_warn_low,
@@ -174,14 +174,6 @@ class ChartRepository:
             h.changed_by,
             h.changed_at
         FROM ChartsHistory h
-        LEFT JOIN ChartsV2 c
-            ON c.chart_set_id = h.chart_set_id
-           AND c.tool_id = h.tool_id
-           AND c.chamber_id = h.chamber_id
-           AND c.recipe_id = h.recipe_id
-           AND c.parameter = h.parameter
-           AND c.step_no = h.step_no
-           AND c.feature_type = h.feature_type
     """
 
     _CHART_HISTORY_FILTER_KEY_SQL = """

--- a/src/portfolio_fdc/db_api/db.py
+++ b/src/portfolio_fdc/db_api/db.py
@@ -211,10 +211,35 @@ def _init_schema(db_path: Path) -> None:
                 changed_by TEXT,
                 change_reason TEXT,
                 change_source TEXT,
+                chart_id INTEGER,
                 FOREIGN KEY(chart_set_id) REFERENCES ChartSet(chart_set_id)
             );
             """
         )
+        # Migration: add chart_id column for existing databases that predate this column.
+        # chart_id stores the ChartsV2 primary key at the time of the change, preserving
+        # the stable identifier in audit records even after the chart row is later deleted.
+        try:
+            con.execute("ALTER TABLE ChartsHistory ADD COLUMN chart_id INTEGER")
+            con.execute(
+                """
+                UPDATE ChartsHistory
+                SET chart_id = (
+                    SELECT c.id
+                    FROM ChartsV2 c
+                    WHERE c.chart_set_id = ChartsHistory.chart_set_id
+                      AND c.tool_id = ChartsHistory.tool_id
+                      AND c.chamber_id = ChartsHistory.chamber_id
+                      AND c.recipe_id = ChartsHistory.recipe_id
+                      AND c.parameter = ChartsHistory.parameter
+                      AND c.step_no = ChartsHistory.step_no
+                      AND c.feature_type = ChartsHistory.feature_type
+                )
+                WHERE chart_id IS NULL
+                """
+            )
+        except sqlite3.OperationalError:
+            pass  # column already exists – migration already applied
         con.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_charts_v2_lookup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,14 @@ from fastapi.testclient import TestClient
 from portfolio_fdc.db_api import app as db_app
 from portfolio_fdc.db_api.db import MAIN_DB
 
+_MIN_SQLITE_VERSION = (3, 38, 0)
+_current_sqlite_version = tuple(int(x) for x in sqlite3.sqlite_version.split("."))
+if _current_sqlite_version < _MIN_SQLITE_VERSION:
+    raise RuntimeError(
+        "SQLite >= 3.38.0 required for timezone-aware datetime() comparisons, "
+        f"got {sqlite3.sqlite_version}"
+    )
+
 
 @pytest.fixture
 def db_api_client() -> Iterator[TestClient]:

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -283,6 +283,19 @@ def test_get_charts_history_rejects_invalid_time_range(client: TestClient) -> No
     assert "end_ts must be greater than or equal to start_ts" in res.json()["detail"]
 
 
+def test_get_charts_history_rejects_mixed_naive_and_aware_timestamps(client: TestClient) -> None:
+    res = client.get(
+        "/charts/history",
+        params={
+            "from_ts": "2026-04-14T00:00:00",
+            "to_ts": "2026-04-14T00:00:00Z",
+        },
+    )
+
+    assert res.status_code == 400
+    assert "same timezone format" in res.json()["detail"]
+
+
 def test_get_charts_history_rejects_chart_id_out_of_int64_range(client: TestClient) -> None:
     # Try chart_id with numeric part exceeding int64 max (2**63 - 1)
     out_of_range_pk = 2**63

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -289,4 +289,4 @@ def test_get_charts_history_rejects_chart_id_out_of_int64_range(client: TestClie
     res = client.get("/charts/history", params={"chart_id": f"CHART_{out_of_range_pk}"})
 
     assert res.status_code == 400
-    assert "out of int64 range" in res.json()["detail"]
+    assert res.json()["detail"] == "Invalid chart_id"

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -668,17 +668,11 @@ def test_get_charts_history_rejects_both_naive_timestamps(client: TestClient) ->
 
 def test_get_charts_history_returns_100_rows_without_filters(
     client: TestClient,
-    seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
     """フィルタなし状態で default limit の 100 件を返すことを検証する。"""
     # ギャップ#4: フィルタなし + 実データで100件返ることの確認
-
-    # 追加の chart を 1 つ投入
-    now = "2026-04-14T09:00:00+09:00"
-    suffix = "extra_" + str(uuid4())[:8]
-    chart_set_id2 = _insert_chart_set(now, suffix)
-    dt = datetime.fromisoformat(now.replace("+09:00", "+09:00"))
-    _insert_chart_and_history(chart_set_id2, suffix, dt)
+    # 複数の chart_set がすでに存在する環境で、フィルタなしリクエストが
+    # default limit の 100 件を返すことを確認
 
     res = client.get("/charts/history")
 

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -288,6 +288,53 @@ def test_get_charts_history_supports_from_to_filter(
     )
 
 
+def test_get_charts_history_supports_from_ts_only_filter(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "from_ts": "2026-04-14T00:01:58Z",
+            "limit": 500,
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    rows = body["data"]
+    assert len(rows) == 2
+    assert all(item["changed_at"] >= "2026-04-14T00:01:58.000Z" for item in rows)
+
+
+def test_get_charts_history_supports_to_ts_only_filter(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "to_ts": "2026-04-14T00:00:01Z",
+            "limit": 500,
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    rows = body["data"]
+    assert len(rows) == 2
+    assert {item["change_reason"] for item in rows} == {"reason-0", "reason-1"}
+    assert all(item["changed_at"] <= "2026-04-14T00:00:01.000Z" for item in rows)
+
+
 def test_get_charts_history_rejects_invalid_chart_id_pattern(client: TestClient) -> None:
     res = client.get("/charts/history", params={"chart_id": "CHART_INVALID"})
 

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -263,6 +263,23 @@ def test_get_charts_history_supports_limit_and_offset(
     assert first_row["history_id"] != second_row["history_id"]
 
 
+def test_get_charts_history_returns_empty_when_offset_exceeds_total(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get(
+        "/charts/history",
+        params={"chart_set_id": seeded.chart_set_id, "offset": 1000},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"] == []
+
+
 def test_get_charts_history_supports_from_to_filter(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
@@ -333,6 +350,26 @@ def test_get_charts_history_supports_to_ts_only_filter(
     assert len(rows) == 2
     assert {item["change_reason"] for item in rows} == {"reason-0", "reason-1"}
     assert all(item["changed_at"] <= "2026-04-14T00:00:01.000Z" for item in rows)
+
+
+def test_get_charts_history_returns_empty_for_non_matching_filters(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "change_source": "nonexistent_source",
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"] == []
 
 
 def test_get_charts_history_rejects_invalid_chart_id_pattern(client: TestClient) -> None:

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -187,6 +187,20 @@ def test_get_charts_history_returns_contract_fields(
     )
 
 
+def test_get_charts_history_applies_default_limit_without_limit_param(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get("/charts/history", params={"chart_set_id": seeded.chart_set_id})
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert len(body["data"]) == 100
+
+
 def test_get_charts_history_supports_chart_id_and_change_source_filters(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
@@ -207,6 +221,23 @@ def test_get_charts_history_supports_chart_id_and_change_source_filters(
     assert len(rows) == 60
     assert all(item["chart_id"] == seeded.chart_id for item in rows)
     assert all(item["change_source"] == "normal_pr" for item in rows)
+
+
+def test_get_charts_history_applies_default_limit_with_chart_id_filter(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get(
+        "/charts/history",
+        params={"chart_id": seeded.chart_id},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert len(body["data"]) == 100
 
 
 def test_get_charts_history_supports_limit_and_offset(

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -33,6 +33,7 @@ def seeded_charts_history_context() -> Iterator[SeededChartsHistoryContext]:
     _init_schema(MAIN_DB)
     con = sqlite3.connect(MAIN_DB.as_posix())
     context: SeededChartsHistoryContext | None = None
+    chart_set_id: int | None = None
     try:
         now = datetime.now(UTC).isoformat()
         suffix = uuid4().hex
@@ -112,20 +113,20 @@ def seeded_charts_history_context() -> Iterator[SeededChartsHistoryContext]:
         yield context
     finally:
         con.close()
-        if context is not None:
+        if chart_set_id is not None:
             cleanup = sqlite3.connect(MAIN_DB.as_posix())
             try:
                 cleanup.execute(
                     "DELETE FROM ChartsHistory WHERE chart_set_id = ?",
-                    (context.chart_set_id,),
+                    (chart_set_id,),
                 )
                 cleanup.execute(
                     "DELETE FROM ChartsV2 WHERE chart_set_id = ?",
-                    (context.chart_set_id,),
+                    (chart_set_id,),
                 )
                 cleanup.execute(
                     "DELETE FROM ChartSet WHERE chart_set_id = ?",
-                    (context.chart_set_id,),
+                    (chart_set_id,),
                 )
                 cleanup.commit()
             finally:

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -461,6 +461,19 @@ def test_get_charts_history_rejects_mixed_naive_and_aware_timestamps(client: Tes
     assert "same timezone format" in res.json()["detail"]
 
 
+def test_get_charts_history_rejects_naive_from_ts_when_provided_alone(client: TestClient) -> None:
+    """naive な from_ts 単独指定を 400 として拒否することを検証する。"""
+    res = client.get(
+        "/charts/history",
+        params={
+            "from_ts": "2026-04-14T00:00:00",
+        },
+    )
+
+    assert res.status_code == 400
+    assert res.json()["detail"] == "from_ts and to_ts must be timezone-aware datetimes"
+
+
 def test_get_charts_history_rejects_chart_id_out_of_int64_range(client: TestClient) -> None:
     """int64 範囲外の chart_id 数値部を 400 として拒否することを検証する。"""
     # Try chart_id with numeric part exceeding int64 max (2**63 - 1)
@@ -565,6 +578,36 @@ def test_get_charts_history_allows_null_change_reason_and_changed_by(
     row = body["data"][0]
     assert row["change_reason"] is None
     assert row["changed_by"] is None
+
+
+def test_get_charts_history_returns_empty_for_deleted_chart_id_filter(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    """削除済み chart は chart_id フィルタでは取得できないことを明示的に検証する。"""
+    seeded = seeded_charts_history_context
+    chart_pk = int(seeded.chart_id.split("_", maxsplit=1)[1])
+
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        con.execute("DELETE FROM ChartsV2 WHERE id = ?", (chart_pk,))
+        con.commit()
+    finally:
+        con.close()
+
+    by_chart_id = client.get("/charts/history", params={"chart_id": seeded.chart_id})
+    assert by_chart_id.status_code == 200
+    assert by_chart_id.json() == {"ok": True, "data": []}
+
+    by_chart_set = client.get(
+        "/charts/history",
+        params={"chart_set_id": seeded.chart_set_id, "limit": 500},
+    )
+    assert by_chart_set.status_code == 200
+    body = by_chart_set.json()
+    assert body["ok"] is True
+    assert len(body["data"]) == 120
+    assert all(item["chart_id"] is None for item in body["data"])
 
 
 def test_get_charts_history_returns_503_then_recovers_from_transient_db_error(

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -668,11 +668,13 @@ def test_get_charts_history_rejects_both_naive_timestamps(client: TestClient) ->
 
 def test_get_charts_history_returns_100_rows_without_filters(
     client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
     """フィルタなし状態で default limit の 100 件を返すことを検証する。"""
-    # ギャップ#4: フィルタなし + 実データで100件返ることの確認
-    # 複数の chart_set がすでに存在する環境で、フィルタなしリクエストが
-    # default limit の 100 件を返すことを確認
+    # ギャップ#4: フィルタなし + 実データで100件返ることを検証する
+    # seeded_charts_history_context は 120 行を提供し、
+    # デフォルト limit 100 で要求した場合に 100 行が返ることを検証
+    _ = seeded_charts_history_context  # fixture 依存を明示（テスト順序独立）
 
     res = client.get("/charts/history")
 

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -474,6 +474,7 @@ def test_get_charts_history_rejects_chart_id_out_of_int64_range(client: TestClie
 @pytest.mark.parametrize(
     "raw_chart_id",
     [
+        "CHART_0",
         "CHART_",
         "CHART_not_number",
         "CHART_1_2",

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -138,13 +138,13 @@ def test_get_charts_history_returns_contract_fields(
 ) -> None:
     seeded = seeded_charts_history_context
 
-    res = client.get("/charts/history", params={"chart_set_id": seeded.chart_set_id})
+    res = client.get("/charts/history", params={"chart_set_id": seeded.chart_set_id, "limit": 500})
 
     assert res.status_code == 200
     body = res.json()
     assert body["ok"] is True
     data = body["data"]
-    assert len(data) == 100
+    assert len(data) == 120
 
     first = data[0]
     expected_keys = {
@@ -178,6 +178,13 @@ def test_get_charts_history_returns_contract_fields(
         "critical_lcl": 0.9,
         "critical_ucl": 2.3,
     }
+
+    reason_0_row = next((item for item in data if item["change_reason"] == "reason-0"), None)
+    assert reason_0_row is not None, "reason-0 history record not found"
+    assert reason_0_row["changed_at"] == "2026-04-14T00:00:00.123Z", (
+        f"Timestamp normalization failed: +09:00 with microsecond 123999 "
+        f"should convert to UTC 00:00:00.123Z, got {reason_0_row['changed_at']}"
+    )
 
 
 def test_get_charts_history_supports_chart_id_and_change_source_filters(

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -649,9 +649,96 @@ def test_get_charts_history_returns_empty_for_deleted_chart_id_filter(
     body = by_chart_set.json()
     assert body["ok"] is True
     assert len(body["data"]) == 120
-    # chart_id is stored directly on ChartsHistory, so it is preserved even
-    # after the ChartsV2 row is deleted.
-    assert all(item["chart_id"] == seeded.chart_id for item in body["data"])
+
+
+def test_get_charts_history_rejects_both_naive_timestamps(client: TestClient) -> None:
+    """両方ともナイーブな from_ts/to_ts を 400 として拒否することを検証する。"""
+    # ギャップ#2: 両方ナイーブな場合の暗黙UTC変換を防ぐ
+    res = client.get(
+        "/charts/history",
+        params={
+            "from_ts": "2026-04-14T00:00:00",
+            "to_ts": "2026-04-14T00:01:00",
+        },
+    )
+
+    assert res.status_code == 400
+    assert "timezone-aware" in res.json()["detail"]
+
+
+def test_get_charts_history_returns_100_rows_without_filters(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    """フィルタなし状態で default limit の 100 件を返すことを検証する。"""
+    # ギャップ#4: フィルタなし + 実データで100件返ることの確認
+
+    # 追加の chart を 1 つ投入
+    now = "2026-04-14T09:00:00+09:00"
+    suffix = "extra_" + str(uuid4())[:8]
+    chart_set_id2 = _insert_chart_set(now, suffix)
+    dt = datetime.fromisoformat(now.replace("+09:00", "+09:00"))
+    _insert_chart_and_history(chart_set_id2, suffix, dt)
+
+    res = client.get("/charts/history")
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    # limit なしの default は 100 件
+    assert len(body["data"]) == 100
+
+
+def test_get_charts_history_change_source_is_case_sensitive(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    """change_source フィルタが case-sensitive であることを検証する。"""
+    # ギャップ#7: SQLite はデフォルト case-sensitive、大文字小文字が異なるとマッチしない
+    seeded = seeded_charts_history_context
+
+    # chart_set_id フィルタで全件取得
+    res_all = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "limit": 500,
+        },
+    )
+    assert res_all.status_code == 200
+    all_data = res_all.json()["data"]
+    assert len(all_data) == 120, f"Expected 120 records, got {len(all_data)}"
+
+    # テストデータは "normal_pr" (小文字) または "emergency_manual" (小文字) なので、
+    # 大文字版 "Normal_PR" で検索すると マッチしないことを確認
+    res_upper = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "change_source": "Normal_PR",  # 大文字版（存在しない）
+            "limit": 500,
+        },
+    )
+    assert res_upper.status_code == 200
+    upper_data = res_upper.json()["data"]
+    assert len(upper_data) == 0, (
+        "Case-sensitive: 'Normal_PR' (uppercase) should not match 'normal_pr'"
+    )
+
+    # 小文字版で検索すると マッチする
+    res_lower = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "change_source": "normal_pr",  # 小文字版（存在する）
+            "limit": 500,
+        },
+    )
+    assert res_lower.status_code == 200
+    lower_data = res_lower.json()["data"]
+    assert len(lower_data) == 60, (
+        "Exact case match: 'normal_pr' should find 60 records (even indices)"
+    )
 
 
 def test_get_charts_history_returns_503_then_recovers_from_transient_db_error(

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -559,7 +559,7 @@ def test_get_charts_history_allows_null_change_reason_and_changed_by(
     try:
         chart_row = con.execute(
             """
-            SELECT tool_id, chamber_id, recipe_id, parameter, step_no, feature_type
+            SELECT id, tool_id, chamber_id, recipe_id, parameter, step_no, feature_type
             FROM ChartsV2
             WHERE id = ?
             """,
@@ -574,17 +574,17 @@ def test_get_charts_history_allows_null_change_reason_and_changed_by(
                 step_no, feature_type, old_warn_low, old_warn_high,
                 old_crit_low, old_crit_high, new_warn_low, new_warn_high,
                 new_crit_low, new_crit_high, changed_at, changed_by,
-                change_reason, change_source
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                change_reason, change_source, chart_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 seeded.chart_set_id,
-                chart_row[0],
                 chart_row[1],
                 chart_row[2],
                 chart_row[3],
                 chart_row[4],
                 chart_row[5],
+                chart_row[6],
                 1.0,
                 2.0,
                 0.8,
@@ -597,6 +597,7 @@ def test_get_charts_history_allows_null_change_reason_and_changed_by(
                 None,
                 None,
                 "null_field_test",
+                chart_row[0],
             ),
         )
         con.commit()

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -30,23 +30,26 @@ class SeededChartsHistoryContext:
     chart_id: str
 
 
-@pytest.fixture
-def seeded_charts_history_context() -> Iterator[SeededChartsHistoryContext]:
-    """ChartsHistory 検証用に 120 件の履歴を持つ chart set を作成する。"""
+def _insert_chart_set(now: str, suffix: str) -> int:
+    """履歴テスト用の ChartSet を 1 件作成して ID を返す。"""
     _init_schema(MAIN_DB)
     con = sqlite3.connect(MAIN_DB.as_posix())
-    context: SeededChartsHistoryContext | None = None
-    chart_set_id: int | None = None
     try:
-        now = datetime.now(UTC).isoformat()
-        suffix = uuid4().hex
-
         con.execute(
             "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
             (f"history_set_{suffix}", "test", now, "test"),
         )
         chart_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+        con.commit()
+        return chart_set_id
+    finally:
+        con.close()
 
+
+def _insert_chart_and_history(chart_set_id: int, suffix: str, base: datetime) -> int:
+    """ChartsV2 と対応する 120 件の ChartsHistory を投入して chart PK を返す。"""
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
         con.execute(
             _INSERT_CHART_SQL,
             (
@@ -69,7 +72,6 @@ def seeded_charts_history_context() -> Iterator[SeededChartsHistoryContext]:
         )
         chart_pk = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
 
-        base = datetime(2026, 4, 14, 0, 0, 0, tzinfo=UTC)
         for index in range(120):
             changed_at = (base + timedelta(seconds=index)).isoformat().replace("+00:00", "Z")
             if index == 0:
@@ -109,31 +111,51 @@ def seeded_charts_history_context() -> Iterator[SeededChartsHistoryContext]:
             )
 
         con.commit()
-        context = SeededChartsHistoryContext(
+        return chart_pk
+    finally:
+        con.close()
+
+
+def _cleanup_seeded_history(chart_set_id: int) -> None:
+    """seed した ChartsHistory/ChartsV2/ChartSet を削除する。"""
+    cleanup = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        cleanup.execute(
+            "DELETE FROM ChartsHistory WHERE chart_set_id = ?",
+            (chart_set_id,),
+        )
+        cleanup.execute(
+            "DELETE FROM ChartsV2 WHERE chart_set_id = ?",
+            (chart_set_id,),
+        )
+        cleanup.execute(
+            "DELETE FROM ChartSet WHERE chart_set_id = ?",
+            (chart_set_id,),
+        )
+        cleanup.commit()
+    finally:
+        cleanup.close()
+
+
+@pytest.fixture
+def seeded_charts_history_context() -> Iterator[SeededChartsHistoryContext]:
+    """ChartsHistory 検証用に 120 件の履歴を持つ chart set を作成する。"""
+    chart_set_id: int | None = None
+    try:
+        now = datetime.now(UTC).isoformat()
+        suffix = uuid4().hex
+        base = datetime(2026, 4, 14, 0, 0, 0, tzinfo=UTC)
+
+        chart_set_id = _insert_chart_set(now, suffix)
+        chart_pk = _insert_chart_and_history(chart_set_id, suffix, base)
+
+        yield SeededChartsHistoryContext(
             chart_set_id=chart_set_id,
             chart_id=f"CHART_{chart_pk}",
         )
-        yield context
     finally:
-        con.close()
         if chart_set_id is not None:
-            cleanup = sqlite3.connect(MAIN_DB.as_posix())
-            try:
-                cleanup.execute(
-                    "DELETE FROM ChartsHistory WHERE chart_set_id = ?",
-                    (chart_set_id,),
-                )
-                cleanup.execute(
-                    "DELETE FROM ChartsV2 WHERE chart_set_id = ?",
-                    (chart_set_id,),
-                )
-                cleanup.execute(
-                    "DELETE FROM ChartSet WHERE chart_set_id = ?",
-                    (chart_set_id,),
-                )
-                cleanup.commit()
-            finally:
-                cleanup.close()
+            _cleanup_seeded_history(chart_set_id)
 
 
 def test_get_charts_history_returns_contract_fields(
@@ -151,7 +173,6 @@ def test_get_charts_history_returns_contract_fields(
     data = body["data"]
     assert len(data) == 120
 
-    first = data[0]
     expected_keys = {
         "history_id",
         "chart_id",
@@ -163,11 +184,14 @@ def test_get_charts_history_returns_contract_fields(
         "changed_by",
         "changed_at",
     }
-    assert expected_keys.issubset(first.keys())
-    assert re.fullmatch(r"HIS_\d+", first["history_id"])
-    assert first["chart_id"] == seeded.chart_id
-    assert first["chart_set_id"] == seeded.chart_set_id
-    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", first["changed_at"])
+    for row in data:
+        assert expected_keys.issubset(row.keys())
+        assert re.fullmatch(r"HIS_\d+", row["history_id"])
+        assert row["chart_id"] == seeded.chart_id
+        assert row["chart_set_id"] == seeded.chart_set_id
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", row["changed_at"])
+
+    first = data[0]
 
     before = first["before"]
     after = first["after"]

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -84,8 +84,8 @@ def _insert_chart_and_history(chart_set_id: int, suffix: str, base: datetime) ->
                     step_no, feature_type, old_warn_low, old_warn_high,
                     old_crit_low, old_crit_high, new_warn_low, new_warn_high,
                     new_crit_low, new_crit_high, changed_at, changed_by,
-                    change_reason, change_source
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    change_reason, change_source, chart_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     chart_set_id,
@@ -107,6 +107,7 @@ def _insert_chart_and_history(chart_set_id: int, suffix: str, base: datetime) ->
                     "tester",
                     f"reason-{index}",
                     change_source,
+                    chart_pk,
                 ),
             )
 
@@ -339,6 +340,30 @@ def test_get_charts_history_supports_from_to_filter(
     )
 
 
+def test_get_charts_history_supports_equal_boundary_from_to_filter(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    """from_ts == to_ts の境界匹合時に 1 件のみ返ることを検証する。"""
+    seeded = seeded_charts_history_context
+    equal_ts = "2026-04-14T00:00:10Z"
+
+    res = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "from_ts": equal_ts,
+            "to_ts": equal_ts,
+            "limit": 500,
+        },
+    )
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert len(rows) == 1
+    assert rows[0]["changed_at"] == "2026-04-14T00:00:10.000Z"
+
+
 def test_get_charts_history_supports_from_ts_only_filter(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
@@ -415,6 +440,22 @@ def test_get_charts_history_rejects_invalid_chart_id_pattern(client: TestClient)
 
     assert res.status_code == 422
     assert_validation_error_envelope(res.json(), expected_loc_fragment="chart_id")
+
+
+def test_get_charts_history_rejects_zero_limit(client: TestClient) -> None:
+    """limit が 0 の場合に 422 を返すことを検証する。"""
+    res = client.get("/charts/history", params={"limit": 0})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="limit")
+
+
+def test_get_charts_history_rejects_zero_chart_set_id(client: TestClient) -> None:
+    """chart_set_id が 0 の場合に 422 を返すことを検証する。"""
+    res = client.get("/charts/history", params={"chart_set_id": 0})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="chart_set_id")
 
 
 def test_get_charts_history_rejects_limit_exceeds_max(client: TestClient) -> None:
@@ -607,7 +648,9 @@ def test_get_charts_history_returns_empty_for_deleted_chart_id_filter(
     body = by_chart_set.json()
     assert body["ok"] is True
     assert len(body["data"]) == 120
-    assert all(item["chart_id"] is None for item in body["data"])
+    # chart_id is stored directly on ChartsHistory, so it is preserved even
+    # after the ChartsV2 row is deleted.
+    assert all(item["chart_id"] == seeded.chart_id for item in body["data"])
 
 
 def test_get_charts_history_returns_503_then_recovers_from_transient_db_error(

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
+from tests.test_utils import assert_validation_error_envelope
+
+_INSERT_CHART_SQL = """
+    INSERT INTO ChartsV2(
+        chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+        step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+        updated_at, updated_by, update_reason, update_source
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+@dataclass(frozen=True)
+class SeededChartsHistoryContext:
+    chart_set_id: int
+    chart_id: str
+
+
+@pytest.fixture
+def seeded_charts_history_context() -> Iterator[SeededChartsHistoryContext]:
+    _init_schema(MAIN_DB)
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    context: SeededChartsHistoryContext | None = None
+    try:
+        now = datetime.now(UTC).isoformat()
+        suffix = uuid4().hex
+
+        con.execute(
+            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
+            (f"history_set_{suffix}", "test", now, "test"),
+        )
+        chart_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+        con.execute(
+            _INSERT_CHART_SQL,
+            (
+                chart_set_id,
+                f"TOOL_HISTORY_{suffix}",
+                "CH_HISTORY",
+                "RECIPE_HISTORY",
+                "dc_bias",
+                1,
+                "mean",
+                1.4,
+                2.6,
+                1.2,
+                2.8,
+                "2026-04-14T00:00:00Z",
+                "tester",
+                "seed",
+                "test",
+            ),
+        )
+        chart_pk = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+        base = datetime(2026, 4, 14, 0, 0, 0, tzinfo=UTC)
+        for index in range(120):
+            changed_at = (base + timedelta(seconds=index)).isoformat().replace("+00:00", "Z")
+            if index == 0:
+                changed_at = "2026-04-14T09:00:00.123999+09:00"
+            change_source = "normal_pr" if index % 2 == 0 else "emergency_manual"
+            con.execute(
+                """
+                INSERT INTO ChartsHistory(
+                    chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                    step_no, feature_type, old_warn_low, old_warn_high,
+                    old_crit_low, old_crit_high, new_warn_low, new_warn_high,
+                    new_crit_low, new_crit_high, changed_at, changed_by,
+                    change_reason, change_source
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    chart_set_id,
+                    f"TOOL_HISTORY_{suffix}",
+                    "CH_HISTORY",
+                    "RECIPE_HISTORY",
+                    "dc_bias",
+                    1,
+                    "mean",
+                    1.0,
+                    2.0,
+                    0.8,
+                    2.2,
+                    1.1,
+                    2.1,
+                    0.9,
+                    2.3,
+                    changed_at,
+                    "tester",
+                    f"reason-{index}",
+                    change_source,
+                ),
+            )
+
+        con.commit()
+        context = SeededChartsHistoryContext(
+            chart_set_id=chart_set_id,
+            chart_id=f"CHART_{chart_pk}",
+        )
+        yield context
+    finally:
+        con.close()
+        if context is not None:
+            cleanup = sqlite3.connect(MAIN_DB.as_posix())
+            try:
+                cleanup.execute(
+                    "DELETE FROM ChartsHistory WHERE chart_set_id = ?",
+                    (context.chart_set_id,),
+                )
+                cleanup.execute(
+                    "DELETE FROM ChartsV2 WHERE chart_set_id = ?",
+                    (context.chart_set_id,),
+                )
+                cleanup.execute(
+                    "DELETE FROM ChartSet WHERE chart_set_id = ?",
+                    (context.chart_set_id,),
+                )
+                cleanup.commit()
+            finally:
+                cleanup.close()
+
+
+def test_get_charts_history_returns_contract_fields(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get("/charts/history", params={"chart_set_id": seeded.chart_set_id})
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert len(data) == 100
+
+    first = data[0]
+    expected_keys = {
+        "history_id",
+        "chart_id",
+        "chart_set_id",
+        "change_source",
+        "change_reason",
+        "before",
+        "after",
+        "changed_by",
+        "changed_at",
+    }
+    assert expected_keys.issubset(first.keys())
+    assert re.fullmatch(r"HIS_\d+", first["history_id"])
+    assert first["chart_id"] == seeded.chart_id
+    assert first["chart_set_id"] == seeded.chart_set_id
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", first["changed_at"])
+
+    before = first["before"]
+    after = first["after"]
+    assert before == {
+        "warning_lcl": 1.0,
+        "warning_ucl": 2.0,
+        "critical_lcl": 0.8,
+        "critical_ucl": 2.2,
+    }
+    assert after == {
+        "warning_lcl": 1.1,
+        "warning_ucl": 2.1,
+        "critical_lcl": 0.9,
+        "critical_ucl": 2.3,
+    }
+
+
+def test_get_charts_history_supports_chart_id_and_change_source_filters(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get(
+        "/charts/history",
+        params={
+            "chart_id": seeded.chart_id,
+            "change_source": "normal_pr",
+            "limit": 500,
+        },
+    )
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert len(rows) == 60
+    assert all(item["chart_id"] == seeded.chart_id for item in rows)
+    assert all(item["change_source"] == "normal_pr" for item in rows)
+
+
+def test_get_charts_history_supports_limit_and_offset(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    first_page = client.get(
+        "/charts/history",
+        params={"chart_set_id": seeded.chart_set_id, "limit": 1, "offset": 0},
+    )
+    second_page = client.get(
+        "/charts/history",
+        params={"chart_set_id": seeded.chart_set_id, "limit": 1, "offset": 1},
+    )
+
+    assert first_page.status_code == 200
+    assert second_page.status_code == 200
+    first_row = first_page.json()["data"][0]
+    second_row = second_page.json()["data"][0]
+    assert first_row["history_id"] != second_row["history_id"]
+
+
+def test_get_charts_history_supports_from_to_filter(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    seeded = seeded_charts_history_context
+
+    res = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "from_ts": "2026-04-14T00:00:10Z",
+            "to_ts": "2026-04-14T00:00:12Z",
+            "limit": 500,
+        },
+    )
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert len(rows) == 3
+    assert all(
+        "2026-04-14T00:00:10.000Z" <= item["changed_at"] <= "2026-04-14T00:00:12.999Z"
+        for item in rows
+    )
+
+
+def test_get_charts_history_rejects_invalid_chart_id_pattern(client: TestClient) -> None:
+    res = client.get("/charts/history", params={"chart_id": "CHART_INVALID"})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="chart_id")
+
+
+def test_get_charts_history_rejects_limit_exceeds_max(client: TestClient) -> None:
+    res = client.get("/charts/history", params={"limit": 501})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="limit")
+
+
+def test_get_charts_history_rejects_invalid_time_range(client: TestClient) -> None:
+    res = client.get(
+        "/charts/history",
+        params={
+            "from_ts": "2026-04-14T00:01:00Z",
+            "to_ts": "2026-04-14T00:00:00Z",
+        },
+    )
+
+    assert res.status_code == 400
+    assert "end_ts must be greater than or equal to start_ts" in res.json()["detail"]

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 
+from portfolio_fdc.db_api import app as db_app
 from portfolio_fdc.db_api.db import MAIN_DB, _init_schema
 from tests.test_utils import assert_validation_error_envelope
 
@@ -30,6 +31,7 @@ class SeededChartsHistoryContext:
 
 @pytest.fixture
 def seeded_charts_history_context() -> Iterator[SeededChartsHistoryContext]:
+    """ChartsHistory 検証用に 120 件の履歴を持つ chart set を作成する。"""
     _init_schema(MAIN_DB)
     con = sqlite3.connect(MAIN_DB.as_posix())
     context: SeededChartsHistoryContext | None = None
@@ -137,6 +139,7 @@ def test_get_charts_history_returns_contract_fields(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """GET /charts/history が契約フィールドと正規化時刻を返すことを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get("/charts/history", params={"chart_set_id": seeded.chart_set_id, "limit": 500})
@@ -192,6 +195,7 @@ def test_get_charts_history_applies_default_limit_without_limit_param(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """limit 未指定時に default の 100 件が適用されることを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get("/charts/history", params={"chart_set_id": seeded.chart_set_id})
@@ -206,6 +210,7 @@ def test_get_charts_history_supports_chart_id_and_change_source_filters(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """chart_id と change_source の複合フィルタが機能することを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get(
@@ -228,6 +233,7 @@ def test_get_charts_history_applies_default_limit_with_chart_id_filter(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """chart_id 指定時も limit 未指定なら 100 件に制限されることを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get(
@@ -245,6 +251,7 @@ def test_get_charts_history_supports_limit_and_offset(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """limit と offset によるページングで取得位置が変わることを検証する。"""
     seeded = seeded_charts_history_context
 
     first_page = client.get(
@@ -267,6 +274,7 @@ def test_get_charts_history_returns_empty_when_offset_exceeds_total(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """総件数を超える offset 指定時に空配列が返ることを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get(
@@ -284,6 +292,7 @@ def test_get_charts_history_supports_from_to_filter(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """from_ts/to_ts 両方指定時に期間内データのみ返ることを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get(
@@ -309,6 +318,7 @@ def test_get_charts_history_supports_from_ts_only_filter(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """from_ts のみ指定時に下限境界で絞り込まれることを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get(
@@ -332,6 +342,7 @@ def test_get_charts_history_supports_to_ts_only_filter(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """to_ts のみ指定時に上限境界で絞り込まれることを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get(
@@ -356,6 +367,7 @@ def test_get_charts_history_returns_empty_for_non_matching_filters(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
+    """一致しないフィルタ条件では空配列が返ることを検証する。"""
     seeded = seeded_charts_history_context
 
     res = client.get(
@@ -373,6 +385,7 @@ def test_get_charts_history_returns_empty_for_non_matching_filters(
 
 
 def test_get_charts_history_rejects_invalid_chart_id_pattern(client: TestClient) -> None:
+    """chart_id がパターン不一致の場合に 422 を返すことを検証する。"""
     res = client.get("/charts/history", params={"chart_id": "CHART_INVALID"})
 
     assert res.status_code == 422
@@ -380,6 +393,7 @@ def test_get_charts_history_rejects_invalid_chart_id_pattern(client: TestClient)
 
 
 def test_get_charts_history_rejects_limit_exceeds_max(client: TestClient) -> None:
+    """limit が上限を超える場合に 422 を返すことを検証する。"""
     res = client.get("/charts/history", params={"limit": 501})
 
     assert res.status_code == 422
@@ -387,6 +401,7 @@ def test_get_charts_history_rejects_limit_exceeds_max(client: TestClient) -> Non
 
 
 def test_get_charts_history_rejects_negative_offset(client: TestClient) -> None:
+    """offset が負数の場合に 422 を返すことを検証する。"""
     res = client.get("/charts/history", params={"offset": -1})
 
     assert res.status_code == 422
@@ -394,6 +409,7 @@ def test_get_charts_history_rejects_negative_offset(client: TestClient) -> None:
 
 
 def test_get_charts_history_rejects_invalid_time_range(client: TestClient) -> None:
+    """to_ts が from_ts より前の場合に 400 を返すことを検証する。"""
     res = client.get(
         "/charts/history",
         params={
@@ -407,6 +423,7 @@ def test_get_charts_history_rejects_invalid_time_range(client: TestClient) -> No
 
 
 def test_get_charts_history_rejects_mixed_naive_and_aware_timestamps(client: TestClient) -> None:
+    """naive/aware 混在の timestamp 指定を 400 として拒否することを検証する。"""
     res = client.get(
         "/charts/history",
         params={
@@ -420,9 +437,136 @@ def test_get_charts_history_rejects_mixed_naive_and_aware_timestamps(client: Tes
 
 
 def test_get_charts_history_rejects_chart_id_out_of_int64_range(client: TestClient) -> None:
+    """int64 範囲外の chart_id 数値部を 400 として拒否することを検証する。"""
     # Try chart_id with numeric part exceeding int64 max (2**63 - 1)
     out_of_range_pk = 2**63
     res = client.get("/charts/history", params={"chart_id": f"CHART_{out_of_range_pk}"})
 
     assert res.status_code == 400
     assert res.json()["detail"] == "Invalid chart_id"
+
+
+def test_get_charts_history_allows_null_change_reason_and_changed_by(
+    client: TestClient,
+    seeded_charts_history_context: SeededChartsHistoryContext,
+) -> None:
+    """change_reason/changed_by が NULL の履歴を正しく返せることを検証する。"""
+    seeded = seeded_charts_history_context
+    chart_pk = int(seeded.chart_id.split("_", maxsplit=1)[1])
+
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        chart_row = con.execute(
+            """
+            SELECT tool_id, chamber_id, recipe_id, parameter, step_no, feature_type
+            FROM ChartsV2
+            WHERE id = ?
+            """,
+            (chart_pk,),
+        ).fetchone()
+        assert chart_row is not None
+
+        con.execute(
+            """
+            INSERT INTO ChartsHistory(
+                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                step_no, feature_type, old_warn_low, old_warn_high,
+                old_crit_low, old_crit_high, new_warn_low, new_warn_high,
+                new_crit_low, new_crit_high, changed_at, changed_by,
+                change_reason, change_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                seeded.chart_set_id,
+                chart_row[0],
+                chart_row[1],
+                chart_row[2],
+                chart_row[3],
+                chart_row[4],
+                chart_row[5],
+                1.0,
+                2.0,
+                0.8,
+                2.2,
+                1.1,
+                2.1,
+                0.9,
+                2.3,
+                "2026-04-14T00:03:00Z",
+                None,
+                None,
+                "null_field_test",
+            ),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    res = client.get(
+        "/charts/history",
+        params={
+            "chart_set_id": seeded.chart_set_id,
+            "change_source": "null_field_test",
+            "limit": 500,
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert len(body["data"]) == 1
+    row = body["data"][0]
+    assert row["change_reason"] is None
+    assert row["changed_by"] is None
+
+
+def test_get_charts_history_returns_503_then_recovers_from_transient_db_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """一時的 DB エラーで 503 を返し、その後回復できることを検証する。"""
+    calls = {"count": 0}
+
+    def flaky_find_chart_history(*args, **kwargs):
+        """初回のみ一時的な OperationalError を発生させる。"""
+        _ = args, kwargs
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return []
+
+    monkeypatch.setattr(
+        db_app._chart_repository,
+        "find_chart_history",
+        flaky_find_chart_history,
+    )
+
+    first = client.get("/charts/history")
+    assert first.status_code == 503
+    assert first.json()["detail"] == "Database temporarily unavailable"
+
+    second = client.get("/charts/history")
+    assert second.status_code == 200
+    assert second.json() == {"ok": True, "data": []}
+
+
+def test_get_charts_history_returns_500_for_non_transient_sql_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """恒久的 SQL エラーを 500 へマッピングすることを検証する。"""
+
+    def broken_find_chart_history(*args, **kwargs):
+        """恒久障害を示す OperationalError を発生させる。"""
+        _ = args, kwargs
+        raise sqlite3.OperationalError("no such table: ChartsHistory")
+
+    monkeypatch.setattr(
+        db_app._chart_repository,
+        "find_chart_history",
+        broken_find_chart_history,
+    )
+
+    res = client.get("/charts/history")
+    assert res.status_code == 500
+    assert res.json()["detail"] == "Database operation failed"

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -281,3 +281,12 @@ def test_get_charts_history_rejects_invalid_time_range(client: TestClient) -> No
 
     assert res.status_code == 400
     assert "end_ts must be greater than or equal to start_ts" in res.json()["detail"]
+
+
+def test_get_charts_history_rejects_chart_id_out_of_int64_range(client: TestClient) -> None:
+    # Try chart_id with numeric part exceeding int64 max (2**63 - 1)
+    out_of_range_pk = 2**63
+    res = client.get("/charts/history", params={"chart_id": f"CHART_{out_of_range_pk}"})
+
+    assert res.status_code == 400
+    assert "out of int64 range" in res.json()["detail"]

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -349,6 +349,13 @@ def test_get_charts_history_rejects_limit_exceeds_max(client: TestClient) -> Non
     assert_validation_error_envelope(res.json(), expected_loc_fragment="limit")
 
 
+def test_get_charts_history_rejects_negative_offset(client: TestClient) -> None:
+    res = client.get("/charts/history", params={"offset": -1})
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="offset")
+
+
 def test_get_charts_history_rejects_invalid_time_range(client: TestClient) -> None:
     res = client.get(
         "/charts/history",

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from portfolio_fdc.db_api import app as db_app
@@ -444,6 +445,27 @@ def test_get_charts_history_rejects_chart_id_out_of_int64_range(client: TestClie
 
     assert res.status_code == 400
     assert res.json()["detail"] == "Invalid chart_id"
+
+
+@pytest.mark.parametrize(
+    "raw_chart_id",
+    [
+        "CHART_",
+        "CHART_not_number",
+        "CHART_1_2",
+        "CHART__1",
+        "CHART",
+    ],
+)
+def test_parse_chart_pk_rejects_malformed_values_without_pattern_validation(
+    raw_chart_id: str,
+) -> None:
+    """_parse_chart_pk が不正形式を 400/Invalid chart_id へ正規化することを検証する。"""
+    with pytest.raises(HTTPException) as exc_info:
+        db_app._parse_chart_pk(raw_chart_id)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid chart_id"
 
 
 def test_get_charts_history_allows_null_change_reason_and_changed_by(

--- a/tests/test_db_api_charts_history_endpoint.py
+++ b/tests/test_db_api_charts_history_endpoint.py
@@ -622,11 +622,11 @@ def test_get_charts_history_allows_null_change_reason_and_changed_by(
     assert row["changed_by"] is None
 
 
-def test_get_charts_history_returns_empty_for_deleted_chart_id_filter(
+def test_get_charts_history_preserves_deleted_chart_id_filter_results(
     client: TestClient,
     seeded_charts_history_context: SeededChartsHistoryContext,
 ) -> None:
-    """削除済み chart は chart_id フィルタでは取得できないことを明示的に検証する。"""
+    """削除済み chart でも chart_id フィルタで履歴取得できることを検証する。"""
     seeded = seeded_charts_history_context
     chart_pk = int(seeded.chart_id.split("_", maxsplit=1)[1])
 
@@ -639,7 +639,10 @@ def test_get_charts_history_returns_empty_for_deleted_chart_id_filter(
 
     by_chart_id = client.get("/charts/history", params={"chart_id": seeded.chart_id})
     assert by_chart_id.status_code == 200
-    assert by_chart_id.json() == {"ok": True, "data": []}
+    by_chart_id_body = by_chart_id.json()
+    assert by_chart_id_body["ok"] is True
+    assert len(by_chart_id_body["data"]) == 100
+    assert all(item["chart_id"] == seeded.chart_id for item in by_chart_id_body["data"])
 
     by_chart_set = client.get(
         "/charts/history",


### PR DESCRIPTION
## Summary
- Implement GET /charts/history in OOP style aligned with GET /charts
- Add repository query criteria/DTO and history fetch method with filters + pagination
- Add endpoint contract tests for success, validation, timestamp normalization, and bounds
- Update endpoint catalog status for /charts/history to implemented

## Changes
- app: add GET /charts/history endpoint and query handling
- repository: add ChartsHistoryQueryCriteria, ChartHistoryView, and find_chart_history
- tests: add 	ests/test_db_api_charts_history_endpoint.py
- docs: update docs/db-api-endpoints.md

## Validation
- E:/work/python/logger/.venv/Scripts/python.exe -m pytest -q tests/test_db_api_charts_history_endpoint.py tests/test_db_api_charts_endpoint.py tests/test_db_api_active_charts_endpoint.py
- pre-commit hooks passed on commit (ruff, mypy, import-linter)

## Related
- Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 実装概要
  - GET /charts/history を追加。
    - app.py：CHART_ID_PATTERN、_normalize_query_datetime、_parse_chart_pk を追加。from_ts/to_ts は timezone-aware を要求し UTC ミリ秒精度に正規化。chart_id (CHART_<digits> → 内部 int、>=1、int64 範囲検証)、chart_set_id、change_source、from_ts、to_ts、limit、offset を受けて ChartsHistoryQueryCriteria を構築し、リポジトリ呼び出し結果を {"ok": True, "data": [...]} で返す。入力検証（範囲・整合性）と DB エラー→HTTP マッピングを実装。
    - chart_repository.py：ChartsHistoryQueryCriteria、ChartThresholdSnapshot、ChartHistoryView を追加。ChartRepository.find_chart_history を実装（可変 WHERE、changed_at 降順→id 降順、LIMIT/OFFSET、行→View マッピング）。_to_chart_history_view で changed_at を UTC ミリ秒 ISO‑8601 に正規化。
    - DB マイグレーション：ChartsHistory に nullable な chart_id カラムを追加し、既存行を ChartsV2 に基づきバックフィルする処理を導入（既に存在する場合は ALTER を無視）。
    - ドキュメント：docs/db-api-endpoints.md と docs/db-api-minimum-contract.md を更新し /charts/history を implemented と記載、timezone-aware 要件と chart_id フィルタが現存する ChartsV2 行に限定されることを明記。README と pyproject.toml に SQLite >= 3.38 の注意を追加。
  - 追加修正（コミット）
    - 「fix: preserve chart history for deleted charts」コミットで、history の除外を招く JOIN 条件を修正して削除された ChartsV2 行に紐づく孤立履歴を保持する対応を適用。SQLite の timezone 挙動ガード（テスト/CI 実行時のバージョンチェック）を含む。

- 振る舞い（契約）
  - クエリ: chart_id (CHART_[0-9]+ → 内部 int、>=1、int64 範囲外で 400 "Invalid chart_id"), chart_set_id, change_source, from_ts/to_ts（tz-aware 必須）、limit（デフォルト100、最大500）、offset（>=0）。
  - from_ts>to_ts は 400。ソートは changed_at 降順、id 降順。offset が総件数を超えると空配列を返す。
  - レスポンス: 200 + {"ok": true, "data": [ChartHistoryView…]}。各レコードに history_id, chart_id, chart_set_id, change_source, change_reason, before, after, changed_by, changed_at（UTC ミリ秒 ISO‑8601, Z）を含む。NULL カラムは JSON null のまま返却。

- テスト
  - tests/test_db_api_charts_history_endpoint.py を追加（SQLite にシードした E2E 風）。120 件を種別化してシードし、正常系／異常系を多数検証。
  - 正常系：200 応答、必須フィールド・ID 形式、changed_at の +09:00→Z 正規化（ミリ秒精度）、before/after、デフォルト limit=100、chart_id/change_source フィルタ、limit/offset ページング、NULL 値透過、時間ウィンドウ境界の包含等を検証。
  - 異常系：chart_id 形式不正で 422、limit/offset/chart_set_id 境界で 422、from_ts>to_ts や naive/aware 混在で 400、chart_id の int64 超で 400 ("Invalid chart_id")、DB の transient エラー→503 / non-transient→500 マッピングを検証。
  - CI テストガード：tests/conftest.py に SQLite >= 3.38 のランタイムチェックを追加（テスト実行環境での日時比較挙動を保証）。

- リスク
  - JOIN による履歴欠落（修正済/検討事項）：
    - 元の実装では LEFT JOIN + WHERE により ChartsV2 が削除されたチャートの履歴が除外されうる問題があった。コミットでクエリ修正（ChartsHistory.chart_id を直接参照）して孤立履歴を保持する対応が入っているが、設計・ドキュメント上の意図を再確認することを推奨。
  - SQLite datetime() のバージョン依存：
    - changed_at のフィルタリングが SQLite >= 3.38 の挙動に依存するため、古い SQLite ではタイムゾーンつき日時比較が誤動作する可能性がある。README とテストガードで注意喚起済みだが、CI やデプロイ環境での保証が必要。
  - テストフィクスチャ掃除ミス：
    - teardown の DELETE 文がスキーマの実際の PK 列名と不一致だとクリーンアップ漏れを招く可能性あり。フィクスチャ削除クエリの列名確認を推奨。
  - tz‑naive 入力の扱い：
    - 実装は tz‑naive を拒否（400）するが、既存クライアントの期待と合わないリスクあり。仕様として明示または受容ポリシーの再検討を推奨。
  - ページング一貫性・性能：
    - 大きな offset や並行更新下での一貫性・性能影響は未評価。必要ならカーソル方式やインデックス最適化を検討。

- テストギャップ（推奨追加）
  - from_ts == to_ts の等値境界（単一レコード含有）の明示テスト（現在指摘はあるが専用ケースが望ましい）。
  - 両方 tz‑naive を与えた場合の動作（拒否か暗黙 UTC 扱いか）を確認するテスト。
  - chart_id フィルタ時に対応する ChartsV2 行が削除されたケースでの明確な検証（孤立履歴の挙動を保証する回帰テスト）。
  - 実データ存在下でデフォルト limit=100 が確実に 100 件を上限として返すことの明示テスト（現在一部テストで空配列を許容している）。
  - chart_set_id=0 や limit=0 等の境界値テスト（期待される 4xx 挙動の明示）。
  - change_source の大文字小文字（case-sensitivity）挙動を明示するテスト。
  - CI における SQLite バージョン保証（ランタイムチェック＋必要ならイメージ/ジョブ設定）を追加してタイムフィルタ前提を強制。

- 総評
  - フィルタ、ページング、タイムスタンプ正規化、主要な正常/異常系の実装と多数のエンドツーエンド風テストが揃っており、契約要件は広く満たされている。だが（1）ChartsV2 との結合に起因する履歴の取りこぼしの設計的扱い、（2）SQLite のバージョン依存、（3）テストフィクスチャの堅牢性、（4）tz‑naive 入力方針、および（5）大規模ページングの一貫性・性能については追加のドキュメント化・回帰テスト・運用保証を推奨する。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->