### PR TITLE
Add dashboard baseline and waveform drilldown

### DIFF
--- a/docs/issues/child-dashboard-read-only-baseline.md
+++ b/docs/issues/child-dashboard-read-only-baseline.md
@@ -1,0 +1,54 @@
+Title: Child - Dashboard Read-only Baseline (Phase 1)
+
+Parent
+
+- #102 [Governance] 変更ガバナンス方針の最終確定（通常PR必須 + 緊急変更例外）
+- 参照: #98 feat(db_api): add read endpoints for dashboard support
+
+Background
+
+- Phase 1 の read endpoint（/charts, /charts/active, /charts/history, /judge/results, /judge/results/{result_id}）が実装済みとなったため、dashboard の read-only baseline を着手可能な状態。
+- 編集系（governance approve/apply/emergency）は #102 配下の後続実装とし、本 Issue では参照表示に責務を限定する。
+
+Scope
+
+- dashboard の read-only baseline 画面実装
+  - chart 一覧表示（/charts）
+  - active chart set 表示（/charts/active）
+  - chart 履歴表示（/charts/history）
+  - judge 結果一覧/詳細ドリルダウン（/judge/results, /judge/results/{result_id}）
+- 表示ルールの適用
+  - 優先順位: NG > WARN > OK
+  - color band: Center/Warning/Critical
+- URL パラメータ経由の画面遷移最小対応（dashboard playbook 準拠）
+
+Out of Scope
+
+- しきい値編集・承認・適用操作
+- emergency change 実行 UI
+- 通知再送 UI
+
+Acceptance Criteria
+
+- read-only 画面から上記 5 endpoint の主要ユースケースを操作できる
+- API エラー時に envelope を解釈してユーザー向けメッセージを表示できる
+- judged_at / process_start_ts / changed_at など時刻表示が UTC ISO 8601 ミリ秒精度の入力を正しく扱う
+- NG/WARN/OK の優先表示と color band が playbook 仕様に一致する
+- dashboard から DB へ直接接続せず、db_api 経由のみで取得する
+
+Tests
+
+- 受け入れテスト: 主要表示フロー（一覧/詳細/履歴/ドリルダウン）
+- 契約テスト: 必須フィールド欠落や 4xx/5xx 応答時の表示劣化なし
+- 回帰確認: 既存 db_api read endpoint 契約への非影響
+
+Docs
+
+- docs/dashboard-architecture-playbook.md（必要に応じて表示仕様追記）
+- docs/db-api-endpoints.md（consumer/tracking 注記が必要なら更新）
+
+Dependency Notes
+
+- Must: #128 完了（read endpoint 実装済み）
+- Must: #102 governance 実装とは分離し、read-only 範囲で先行
+- Follow-up: 編集系 UI は #102 配下 endpoint 実装後に別Issueで対応

--- a/docs/issues/child-judge-mvp.md
+++ b/docs/issues/child-judge-mvp.md
@@ -1,0 +1,57 @@
+Title: Child - Judge MVP (Phase 1)
+
+Parent
+
+- #102 [Governance] 変更ガバナンス方針の最終確定（通常PR必須 + 緊急変更例外）
+- 参照: #85 [Architecture] judge モジュールの設計前提確定
+- 参照: #109 [API Contract] しきい値更新APIの競合制御・監査・必須テスト仕様を確定
+
+Background
+
+- 判定ロジックの最小実装（MVP）を先行し、dashboard read-only baseline へ結果を供給できる状態を作る。
+- governance の編集承認フロー実装前でも、read path と運用監視の基盤を進める。
+
+Scope
+
+- judge MVP の実装
+  - warning / critical 判定ロジック
+  - 同一 run 内の評価対象データ取得（db_api read path 準拠）
+  - 判定結果の保存（JudgementResults）
+  - 通知送信（warning/critical）
+  - critical 時の停止 API 呼び出しフック
+- 監査可能性の担保
+  - stop_api_called / stop_api_status の記録
+  - 判定時刻・入力特徴量・参照 chart のトレース情報保持
+
+Out of Scope
+
+- suppression 高度化（重複通知最適化の拡張）
+- 複雑な運転モード別ポリシー
+- governance 承認状態を加味した編集反映制御
+
+Acceptance Criteria
+
+- warning/critical のしきい値判定が docs 方針どおり動作する
+- warning/critical いずれも通知処理が実行される
+- critical で停止 API 呼び出しが行われ、結果が記録される
+- stop API 失敗時でも judge 全体が異常終了せず、結果に失敗状態を残せる
+- db_api read endpoint の契約変更なしで judge が必要データを取得できる
+
+Tests
+
+- 単体テスト: 判定境界（LCL/UCL 付近、WARN/NG 遷移）
+- 単体テスト: 通知分岐（OK/WARN/NG）
+- 単体テスト: 停止 API 成功/失敗/タイムアウト
+- 統合テスト: 入力 -> 判定 -> JudgementResults 記録 -> db_api /judge/results 参照
+- 回帰確認: 既存 ingest/db_api の write/read フローに非影響
+
+Docs
+
+- docs/decision-log.md（判定/通知/停止 API 実装判断を追記）
+- docs/dashboard-architecture-playbook.md（judge 結果表示契約に変更があれば更新）
+
+Dependency Notes
+
+- Must: #128 完了（judge 結果参照 endpoint が利用可能）
+- Must: #98 の read path 方針準拠（dashboard/judge は db_api 経由）
+- Should: #102 の governance endpoint 実装と独立に MVP を先行し、後で編集フローと統合

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,11 @@ requires-python = ">=3.11"
 # UTC ISO 8601 before they reach these comparisons; SQLite < 3.38 may parse
 # those strings incorrectly and silently produce wrong filter results.
 dependencies = [
+  "dash>=2.18",
   "fastapi>=0.115",
   "numpy>=2.4.2",
   "pandas>=3.0.1",
+  "plotly>=5.24",
   "pydantic>=2.8",
   "PyYAML>=6.0",
   "requests>=2.32.5",

--- a/src/portfolio_fdc/dashboard/api_client.py
+++ b/src/portfolio_fdc/dashboard/api_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NoReturn
 
 import requests
 
@@ -94,19 +94,31 @@ def _request_envelope(
     return payload.get("data")
 
 
+def _raise_invalid_shape(endpoint: str, expected: str, actual: Any) -> NoReturn:
+    raise APIError(
+        message=(f"Malformed API response for {endpoint}: expected {expected}, got {actual!r}")
+    )
+
+
 def get_charts(base_url: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
     data = _request_envelope(base_url, "/charts", params=params)
-    return data if isinstance(data, list) else []
+    if not isinstance(data, list):
+        _raise_invalid_shape("/charts", "list", data)
+    return data
 
 
 def get_active_charts(base_url: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     data = _request_envelope(base_url, "/charts/active", params=params)
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        _raise_invalid_shape("/charts/active", "dict", data)
+    return data
 
 
 def get_charts_history(base_url: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
     data = _request_envelope(base_url, "/charts/history", params=params)
-    return data if isinstance(data, list) else []
+    if not isinstance(data, list):
+        _raise_invalid_shape("/charts/history", "list", data)
+    return data
 
 
 def get_chart_points(
@@ -115,7 +127,9 @@ def get_chart_points(
     params: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     data = _request_envelope(base_url, f"/charts/{chart_id}/points", params=params)
-    return data if isinstance(data, list) else []
+    if not isinstance(data, list):
+        _raise_invalid_shape(f"/charts/{chart_id}/points", "list", data)
+    return data
 
 
 def get_process_waveform_preview(
@@ -128,14 +142,20 @@ def get_process_waveform_preview(
         f"/processes/{process_id}/waveform-preview",
         params=params,
     )
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        _raise_invalid_shape(f"/processes/{process_id}/waveform-preview", "dict", data)
+    return data
 
 
 def get_judge_results(base_url: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
     data = _request_envelope(base_url, "/judge/results", params=params)
-    return data if isinstance(data, list) else []
+    if not isinstance(data, list):
+        _raise_invalid_shape("/judge/results", "list", data)
+    return data
 
 
 def get_judge_result(base_url: str, result_id: str) -> dict[str, Any]:
     data = _request_envelope(base_url, f"/judge/results/{result_id}")
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        _raise_invalid_shape(f"/judge/results/{result_id}", "dict", data)
+    return data

--- a/src/portfolio_fdc/dashboard/api_client.py
+++ b/src/portfolio_fdc/dashboard/api_client.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import requests
+
+DEFAULT_TIMEOUT_SEC = 8.0
+
+
+@dataclass(frozen=True)
+class APIError(Exception):
+    """db_api 呼び出し失敗時の表示向けエラー情報。"""
+
+    message: str
+    code: str | None = None
+    status_code: int | None = None
+
+
+def parse_utc_millis(timestamp: str | None) -> str:
+    """UTC ISO 8601 文字列を見やすい UTC 表示へ変換する。"""
+    if not timestamp:
+        return "-"
+
+    raw = timestamp
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+
+    try:
+        dt = datetime.fromisoformat(raw).astimezone(UTC)
+    except ValueError:
+        return timestamp
+
+    return dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + " UTC"
+
+
+def parse_api_error(payload: dict[str, Any] | None, status_code: int) -> APIError:
+    """error envelope を表示可能なエラーへ正規化する。"""
+    if not isinstance(payload, dict):
+        return APIError(
+            message=f"API error (status={status_code})",
+            status_code=status_code,
+        )
+
+    error = payload.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        message = error.get("message")
+        if isinstance(message, str) and message:
+            return APIError(
+                message=message,
+                code=code if isinstance(code, str) else None,
+                status_code=status_code,
+            )
+
+    detail = payload.get("detail")
+    if isinstance(detail, str) and detail:
+        return APIError(message=detail, status_code=status_code)
+
+    return APIError(message=f"API error (status={status_code})", status_code=status_code)
+
+
+def _request_envelope(
+    base_url: str,
+    path: str,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    url = f"{base_url.rstrip('/')}{path}"
+    try:
+        response = requests.get(url, params=params, timeout=DEFAULT_TIMEOUT_SEC)
+    except requests.RequestException as exc:
+        raise APIError(message=f"Network error: {exc}") from exc
+
+    payload: dict[str, Any] | None = None
+    try:
+        payload = response.json()
+    except ValueError:
+        if response.status_code >= 400:
+            raise APIError(
+                message=f"API error (status={response.status_code})",
+                status_code=response.status_code,
+            ) from None
+
+    if response.status_code >= 400:
+        raise parse_api_error(payload, response.status_code)
+
+    if not isinstance(payload, dict):
+        raise APIError(message="Invalid response envelope")
+
+    if payload.get("ok") is not True:
+        raise parse_api_error(payload, response.status_code)
+
+    return payload.get("data")
+
+
+def get_charts(base_url: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    data = _request_envelope(base_url, "/charts", params=params)
+    return data if isinstance(data, list) else []
+
+
+def get_active_charts(base_url: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = _request_envelope(base_url, "/charts/active", params=params)
+    return data if isinstance(data, dict) else {}
+
+
+def get_charts_history(base_url: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    data = _request_envelope(base_url, "/charts/history", params=params)
+    return data if isinstance(data, list) else []
+
+
+def get_chart_points(
+    base_url: str,
+    chart_id: str,
+    params: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    data = _request_envelope(base_url, f"/charts/{chart_id}/points", params=params)
+    return data if isinstance(data, list) else []
+
+
+def get_process_waveform_preview(
+    base_url: str,
+    process_id: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    data = _request_envelope(
+        base_url,
+        f"/processes/{process_id}/waveform-preview",
+        params=params,
+    )
+    return data if isinstance(data, dict) else {}
+
+
+def get_judge_results(base_url: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    data = _request_envelope(base_url, "/judge/results", params=params)
+    return data if isinstance(data, list) else []
+
+
+def get_judge_result(base_url: str, result_id: str) -> dict[str, Any]:
+    data = _request_envelope(base_url, f"/judge/results/{result_id}")
+    return data if isinstance(data, dict) else {}

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -482,6 +482,13 @@ def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: s
     detail_block: Any = html.Div("Select/enter result_id to load detail")
     if detail is not None:
         level = str(detail.get("level", ""))
+        judged_at_val = parse_utc_millis(
+            str(detail.get("judged_at")) if detail.get("judged_at") else None
+        )
+        process_start_ts_val = parse_utc_millis(
+            str(detail.get("process_start_ts")) if detail.get("process_start_ts") else None
+        )
+
         detail_block = html.Pre(
             "\n".join(
                 [
@@ -495,8 +502,8 @@ def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: s
                         f"warn[{detail.get('warning_lcl')}, {detail.get('warning_ucl')}], "
                         f"crit[{detail.get('critical_lcl')}, {detail.get('critical_ucl')}]"
                     ),
-                    f"judged_at: {parse_utc_millis(str(detail.get('judged_at')))}",
-                    f"process_start_ts: {parse_utc_millis(str(detail.get('process_start_ts')))}",
+                    f"judged_at: {judged_at_val}",
+                    f"process_start_ts: {process_start_ts_val}",
                 ]
             ),
             style={

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -4,7 +4,7 @@ import os
 from typing import Any, cast
 from urllib.parse import parse_qs, urlencode
 
-from dash import Dash, Input, Output, State, dash_table, dcc, html, no_update
+from dash import Dash, Input, Output, State, callback_context, dash_table, dcc, html, no_update
 
 from .api_client import (
     APIError,
@@ -126,19 +126,25 @@ def sync_filters_from_url(search: str) -> tuple[str, str, str, str]:
     Output("error-banner", "children"),
     Input("tabs", "value"),
     Input("load-btn", "n_clicks"),
-    Input("base-url", "value"),
-    Input("recipe-id", "value"),
-    Input("chart-id", "value"),
-    Input("result-id", "value"),
+    State("base-url", "value"),
+    State("recipe-id", "value"),
+    State("chart-id", "value"),
+    State("result-id", "value"),
 )
 def load_data(
     active_tab: str,
-    _n_clicks: int,
+    n_clicks: int,
     base_url: str,
     recipe_id: str,
     chart_id: str,
     result_id: str,
 ) -> tuple[Any, str]:
+    triggered_id = callback_context.triggered_id
+    if triggered_id != "load-btn":
+        if n_clicks and n_clicks > 0:
+            return no_update, ""
+        return html.Div("Press Load to fetch data"), ""
+
     try:
         if active_tab == "charts":
             return _render_charts_tab(base_url, recipe_id), ""
@@ -156,16 +162,19 @@ def load_data(
     Output("chart-name", "options"),
     Output("chart-name", "value"),
     Input("load-btn", "n_clicks"),
-    Input("base-url", "value"),
-    Input("recipe-id", "value"),
-    Input("chart-id", "value"),
+    State("base-url", "value"),
+    State("recipe-id", "value"),
+    State("chart-id", "value"),
 )
 def refresh_chart_name_options(
-    _n_clicks: int,
+    n_clicks: int,
     base_url: str,
     recipe_id: str,
     chart_id: str,
 ) -> tuple[list[dict[str, str]], str | None]:
+    if not n_clicks:
+        return [], None
+
     params: dict[str, Any] = {}
     if recipe_id:
         params["recipe_id"] = recipe_id
@@ -258,7 +267,19 @@ def _render_charts_tab(base_url: str, recipe_id: str) -> html.Div:
                 str(row.get("updated_at")) if row.get("updated_at") else None
             ),
             "open": (
-                f"[Open](?tab=active&chart_id={row.get('chart_id')}&recipe_id={recipe_id})"
+                (
+                    "[Open](?"
+                    + urlencode(
+                        {
+                            "tab": "active",
+                            "chart_id": str(row.get("chart_id")),
+                            "recipe_id": recipe_id,
+                        },
+                        doseq=False,
+                        safe="",
+                    )
+                    + ")"
+                )
                 if row.get("chart_id")
                 else ""
             ),
@@ -468,11 +489,15 @@ def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: s
         rid = row.get("result_id")
         if not isinstance(rid, str):
             continue
-        href = f"?tab=judge&result_id={rid}"
+        params_for_href: dict[str, str] = {
+            "tab": "judge",
+            "result_id": rid,
+        }
         if recipe_id:
-            href += f"&recipe_id={recipe_id}"
+            params_for_href["recipe_id"] = recipe_id
         if chart_id:
-            href += f"&chart_id={chart_id}"
+            params_for_href["chart_id"] = chart_id
+        href = f"?{urlencode(params_for_href, doseq=False, safe='')}"
         drilldown_links.append(html.Li(html.A(rid, href=href)))
 
     detail: dict[str, Any] | None = None

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -126,10 +126,10 @@ def sync_filters_from_url(search: str) -> tuple[str, str, str, str]:
     Output("error-banner", "children"),
     Input("tabs", "value"),
     Input("load-btn", "n_clicks"),
-    State("base-url", "value"),
-    State("recipe-id", "value"),
-    State("chart-id", "value"),
-    State("result-id", "value"),
+    Input("base-url", "value"),
+    Input("recipe-id", "value"),
+    Input("chart-id", "value"),
+    Input("result-id", "value"),
 )
 def load_data(
     active_tab: str,
@@ -156,9 +156,9 @@ def load_data(
     Output("chart-name", "options"),
     Output("chart-name", "value"),
     Input("load-btn", "n_clicks"),
-    State("base-url", "value"),
-    State("recipe-id", "value"),
-    State("chart-id", "value"),
+    Input("base-url", "value"),
+    Input("recipe-id", "value"),
+    Input("chart-id", "value"),
 )
 def refresh_chart_name_options(
     _n_clicks: int,
@@ -186,8 +186,6 @@ def refresh_chart_name_options(
 
     if chart_id and any(opt["value"] == chart_id for opt in options):
         return options, chart_id
-    if options:
-        return options, options[0]["value"]
     return options, None
 
 
@@ -546,4 +544,7 @@ def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: s
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8050, debug=True)
+    host = os.getenv("HOST", "127.0.0.1")
+    port = int(os.getenv("PORT", "8050"))
+    debug = os.getenv("DEBUG", "false").strip().lower() in {"1", "true", "yes", "on"}
+    app.run(host=host, port=port, debug=debug)

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -4,7 +4,7 @@ import os
 from typing import Any, cast
 from urllib.parse import parse_qs, urlencode
 
-from dash import Dash, Input, Output, State, callback_context, dash_table, dcc, html, no_update
+from dash import Dash, Input, Output, State, dash_table, dcc, html, no_update
 
 from .api_client import (
     APIError,
@@ -139,10 +139,7 @@ def load_data(
     chart_id: str,
     result_id: str,
 ) -> tuple[Any, str]:
-    triggered_id = callback_context.triggered_id
-    if triggered_id != "load-btn":
-        if n_clicks and n_clicks > 0:
-            return no_update, ""
+    if not n_clicks:
         return html.Div("Press Load to fetch data"), ""
 
     try:

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 
 def _default_allowed_db_api_hosts() -> set[str]:
-    hosts = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+    hosts = {"localhost", "127.0.0.1", "::1"}
     parsed_default = urlparse(DEFAULT_DB_API_BASE_URL)
     if parsed_default.hostname:
         hosts.add(parsed_default.hostname.lower())
@@ -70,26 +70,37 @@ def validate_base_url(base_url: str) -> str:
         raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
 
     parsed = urlparse(raw_value)
+    log_target = f"{parsed.scheme or '-'}://{parsed.hostname or '-'}"
+
+    has_credentials = bool(parsed.username or parsed.password or "@" in parsed.netloc)
+    if has_credentials:
+        logger.warning("Rejected db_api base URL with credentials: %s", log_target)
+        raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
+
     if parsed.scheme not in {"http", "https"}:
-        logger.warning("Rejected db_api base URL with unsupported scheme: %s", raw_value)
+        logger.warning("Rejected db_api base URL with unsupported scheme: %s", log_target)
         raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
 
     if not parsed.hostname:
-        logger.warning("Rejected db_api base URL without hostname: %s", raw_value)
+        logger.warning("Rejected db_api base URL without hostname: %s", log_target)
         raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
 
     if parsed.path not in {"", "/"} or parsed.params or parsed.query or parsed.fragment:
-        logger.warning("Rejected db_api base URL with path/query/fragment: %s", raw_value)
+        logger.warning("Rejected db_api base URL with path/query/fragment: %s", log_target)
         raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
 
     hostname = parsed.hostname.lower()
+    safe_base_url = f"{parsed.scheme}://{hostname}"
+    if parsed.port is not None:
+        safe_base_url = f"{safe_base_url}:{parsed.port}"
+
     if hostname in _allowed_db_api_hosts():
-        return raw_value.rstrip("/")
+        return safe_base_url
 
     try:
         resolved = socket.getaddrinfo(hostname, parsed.port or 80, type=socket.SOCK_STREAM)
     except OSError:
-        logger.warning("Rejected db_api base URL; hostname resolution failed: %s", raw_value)
+        logger.warning("Rejected db_api base URL; hostname resolution failed: %s", log_target)
         raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL") from None
 
     for result in resolved:
@@ -100,13 +111,13 @@ def validate_base_url(base_url: str) -> str:
         try:
             ip_value = ipaddress.ip_address(candidate_ip)
         except ValueError:
-            logger.warning("Rejected db_api base URL; invalid resolved IP: %s", raw_value)
+            logger.warning("Rejected db_api base URL; invalid resolved IP: %s", log_target)
             raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL") from None
         if _is_restricted_ip(ip_value):
-            logger.warning("Rejected db_api base URL; restricted network target: %s", raw_value)
+            logger.warning("Rejected db_api base URL; restricted network target: %s", log_target)
             raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
 
-    return raw_value.rstrip("/")
+    return safe_base_url
 
 
 app = Dash(__name__, suppress_callback_exceptions=True, title="FDC Dashboard Baseline")

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -1,0 +1,548 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import parse_qs, urlencode
+
+from dash import Dash, Input, Output, State, dash_table, dcc, html, no_update
+
+from .api_client import (
+    APIError,
+    get_active_charts,
+    get_chart_points,
+    get_charts,
+    get_charts_history,
+    get_judge_result,
+    get_judge_results,
+    get_process_waveform_preview,
+    parse_utc_millis,
+)
+from .view_models import (
+    LEVEL_COLOR,
+    build_chart_name,
+    empty_drilldown_figure,
+    format_range,
+    sort_judge_rows,
+    spc_band_with_points_figure,
+    waveform_figure,
+)
+
+DEFAULT_DB_API_BASE_URL = os.getenv("PORTFOLIO_DB_API_URL", "http://localhost:8000")
+
+app = Dash(__name__, suppress_callback_exceptions=True, title="FDC Dashboard Baseline")
+DataTable: Any = dash_table.DataTable
+
+app.layout = html.Div(
+    [
+        dcc.Location(id="url", refresh=False),
+        html.H2("FDC Dashboard Read-only Baseline"),
+        html.Div(
+            "Issue #146 scope: /charts /charts/active /charts/history "
+            "/judge/results /judge/results/{id}"
+        ),
+        html.Div(
+            [
+                html.Label("db_api base URL"),
+                dcc.Input(
+                    id="base-url",
+                    type="text",
+                    value=DEFAULT_DB_API_BASE_URL,
+                    style={"width": "360px"},
+                ),
+                html.Label("recipe_id"),
+                dcc.Input(id="recipe-id", type="text", value="", style={"width": "220px"}),
+                html.Label("chart_id"),
+                dcc.Input(id="chart-id", type="text", value="", style={"width": "160px"}),
+                html.Label("chart_name"),
+                dcc.Dropdown(
+                    id="chart-name",
+                    options=[],
+                    value=None,
+                    placeholder="Select chart",
+                    style={"width": "500px"},
+                ),
+                html.Label("result_id"),
+                dcc.Input(id="result-id", type="text", value="", style={"width": "160px"}),
+                html.Button("Load", id="load-btn", n_clicks=0),
+            ],
+            style={
+                "display": "grid",
+                "gridTemplateColumns": "auto auto auto auto auto auto auto auto auto auto auto",
+                "gap": "8px",
+                "alignItems": "center",
+                "margin": "12px 0",
+            },
+        ),
+        html.Div(
+            id="error-banner",
+            style={"color": "#b00020", "fontWeight": "bold", "marginBottom": "8px"},
+        ),
+        dcc.Tabs(
+            id="tabs",
+            value="charts",
+            children=[
+                dcc.Tab(label="Charts", value="charts"),
+                dcc.Tab(label="Active", value="active"),
+                dcc.Tab(label="History", value="history"),
+                dcc.Tab(label="Judge", value="judge"),
+            ],
+        ),
+        html.Div(id="tab-content"),
+    ],
+    style={"padding": "12px", "fontFamily": "Segoe UI, sans-serif"},
+)
+
+
+def _get_query_value(query_string: str, key: str) -> str:
+    parsed = parse_qs((query_string or "").lstrip("?"))
+    values = parsed.get(key)
+    if not values:
+        return ""
+    return values[0]
+
+
+@app.callback(
+    Output("tabs", "value"),
+    Output("recipe-id", "value"),
+    Output("chart-id", "value"),
+    Output("result-id", "value"),
+    Input("url", "search"),
+    prevent_initial_call=False,
+)
+def sync_filters_from_url(search: str) -> tuple[str, str, str, str]:
+    tab = _get_query_value(search, "tab")
+    tab_value = tab if tab in {"charts", "active", "history", "judge"} else "charts"
+    return (
+        tab_value,
+        _get_query_value(search, "recipe_id"),
+        _get_query_value(search, "chart_id"),
+        _get_query_value(search, "result_id"),
+    )
+
+
+@app.callback(
+    Output("tab-content", "children"),
+    Output("error-banner", "children"),
+    Input("tabs", "value"),
+    Input("load-btn", "n_clicks"),
+    State("base-url", "value"),
+    State("recipe-id", "value"),
+    State("chart-id", "value"),
+    State("result-id", "value"),
+)
+def load_data(
+    active_tab: str,
+    _n_clicks: int,
+    base_url: str,
+    recipe_id: str,
+    chart_id: str,
+    result_id: str,
+) -> tuple[Any, str]:
+    try:
+        if active_tab == "charts":
+            return _render_charts_tab(base_url, recipe_id), ""
+        if active_tab == "active":
+            return _render_active_tab(base_url, recipe_id, chart_id), ""
+        if active_tab == "history":
+            return _render_history_tab(base_url, chart_id), ""
+        return _render_judge_tab(base_url, recipe_id, chart_id, result_id), ""
+    except APIError as exc:
+        code = f" [{exc.code}]" if exc.code else ""
+        return html.Div(""), f"{exc.message}{code}"
+
+
+@app.callback(
+    Output("chart-name", "options"),
+    Output("chart-name", "value"),
+    Input("load-btn", "n_clicks"),
+    State("base-url", "value"),
+    State("recipe-id", "value"),
+    State("chart-id", "value"),
+)
+def refresh_chart_name_options(
+    _n_clicks: int,
+    base_url: str,
+    recipe_id: str,
+    chart_id: str,
+) -> tuple[list[dict[str, str]], str | None]:
+    params: dict[str, Any] = {}
+    if recipe_id:
+        params["recipe_id"] = recipe_id
+
+    try:
+        rows = get_charts(base_url, params=params)
+    except APIError:
+        return [], None
+
+    options = [
+        {
+            "label": build_chart_name(row),
+            "value": str(row.get("chart_id") or ""),
+        }
+        for row in rows
+        if row.get("chart_id")
+    ]
+
+    if chart_id and any(opt["value"] == chart_id for opt in options):
+        return options, chart_id
+    if options:
+        return options, options[0]["value"]
+    return options, None
+
+
+@app.callback(
+    Output("tabs", "value", allow_duplicate=True),
+    Output("chart-id", "value", allow_duplicate=True),
+    Output("url", "search", allow_duplicate=True),
+    Input("chart-name", "value"),
+    State("recipe-id", "value"),
+    prevent_initial_call=True,
+)
+def move_to_active_by_chart_name(
+    selected_chart_id: str | None,
+    recipe_id: str,
+) -> tuple[str, str, str] | tuple[Any, Any, Any]:
+    if not selected_chart_id:
+        return no_update, no_update, no_update
+
+    params: dict[str, str] = {
+        "tab": "active",
+        "chart_id": selected_chart_id,
+    }
+    if recipe_id:
+        params["recipe_id"] = recipe_id
+
+    return "active", selected_chart_id, f"?{urlencode(params)}"
+
+
+@app.callback(
+    Output("chart-name", "value", allow_duplicate=True),
+    Input("charts-table", "active_cell"),
+    State("charts-table", "data"),
+    prevent_initial_call=True,
+)
+def select_chart_from_table(
+    active_cell: dict[str, Any] | None,
+    data: list[dict[str, Any]] | None,
+) -> str | Any:
+    if not active_cell or not data:
+        return no_update
+
+    row_idx = active_cell.get("row")
+    if not isinstance(row_idx, int) or row_idx < 0 or row_idx >= len(data):
+        return no_update
+
+    selected = data[row_idx].get("chart_id")
+    if not selected:
+        return no_update
+    return str(selected)
+
+
+def _render_charts_tab(base_url: str, recipe_id: str) -> html.Div:
+    params: dict[str, Any] = {}
+    if recipe_id:
+        params["recipe_id"] = recipe_id
+
+    rows = get_charts(base_url, params=params)
+    table_rows = [
+        {
+            "chart_id": row.get("chart_id"),
+            "is_active": row.get("is_active"),
+            "chart_name": build_chart_name(row),
+            "recipe_id": row.get("recipe_id"),
+            "parameter": row.get("parameter"),
+            "step_no": row.get("step_no"),
+            "feature_type": row.get("feature_type"),
+            "center": format_range(row.get("warning_lcl"), row.get("warning_ucl")),
+            "critical": format_range(row.get("critical_lcl"), row.get("critical_ucl")),
+            "updated_at": parse_utc_millis(
+                str(row.get("updated_at")) if row.get("updated_at") else None
+            ),
+            "open": (
+                f"[Open](?tab=active&chart_id={row.get('chart_id')}&recipe_id={recipe_id})"
+                if row.get("chart_id")
+                else ""
+            ),
+        }
+        for row in rows
+    ]
+
+    return html.Div(
+        [
+            html.H4(f"Charts: {len(table_rows)} rows"),
+            DataTable(
+                id="charts-table",
+                data=table_rows,
+                columns=(
+                    [
+                        {"name": "chart_id", "id": "chart_id"},
+                        {"name": "is_active", "id": "is_active"},
+                        {"name": "chart_name", "id": "chart_name"},
+                        {"name": "recipe_id", "id": "recipe_id"},
+                        {"name": "parameter", "id": "parameter"},
+                        {"name": "step_no", "id": "step_no"},
+                        {"name": "feature_type", "id": "feature_type"},
+                        {"name": "center", "id": "center"},
+                        {"name": "critical", "id": "critical"},
+                        {"name": "updated_at", "id": "updated_at"},
+                        {"name": "open", "id": "open", "presentation": "markdown"},
+                    ]
+                    if table_rows
+                    else []
+                ),
+                page_size=12,
+                markdown_options={"link_target": "_self"},
+                style_table={"overflowX": "auto"},
+            ),
+        ]
+    )
+
+
+def _render_active_tab(base_url: str, recipe_id: str, chart_id: str) -> html.Div:
+    params: dict[str, Any] = {}
+    if recipe_id:
+        params["recipe_id"] = recipe_id
+
+    data = get_active_charts(base_url, params=params)
+    charts = data.get("charts", []) if isinstance(data, dict) else []
+
+    selected_chart = charts[0] if charts else {}
+    selected_chart_id = str(selected_chart.get("chart_id")) if selected_chart else ""
+    if chart_id:
+        matched = [row for row in charts if str(row.get("chart_id")) == chart_id]
+        if matched:
+            selected_chart = matched[0]
+            selected_chart_id = chart_id
+
+    points: list[dict[str, Any]] = []
+    if selected_chart_id:
+        points = get_chart_points(
+            base_url,
+            chart_id=selected_chart_id,
+            params={"limit": 30},
+        )
+
+    figure = spc_band_with_points_figure(selected_chart, points)
+    activated_at = parse_utc_millis(
+        str(data.get("activated_at")) if data.get("activated_at") else None
+    )
+    rows = [
+        {
+            "chart_id": row.get("chart_id"),
+            "chart_name": build_chart_name(row),
+            "parameter": row.get("parameter"),
+            "step_no": row.get("step_no"),
+            "feature_type": row.get("feature_type"),
+            "warning": format_range(row.get("warning_lcl"), row.get("warning_ucl")),
+            "critical": format_range(row.get("critical_lcl"), row.get("critical_ucl")),
+        }
+        for row in charts
+    ]
+
+    return html.Div(
+        [
+            html.H4(
+                "Active chart_set="
+                f"{data.get('active_chart_set_id', '-')} / activated_at={activated_at}"
+            ),
+            html.Div(
+                f"Focused chart: {build_chart_name(selected_chart) if selected_chart else '-'}",
+                style={"marginBottom": "8px", "fontWeight": "bold"},
+            ),
+            dcc.Store(id="active-selected-base-url", data=base_url),
+            dcc.Graph(id="active-main-graph", figure=figure),
+            dcc.Graph(
+                id="active-drilldown-graph",
+                figure=empty_drilldown_figure(
+                    "Click a point in the top graph to show raw waveform"
+                ),
+            ),
+            DataTable(
+                data=rows,
+                columns=[{"name": col, "id": col} for col in rows[0].keys()] if rows else [],
+                page_size=10,
+                style_table={"overflowX": "auto"},
+            ),
+        ]
+    )
+
+
+@app.callback(
+    Output("active-drilldown-graph", "figure"),
+    Input("active-main-graph", "clickData"),
+    State("active-selected-base-url", "data"),
+    prevent_initial_call=True,
+)
+def render_active_drilldown(
+    click_data: dict[str, Any] | None,
+    base_url: str,
+) -> dict[str, Any]:
+    if not click_data:
+        return empty_drilldown_figure("Click a point in the top graph to show raw waveform")
+
+    points = click_data.get("points")
+    if not isinstance(points, list) or not points:
+        return empty_drilldown_figure("Click a feature point to show raw waveform")
+
+    point = points[0]
+    process_id = point.get("customdata")
+    if not isinstance(process_id, str) or not process_id:
+        return empty_drilldown_figure("Only feature points are clickable for drilldown")
+
+    try:
+        preview = get_process_waveform_preview(
+            base_url,
+            process_id,
+            params={"limit": 500},
+        )
+    except APIError as exc:
+        return empty_drilldown_figure(f"Failed to load waveform: {exc.message}")
+
+    wave_points = preview.get("points", []) if isinstance(preview, dict) else []
+    return waveform_figure(wave_points if isinstance(wave_points, list) else [], process_id)
+
+
+def _render_history_tab(base_url: str, chart_id: str) -> html.Div:
+    params: dict[str, Any] = {"limit": 100}
+    if chart_id:
+        params["chart_id"] = chart_id
+
+    rows = get_charts_history(base_url, params=params)
+    table_rows = [
+        {
+            "history_id": row.get("history_id"),
+            "chart_id": row.get("chart_id"),
+            "change_source": row.get("change_source"),
+            "change_reason": row.get("change_reason"),
+            "changed_by": row.get("changed_by"),
+            "changed_at": parse_utc_millis(
+                str(row.get("changed_at")) if row.get("changed_at") else None
+            ),
+        }
+        for row in rows
+    ]
+
+    return html.Div(
+        [
+            html.H4(f"History: {len(table_rows)} rows"),
+            DataTable(
+                data=table_rows,
+                columns=[{"name": col, "id": col} for col in table_rows[0].keys()]
+                if table_rows
+                else [],
+                page_size=12,
+                style_table={"overflowX": "auto"},
+            ),
+        ]
+    )
+
+
+def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: str) -> html.Div:
+    params: dict[str, Any] = {"limit": 200}
+    if recipe_id:
+        params["recipe_id"] = recipe_id
+    if chart_id:
+        params["chart_id"] = chart_id
+
+    rows = sort_judge_rows(get_judge_results(base_url, params=params))
+    table_rows = [
+        {
+            "result_id": row.get("result_id"),
+            "level": row.get("level"),
+            "chart_id": row.get("chart_id"),
+            "process_id": row.get("process_id"),
+            "lot_id": row.get("lot_id"),
+            "feature_type": row.get("feature_type"),
+            "feature_value": row.get("feature_value"),
+            "judged_at": parse_utc_millis(
+                str(row.get("judged_at")) if row.get("judged_at") else None
+            ),
+            "process_start_ts": parse_utc_millis(
+                str(row.get("process_start_ts")) if row.get("process_start_ts") else None
+            ),
+        }
+        for row in rows
+    ]
+
+    drilldown_links: list[html.Li] = []
+    for row in rows[:20]:
+        rid = row.get("result_id")
+        if not isinstance(rid, str):
+            continue
+        href = f"?tab=judge&result_id={rid}"
+        if recipe_id:
+            href += f"&recipe_id={recipe_id}"
+        if chart_id:
+            href += f"&chart_id={chart_id}"
+        drilldown_links.append(html.Li(html.A(rid, href=href)))
+
+    detail: dict[str, Any] | None = None
+    if result_id:
+        detail = get_judge_result(base_url, result_id=result_id)
+
+    detail_block: Any = html.Div("Select/enter result_id to load detail")
+    if detail is not None:
+        level = str(detail.get("level", ""))
+        detail_block = html.Pre(
+            "\n".join(
+                [
+                    f"result_id: {detail.get('result_id')}",
+                    f"level: {level}",
+                    f"chart_id: {detail.get('chart_id')}",
+                    f"process_id: {detail.get('process_id')}",
+                    f"feature: {detail.get('feature_type')}={detail.get('feature_value')}",
+                    (
+                        "thresholds: "
+                        f"warn[{detail.get('warning_lcl')}, {detail.get('warning_ucl')}], "
+                        f"crit[{detail.get('critical_lcl')}, {detail.get('critical_ucl')}]"
+                    ),
+                    f"judged_at: {parse_utc_millis(str(detail.get('judged_at')))}",
+                    f"process_start_ts: {parse_utc_millis(str(detail.get('process_start_ts')))}",
+                ]
+            ),
+            style={
+                "padding": "10px",
+                "backgroundColor": "#f5f5f5",
+                "borderLeft": f"6px solid {LEVEL_COLOR.get(level, '#555555')}",
+            },
+        )
+
+    return html.Div(
+        [
+            html.H4("Judge Results (priority: NG > WARN > OK)"),
+            html.Div(
+                [
+                    html.Div("Drilldown Links (URL parameter navigation)"),
+                    html.Ul(drilldown_links),
+                ]
+            ),
+            DataTable(
+                data=table_rows,
+                columns=(
+                    [{"name": col, "id": col} for col in table_rows[0].keys()] if table_rows else []
+                ),
+                page_size=12,
+                style_data_conditional=[
+                    {
+                        "if": {"filter_query": "{level} = NG"},
+                        "backgroundColor": "rgba(176,0,32,0.08)",
+                    },
+                    {
+                        "if": {"filter_query": "{level} = WARN"},
+                        "backgroundColor": "rgba(245,124,0,0.08)",
+                    },
+                    {
+                        "if": {"filter_query": "{level} = OK"},
+                        "backgroundColor": "rgba(46,125,50,0.08)",
+                    },
+                ],
+                style_table={"overflowX": "auto"},
+            ),
+            html.H4("Judge Result Detail"),
+            detail_block,
+        ]
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8050, debug=True)

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -89,16 +89,29 @@ def validate_base_url(base_url: str) -> str:
         logger.warning("Rejected db_api base URL with path/query/fragment: %s", log_target)
         raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
 
+    try:
+        parsed_port = parsed.port
+    except ValueError:
+        logger.warning("Rejected db_api base URL with invalid port: %s", log_target)
+        raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL") from None
+
+    if parsed_port == 0:
+        logger.warning("Rejected db_api base URL with disallowed port: %s", log_target)
+        raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
+
     hostname = parsed.hostname.lower()
-    safe_base_url = f"{parsed.scheme}://{hostname}"
-    if parsed.port is not None:
-        safe_base_url = f"{safe_base_url}:{parsed.port}"
+    bracketed_host = f"[{hostname}]" if ":" in hostname else hostname
+    safe_base_url = f"{parsed.scheme}://{bracketed_host}"
+    if parsed_port is not None:
+        safe_base_url = f"{safe_base_url}:{parsed_port}"
 
     if hostname in _allowed_db_api_hosts():
         return safe_base_url
 
+    resolve_host = bracketed_host[1:-1] if bracketed_host.startswith("[") else bracketed_host
+
     try:
-        resolved = socket.getaddrinfo(hostname, parsed.port or 80, type=socket.SOCK_STREAM)
+        resolved = socket.getaddrinfo(resolve_host, parsed_port or 80, type=socket.SOCK_STREAM)
     except OSError:
         logger.warning("Rejected db_api base URL; hostname resolution failed: %s", log_target)
         raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL") from None

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qs, urlencode
 
 from dash import Dash, Input, Output, State, dash_table, dcc, html, no_update
@@ -30,7 +30,8 @@ from .view_models import (
 DEFAULT_DB_API_BASE_URL = os.getenv("PORTFOLIO_DB_API_URL", "http://localhost:8000")
 
 app = Dash(__name__, suppress_callback_exceptions=True, title="FDC Dashboard Baseline")
-DataTable: Any = dash_table.DataTable
+typed_dash_table = cast(Any, dash_table)
+DataTable: Any = typed_dash_table.DataTable
 
 app.layout = html.Div(
     [

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import ipaddress
+import logging
 import os
+import socket
 from typing import Any, cast
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from dash import Dash, Input, Output, State, dash_table, dcc, html, no_update
 
@@ -28,6 +31,83 @@ from .view_models import (
 )
 
 DEFAULT_DB_API_BASE_URL = os.getenv("PORTFOLIO_DB_API_URL", "http://localhost:8000")
+logger = logging.getLogger(__name__)
+
+
+def _default_allowed_db_api_hosts() -> set[str]:
+    hosts = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+    parsed_default = urlparse(DEFAULT_DB_API_BASE_URL)
+    if parsed_default.hostname:
+        hosts.add(parsed_default.hostname.lower())
+    return hosts
+
+
+def _allowed_db_api_hosts() -> set[str]:
+    env_hosts = os.getenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", "")
+    hosts = _default_allowed_db_api_hosts()
+    for host in env_hosts.split(","):
+        normalized = host.strip().lower()
+        if normalized:
+            hosts.add(normalized)
+    return hosts
+
+
+def _is_restricted_ip(ip_value: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        ip_value.is_private
+        or ip_value.is_loopback
+        or ip_value.is_link_local
+        or ip_value.is_multicast
+        or ip_value.is_reserved
+        or ip_value.is_unspecified
+    )
+
+
+def validate_base_url(base_url: str) -> str:
+    raw_value = (base_url or "").strip()
+    if not raw_value:
+        logger.warning("Rejected empty db_api base URL")
+        raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
+
+    parsed = urlparse(raw_value)
+    if parsed.scheme not in {"http", "https"}:
+        logger.warning("Rejected db_api base URL with unsupported scheme: %s", raw_value)
+        raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
+
+    if not parsed.hostname:
+        logger.warning("Rejected db_api base URL without hostname: %s", raw_value)
+        raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
+
+    if parsed.path not in {"", "/"} or parsed.params or parsed.query or parsed.fragment:
+        logger.warning("Rejected db_api base URL with path/query/fragment: %s", raw_value)
+        raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
+
+    hostname = parsed.hostname.lower()
+    if hostname in _allowed_db_api_hosts():
+        return raw_value.rstrip("/")
+
+    try:
+        resolved = socket.getaddrinfo(hostname, parsed.port or 80, type=socket.SOCK_STREAM)
+    except OSError:
+        logger.warning("Rejected db_api base URL; hostname resolution failed: %s", raw_value)
+        raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL") from None
+
+    for result in resolved:
+        sockaddr = result[4]
+        if not sockaddr:
+            continue
+        candidate_ip = sockaddr[0]
+        try:
+            ip_value = ipaddress.ip_address(candidate_ip)
+        except ValueError:
+            logger.warning("Rejected db_api base URL; invalid resolved IP: %s", raw_value)
+            raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL") from None
+        if _is_restricted_ip(ip_value):
+            logger.warning("Rejected db_api base URL; restricted network target: %s", raw_value)
+            raise APIError(message="Invalid db_api base URL", code="INVALID_BASE_URL")
+
+    return raw_value.rstrip("/")
+
 
 app = Dash(__name__, suppress_callback_exceptions=True, title="FDC Dashboard Baseline")
 typed_dash_table = cast(Any, dash_table)
@@ -143,13 +223,14 @@ def load_data(
         return html.Div("Press Load to fetch data"), ""
 
     try:
+        safe_base_url = validate_base_url(base_url)
         if active_tab == "charts":
-            return _render_charts_tab(base_url, recipe_id), ""
+            return _render_charts_tab(safe_base_url, recipe_id), ""
         if active_tab == "active":
-            return _render_active_tab(base_url, recipe_id, chart_id), ""
+            return _render_active_tab(safe_base_url, recipe_id, chart_id), ""
         if active_tab == "history":
-            return _render_history_tab(base_url, chart_id), ""
-        return _render_judge_tab(base_url, recipe_id, chart_id, result_id), ""
+            return _render_history_tab(safe_base_url, chart_id), ""
+        return _render_judge_tab(safe_base_url, recipe_id, chart_id, result_id), ""
     except APIError as exc:
         code = f" [{exc.code}]" if exc.code else ""
         return html.Div(""), f"{exc.message}{code}"
@@ -172,12 +253,17 @@ def refresh_chart_name_options(
     if not n_clicks:
         return [], None
 
+    try:
+        safe_base_url = validate_base_url(base_url)
+    except APIError:
+        return [], None
+
     params: dict[str, Any] = {}
     if recipe_id:
         params["recipe_id"] = recipe_id
 
     try:
-        rows = get_charts(base_url, params=params)
+        rows = get_charts(safe_base_url, params=params)
     except APIError:
         return [], None
 
@@ -407,8 +493,9 @@ def render_active_drilldown(
         return empty_drilldown_figure("Only feature points are clickable for drilldown")
 
     try:
+        safe_base_url = validate_base_url(base_url)
         preview = get_process_waveform_preview(
-            base_url,
+            safe_base_url,
             process_id,
             params={"limit": 500},
         )
@@ -454,13 +541,10 @@ def _render_history_tab(base_url: str, chart_id: str) -> html.Div:
     )
 
 
-def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: str) -> html.Div:
-    params: dict[str, Any] = {"limit": 200}
-    if recipe_id:
-        params["recipe_id"] = recipe_id
-    if chart_id:
-        params["chart_id"] = chart_id
-
+def _build_judge_table_rows(
+    base_url: str,
+    params: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     rows = sort_judge_rows(get_judge_results(base_url, params=params))
     table_rows = [
         {
@@ -480,7 +564,14 @@ def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: s
         }
         for row in rows
     ]
+    return rows, table_rows
 
+
+def _build_judge_drilldown_links(
+    rows: list[dict[str, Any]],
+    recipe_id: str,
+    chart_id: str,
+) -> list[html.Li]:
     drilldown_links: list[html.Li] = []
     for row in rows[:20]:
         rid = row.get("result_id")
@@ -496,44 +587,64 @@ def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: s
             params_for_href["chart_id"] = chart_id
         href = f"?{urlencode(params_for_href, doseq=False, safe='')}"
         drilldown_links.append(html.Li(html.A(rid, href=href)))
+    return drilldown_links
+
+
+def _build_judge_detail_block(
+    detail: dict[str, Any] | None,
+    level_color_map: dict[str, str],
+) -> Any:
+    if detail is None:
+        return html.Div("Select/enter result_id to load detail")
+
+    level = str(detail.get("level", ""))
+    judged_at_val = parse_utc_millis(
+        str(detail.get("judged_at")) if detail.get("judged_at") else None
+    )
+    process_start_ts_val = parse_utc_millis(
+        str(detail.get("process_start_ts")) if detail.get("process_start_ts") else None
+    )
+
+    return html.Pre(
+        "\n".join(
+            [
+                f"result_id: {detail.get('result_id')}",
+                f"level: {level}",
+                f"chart_id: {detail.get('chart_id')}",
+                f"process_id: {detail.get('process_id')}",
+                f"feature: {detail.get('feature_type')}={detail.get('feature_value')}",
+                (
+                    "thresholds: "
+                    f"warn[{detail.get('warning_lcl')}, {detail.get('warning_ucl')}], "
+                    f"crit[{detail.get('critical_lcl')}, {detail.get('critical_ucl')}]"
+                ),
+                f"judged_at: {judged_at_val}",
+                f"process_start_ts: {process_start_ts_val}",
+            ]
+        ),
+        style={
+            "padding": "10px",
+            "backgroundColor": "#f5f5f5",
+            "borderLeft": f"6px solid {level_color_map.get(level, '#555555')}",
+        },
+    )
+
+
+def _render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: str) -> html.Div:
+    params: dict[str, Any] = {"limit": 200}
+    if recipe_id:
+        params["recipe_id"] = recipe_id
+    if chart_id:
+        params["chart_id"] = chart_id
+
+    rows, table_rows = _build_judge_table_rows(base_url, params)
+    drilldown_links = _build_judge_drilldown_links(rows, recipe_id, chart_id)
 
     detail: dict[str, Any] | None = None
     if result_id:
         detail = get_judge_result(base_url, result_id=result_id)
 
-    detail_block: Any = html.Div("Select/enter result_id to load detail")
-    if detail is not None:
-        level = str(detail.get("level", ""))
-        judged_at_val = parse_utc_millis(
-            str(detail.get("judged_at")) if detail.get("judged_at") else None
-        )
-        process_start_ts_val = parse_utc_millis(
-            str(detail.get("process_start_ts")) if detail.get("process_start_ts") else None
-        )
-
-        detail_block = html.Pre(
-            "\n".join(
-                [
-                    f"result_id: {detail.get('result_id')}",
-                    f"level: {level}",
-                    f"chart_id: {detail.get('chart_id')}",
-                    f"process_id: {detail.get('process_id')}",
-                    f"feature: {detail.get('feature_type')}={detail.get('feature_value')}",
-                    (
-                        "thresholds: "
-                        f"warn[{detail.get('warning_lcl')}, {detail.get('warning_ucl')}], "
-                        f"crit[{detail.get('critical_lcl')}, {detail.get('critical_ucl')}]"
-                    ),
-                    f"judged_at: {judged_at_val}",
-                    f"process_start_ts: {process_start_ts_val}",
-                ]
-            ),
-            style={
-                "padding": "10px",
-                "backgroundColor": "#f5f5f5",
-                "borderLeft": f"6px solid {LEVEL_COLOR.get(level, '#555555')}",
-            },
-        )
+    detail_block = _build_judge_detail_block(detail, LEVEL_COLOR)
 
     return html.Div(
         [

--- a/src/portfolio_fdc/dashboard/view_models.py
+++ b/src/portfolio_fdc/dashboard/view_models.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+LEVEL_PRIORITY: dict[str, int] = {"NG": 0, "WARN": 1, "OK": 2}
+LEVEL_COLOR: dict[str, str] = {
+    "NG": "#b00020",
+    "WARN": "#f57c00",
+    "OK": "#2e7d32",
+}
+
+
+def sort_judge_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """NG > WARN > OK を優先し、同順位内は judged_at 降順に並べる。"""
+
+    def _key(row: dict[str, Any]) -> tuple[int, str]:
+        level = str(row.get("level", "")).upper()
+        judged_at = str(row.get("judged_at", ""))
+        return (LEVEL_PRIORITY.get(level, 9), judged_at)
+
+    return sorted(rows, key=_key)
+
+
+def format_range(low: Any, high: Any) -> str:
+    if low is None or high is None:
+        return "-"
+    return f"{low} .. {high}"
+
+
+def build_chart_name(row: dict[str, Any]) -> str:
+    """ユーザー向け表示名を返す。API が chart_name を返せば優先利用する。"""
+    chart_name = row.get("chart_name")
+    if isinstance(chart_name, str) and chart_name.strip():
+        return chart_name
+
+    recipe_id = str(row.get("recipe_id") or "-")
+    parameter = str(row.get("parameter") or "-")
+    step_no = str(row.get("step_no") or "-")
+    feature_type = str(row.get("feature_type") or "-")
+    chart_id = str(row.get("chart_id") or "-")
+    return f"{recipe_id} / {parameter} / step:{step_no} / {feature_type} ({chart_id})"
+
+
+def chart_band_figure(chart: dict[str, Any]) -> dict[str, Any]:
+    """Center/Warning/Critical の color band を表す最小 Figure を返す。"""
+    warning_lcl = chart.get("warning_lcl")
+    warning_ucl = chart.get("warning_ucl")
+    critical_lcl = chart.get("critical_lcl")
+    critical_ucl = chart.get("critical_ucl")
+
+    if any(v is None for v in (warning_lcl, warning_ucl, critical_lcl, critical_ucl)):
+        return {
+            "data": [],
+            "layout": {
+                "title": "No threshold data",
+                "xaxis": {"visible": False},
+                "yaxis": {"visible": False},
+            },
+        }
+
+    warning_lcl_f = float(cast(float, warning_lcl))
+    warning_ucl_f = float(cast(float, warning_ucl))
+    critical_lcl_f = float(cast(float, critical_lcl))
+    critical_ucl_f = float(cast(float, critical_ucl))
+    center = (warning_lcl_f + warning_ucl_f) / 2.0
+    lower_crit = min(critical_lcl_f, warning_lcl_f)
+    upper_crit = max(critical_ucl_f, warning_ucl_f)
+
+    shapes = [
+        {
+            "type": "rect",
+            "x0": 0,
+            "x1": 1,
+            "y0": lower_crit,
+            "y1": warning_lcl_f,
+            "fillcolor": "rgba(176,0,32,0.25)",
+            "line": {"width": 0},
+        },
+        {
+            "type": "rect",
+            "x0": 0,
+            "x1": 1,
+            "y0": warning_lcl_f,
+            "y1": warning_ucl_f,
+            "fillcolor": "rgba(46,125,50,0.25)",
+            "line": {"width": 0},
+        },
+        {
+            "type": "rect",
+            "x0": 0,
+            "x1": 1,
+            "y0": warning_ucl_f,
+            "y1": upper_crit,
+            "fillcolor": "rgba(176,0,32,0.25)",
+            "line": {"width": 0},
+        },
+    ]
+
+    return {
+        "data": [
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "x": [0, 1],
+                "y": [center, center],
+                "name": "Center",
+                "line": {"color": "#2e7d32", "width": 3},
+            },
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "x": [0, 1],
+                "y": [warning_lcl_f, warning_lcl_f],
+                "name": "Warning LCL",
+                "line": {"color": "#f57c00", "dash": "dot"},
+            },
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "x": [0, 1],
+                "y": [warning_ucl_f, warning_ucl_f],
+                "name": "Warning UCL",
+                "line": {"color": "#f57c00", "dash": "dot"},
+            },
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "x": [0, 1],
+                "y": [critical_lcl_f, critical_lcl_f],
+                "name": "Critical LCL",
+                "line": {"color": "#b00020", "dash": "dash"},
+            },
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "x": [0, 1],
+                "y": [critical_ucl_f, critical_ucl_f],
+                "name": "Critical UCL",
+                "line": {"color": "#b00020", "dash": "dash"},
+            },
+        ],
+        "layout": {
+            "title": "Color Band (Center / Warning / Critical)",
+            "xaxis": {"visible": False, "range": [0, 1]},
+            "yaxis": {"title": "threshold"},
+            "shapes": shapes,
+            "height": 320,
+            "margin": {"l": 40, "r": 20, "t": 50, "b": 30},
+        },
+    }
+
+
+def chart_points_figure(chart: dict[str, Any], points: list[dict[str, Any]]) -> dict[str, Any]:
+    """特徴量点としきい値線を重ねた Figure を返す。"""
+    if not points:
+        return {
+            "data": [],
+            "layout": {
+                "title": "No feature points",
+                "xaxis": {"visible": False},
+                "yaxis": {"visible": False},
+            },
+        }
+
+    ordered = list(reversed(points))
+    x = list(range(1, len(ordered) + 1))
+    y = [float(point.get("feature_value", 0.0)) for point in ordered]
+    hover = [
+        f"process_id={point.get('process_id')}<br>start={point.get('process_start_ts')}"
+        for point in ordered
+    ]
+
+    warning_lcl = chart.get("warning_lcl")
+    warning_ucl = chart.get("warning_ucl")
+    critical_lcl = chart.get("critical_lcl")
+    critical_ucl = chart.get("critical_ucl")
+
+    traces: list[dict[str, Any]] = [
+        {
+            "type": "scatter",
+            "mode": "markers+lines",
+            "x": x,
+            "y": y,
+            "name": "Feature value",
+            "marker": {"color": "#1565c0", "size": 7},
+            "line": {"color": "rgba(21,101,192,0.35)", "width": 1},
+            "text": hover,
+            "hovertemplate": "%{text}<br>value=%{y}<extra></extra>",
+        }
+    ]
+
+    def _hline(name: str, value: Any, color: str, dash: str) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        return {
+            "type": "scatter",
+            "mode": "lines",
+            "x": [x[0], x[-1]],
+            "y": [value, value],
+            "name": name,
+            "line": {"color": color, "dash": dash},
+            "hoverinfo": "skip",
+        }
+
+    for threshold_line in (
+        _hline("Warning LCL", warning_lcl, "#f57c00", "dot"),
+        _hline("Warning UCL", warning_ucl, "#f57c00", "dot"),
+        _hline("Critical LCL", critical_lcl, "#b00020", "dash"),
+        _hline("Critical UCL", critical_ucl, "#b00020", "dash"),
+    ):
+        if threshold_line is not None:
+            traces.append(threshold_line)
+
+    return {
+        "data": traces,
+        "layout": {
+            "title": "Recent Feature Points",
+            "xaxis": {"title": "sample (old -> new)"},
+            "yaxis": {"title": "feature_value"},
+            "height": 360,
+            "margin": {"l": 50, "r": 20, "t": 50, "b": 45},
+        },
+    }
+
+
+def spc_band_with_points_figure(
+    chart: dict[str, Any], points: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """上段用: color band と特徴量点を同一グラフに重ねる。"""
+    if not points:
+        return chart_band_figure(chart)
+
+    ordered = list(reversed(points))
+    x = list(range(1, len(ordered) + 1))
+    y = [float(point.get("feature_value", 0.0)) for point in ordered]
+    process_ids = [str(point.get("process_id", "")) for point in ordered]
+    hover = [
+        "process_id="
+        f"{point.get('process_id')}<br>start={point.get('process_start_ts')}"
+        f"<br>value={point.get('feature_value')}"
+        for point in ordered
+    ]
+
+    warning_lcl = chart.get("warning_lcl")
+    warning_ucl = chart.get("warning_ucl")
+    critical_lcl = chart.get("critical_lcl")
+    critical_ucl = chart.get("critical_ucl")
+    center = None
+    if warning_lcl is not None and warning_ucl is not None:
+        center = (float(cast(float, warning_lcl)) + float(cast(float, warning_ucl))) / 2.0
+
+    traces: list[dict[str, Any]] = [
+        {
+            "type": "scatter",
+            "mode": "markers+lines",
+            "x": x,
+            "y": y,
+            "name": "Feature value",
+            "marker": {"color": "#1565c0", "size": 8},
+            "line": {"color": "rgba(21,101,192,0.35)", "width": 1},
+            "text": hover,
+            "customdata": process_ids,
+            "hovertemplate": "%{text}<extra></extra>",
+        }
+    ]
+
+    def _hline(name: str, value: Any, color: str, dash: str, width: int = 2) -> None:
+        if value is None:
+            return
+        traces.append(
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "x": [x[0], x[-1]],
+                "y": [value, value],
+                "name": name,
+                "line": {"color": color, "dash": dash, "width": width},
+                "hoverinfo": "skip",
+            }
+        )
+
+    _hline("Center", center, "#2e7d32", "solid", 3)
+    _hline("Warning LCL", warning_lcl, "#f57c00", "dot")
+    _hline("Warning UCL", warning_ucl, "#f57c00", "dot")
+    _hline("Critical LCL", critical_lcl, "#b00020", "dash")
+    _hline("Critical UCL", critical_ucl, "#b00020", "dash")
+
+    shapes: list[dict[str, Any]] = []
+    if None not in (warning_lcl, warning_ucl, critical_lcl, critical_ucl):
+        warning_lcl_f = float(cast(float, warning_lcl))
+        warning_ucl_f = float(cast(float, warning_ucl))
+        critical_lcl_f = float(cast(float, critical_lcl))
+        critical_ucl_f = float(cast(float, critical_ucl))
+        lower_crit = min(critical_lcl_f, warning_lcl_f)
+        upper_crit = max(critical_ucl_f, warning_ucl_f)
+        x0 = x[0]
+        x1 = x[-1]
+        shapes = [
+            {
+                "type": "rect",
+                "x0": x0,
+                "x1": x1,
+                "y0": lower_crit,
+                "y1": warning_lcl_f,
+                "fillcolor": "rgba(176,0,32,0.15)",
+                "line": {"width": 0},
+                "layer": "below",
+            },
+            {
+                "type": "rect",
+                "x0": x0,
+                "x1": x1,
+                "y0": warning_lcl_f,
+                "y1": warning_ucl_f,
+                "fillcolor": "rgba(46,125,50,0.15)",
+                "line": {"width": 0},
+                "layer": "below",
+            },
+            {
+                "type": "rect",
+                "x0": x0,
+                "x1": x1,
+                "y0": warning_ucl_f,
+                "y1": upper_crit,
+                "fillcolor": "rgba(176,0,32,0.15)",
+                "line": {"width": 0},
+                "layer": "below",
+            },
+        ]
+
+    return {
+        "data": traces,
+        "layout": {
+            "title": "SPC Band + Feature Points",
+            "xaxis": {"title": "sample (old -> new)"},
+            "yaxis": {"title": "feature_value"},
+            "height": 360,
+            "margin": {"l": 50, "r": 20, "t": 50, "b": 45},
+            "shapes": shapes,
+        },
+    }
+
+
+def empty_drilldown_figure(message: str) -> dict[str, Any]:
+    return {
+        "data": [],
+        "layout": {
+            "title": "Raw Waveform Drilldown",
+            "xaxis": {"visible": False},
+            "yaxis": {"visible": False},
+            "annotations": [
+                {
+                    "text": message,
+                    "x": 0.5,
+                    "y": 0.5,
+                    "showarrow": False,
+                }
+            ],
+            "height": 320,
+            "margin": {"l": 40, "r": 20, "t": 50, "b": 30},
+        },
+    }
+
+
+def waveform_figure(wave_points: list[dict[str, Any]], process_id: str) -> dict[str, Any]:
+    if not wave_points:
+        return empty_drilldown_figure("No waveform preview data for this process")
+
+    x = [str(p.get("x", "")) for p in wave_points]
+    y = [float(p.get("y", 0.0)) for p in wave_points]
+    return {
+        "data": [
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "x": x,
+                "y": y,
+                "name": "Raw waveform",
+                "line": {"color": "#263238", "width": 1.5},
+            }
+        ],
+        "layout": {
+            "title": f"Raw Waveform Preview ({process_id})",
+            "xaxis": {"title": "timestamp"},
+            "yaxis": {"title": "value"},
+            "height": 320,
+            "margin": {"l": 50, "r": 20, "t": 50, "b": 45},
+        },
+    }

--- a/src/portfolio_fdc/dashboard/view_models.py
+++ b/src/portfolio_fdc/dashboard/view_models.py
@@ -38,11 +38,21 @@ def build_chart_name(row: dict[str, Any]) -> str:
     if isinstance(chart_name, str) and chart_name.strip():
         return chart_name
 
-    recipe_id = str(row.get("recipe_id") or "-")
-    parameter = str(row.get("parameter") or "-")
-    step_no = str(row.get("step_no") or "-")
-    feature_type = str(row.get("feature_type") or "-")
-    chart_id = str(row.get("chart_id") or "-")
+    recipe_id_raw = row.get("recipe_id")
+    recipe_id = "-" if recipe_id_raw is None else str(recipe_id_raw)
+
+    parameter_raw = row.get("parameter")
+    parameter = "-" if parameter_raw is None else str(parameter_raw)
+
+    step_no_raw = row.get("step_no")
+    step_no = "-" if step_no_raw is None else str(step_no_raw)
+
+    feature_type_raw = row.get("feature_type")
+    feature_type = "-" if feature_type_raw is None else str(feature_type_raw)
+
+    chart_id_raw = row.get("chart_id")
+    chart_id = "-" if chart_id_raw is None else str(chart_id_raw)
+
     return f"{recipe_id} / {parameter} / step:{step_no} / {feature_type} ({chart_id})"
 
 

--- a/src/portfolio_fdc/dashboard/view_models.py
+++ b/src/portfolio_fdc/dashboard/view_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 LEVEL_PRIORITY: dict[str, int] = {"NG": 0, "WARN": 1, "OK": 2}
 LEVEL_COLOR: dict[str, str] = {
@@ -15,7 +15,7 @@ def sort_judge_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     rows_by_judged_at = sorted(
         rows,
-        key=lambda row: str(row.get("judged_at", "")),
+        key=lambda row: str(row.get("judged_at") or ""),
         reverse=True,
     )
 
@@ -30,6 +30,20 @@ def format_range(low: Any, high: Any) -> str:
     if low is None or high is None:
         return "-"
     return f"{low} .. {high}"
+
+
+def safe_cast_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed:
+            return None
+        value = trimmed
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def build_chart_name(row: dict[str, Any]) -> str:
@@ -63,7 +77,12 @@ def chart_band_figure(chart: dict[str, Any]) -> dict[str, Any]:
     critical_lcl = chart.get("critical_lcl")
     critical_ucl = chart.get("critical_ucl")
 
-    if any(v is None for v in (warning_lcl, warning_ucl, critical_lcl, critical_ucl)):
+    warning_lcl_f = safe_cast_float(warning_lcl)
+    warning_ucl_f = safe_cast_float(warning_ucl)
+    critical_lcl_f = safe_cast_float(critical_lcl)
+    critical_ucl_f = safe_cast_float(critical_ucl)
+
+    if any(v is None for v in (warning_lcl_f, warning_ucl_f, critical_lcl_f, critical_ucl_f)):
         return {
             "data": [],
             "layout": {
@@ -73,10 +92,11 @@ def chart_band_figure(chart: dict[str, Any]) -> dict[str, Any]:
             },
         }
 
-    warning_lcl_f = float(cast(float, warning_lcl))
-    warning_ucl_f = float(cast(float, warning_ucl))
-    critical_lcl_f = float(cast(float, critical_lcl))
-    critical_ucl_f = float(cast(float, critical_ucl))
+    assert warning_lcl_f is not None
+    assert warning_ucl_f is not None
+    assert critical_lcl_f is not None
+    assert critical_ucl_f is not None
+
     center = (warning_lcl_f + warning_ucl_f) / 2.0
     lower_crit = min(critical_lcl_f, warning_lcl_f)
     upper_crit = max(critical_ucl_f, warning_ucl_f)
@@ -178,11 +198,29 @@ def chart_points_figure(chart: dict[str, Any], points: list[dict[str, Any]]) -> 
         }
 
     ordered = list(reversed(points))
-    x = list(range(1, len(ordered) + 1))
-    y = [float(point.get("feature_value", 0.0)) for point in ordered]
+
+    filtered_points: list[tuple[dict[str, Any], float]] = []
+    for point in ordered:
+        feature_value = safe_cast_float(point.get("feature_value"))
+        if feature_value is None:
+            continue
+        filtered_points.append((point, feature_value))
+
+    if not filtered_points:
+        return {
+            "data": [],
+            "layout": {
+                "title": "No feature points",
+                "xaxis": {"visible": False},
+                "yaxis": {"visible": False},
+            },
+        }
+
+    x = list(range(1, len(filtered_points) + 1))
+    y = [feature_value for _, feature_value in filtered_points]
     hover = [
         f"process_id={point.get('process_id')}<br>start={point.get('process_start_ts')}"
-        for point in ordered
+        for point, _ in filtered_points
     ]
 
     warning_lcl = chart.get("warning_lcl")
@@ -205,13 +243,14 @@ def chart_points_figure(chart: dict[str, Any], points: list[dict[str, Any]]) -> 
     ]
 
     def _hline(name: str, value: Any, color: str, dash: str) -> dict[str, Any] | None:
-        if value is None:
+        value_f = safe_cast_float(value)
+        if value_f is None:
             return None
         return {
             "type": "scatter",
             "mode": "lines",
             "x": [x[0], x[-1]],
-            "y": [value, value],
+            "y": [value_f, value_f],
             "name": name,
             "line": {"color": color, "dash": dash},
             "hoverinfo": "skip",
@@ -246,23 +285,39 @@ def spc_band_with_points_figure(
         return chart_band_figure(chart)
 
     ordered = list(reversed(points))
-    x = list(range(1, len(ordered) + 1))
-    y = [float(point.get("feature_value", 0.0)) for point in ordered]
-    process_ids = [str(point.get("process_id", "")) for point in ordered]
+    filtered_points: list[tuple[dict[str, Any], float]] = []
+    for point in ordered:
+        feature_value = safe_cast_float(point.get("feature_value"))
+        if feature_value is None:
+            continue
+        filtered_points.append((point, feature_value))
+
+    if not filtered_points:
+        return chart_band_figure(chart)
+
+    x = list(range(1, len(filtered_points) + 1))
+    y = [feature_value for _, feature_value in filtered_points]
+    process_ids = [str(point.get("process_id", "")) for point, _ in filtered_points]
     hover = [
         "process_id="
         f"{point.get('process_id')}<br>start={point.get('process_start_ts')}"
-        f"<br>value={point.get('feature_value')}"
-        for point in ordered
+        f"<br>value={feature_value}"
+        for point, feature_value in filtered_points
     ]
 
     warning_lcl = chart.get("warning_lcl")
     warning_ucl = chart.get("warning_ucl")
     critical_lcl = chart.get("critical_lcl")
     critical_ucl = chart.get("critical_ucl")
+
+    warning_lcl_f = safe_cast_float(warning_lcl)
+    warning_ucl_f = safe_cast_float(warning_ucl)
+    critical_lcl_f = safe_cast_float(critical_lcl)
+    critical_ucl_f = safe_cast_float(critical_ucl)
+
     center = None
-    if warning_lcl is not None and warning_ucl is not None:
-        center = (float(cast(float, warning_lcl)) + float(cast(float, warning_ucl))) / 2.0
+    if warning_lcl_f is not None and warning_ucl_f is not None:
+        center = (warning_lcl_f + warning_ucl_f) / 2.0
 
     traces: list[dict[str, Any]] = [
         {
@@ -295,17 +350,17 @@ def spc_band_with_points_figure(
         )
 
     _hline("Center", center, "#2e7d32", "solid", 3)
-    _hline("Warning LCL", warning_lcl, "#f57c00", "dot")
-    _hline("Warning UCL", warning_ucl, "#f57c00", "dot")
-    _hline("Critical LCL", critical_lcl, "#b00020", "dash")
-    _hline("Critical UCL", critical_ucl, "#b00020", "dash")
+    _hline("Warning LCL", warning_lcl_f, "#f57c00", "dot")
+    _hline("Warning UCL", warning_ucl_f, "#f57c00", "dot")
+    _hline("Critical LCL", critical_lcl_f, "#b00020", "dash")
+    _hline("Critical UCL", critical_ucl_f, "#b00020", "dash")
 
     shapes: list[dict[str, Any]] = []
-    if None not in (warning_lcl, warning_ucl, critical_lcl, critical_ucl):
-        warning_lcl_f = float(cast(float, warning_lcl))
-        warning_ucl_f = float(cast(float, warning_ucl))
-        critical_lcl_f = float(cast(float, critical_lcl))
-        critical_ucl_f = float(cast(float, critical_ucl))
+    if None not in (warning_lcl_f, warning_ucl_f, critical_lcl_f, critical_ucl_f):
+        assert warning_lcl_f is not None
+        assert warning_ucl_f is not None
+        assert critical_lcl_f is not None
+        assert critical_ucl_f is not None
         lower_crit = min(critical_lcl_f, warning_lcl_f)
         upper_crit = max(critical_ucl_f, warning_ucl_f)
         x0 = x[0]
@@ -381,8 +436,23 @@ def waveform_figure(wave_points: list[dict[str, Any]], process_id: str) -> dict[
     if not wave_points:
         return empty_drilldown_figure("No waveform preview data for this process")
 
-    x = [str(p.get("x", "")) for p in wave_points]
-    y = [float(p.get("y", 0.0)) for p in wave_points]
+    valid_wave_points: list[dict[str, Any]] = []
+    for point in wave_points:
+        y_val = safe_cast_float(point.get("y"))
+        if y_val is None:
+            continue
+        valid_wave_points.append(
+            {
+                "x": str(point.get("x", "")),
+                "y": y_val,
+            }
+        )
+
+    if not valid_wave_points:
+        return empty_drilldown_figure("No valid waveform preview data for this process")
+
+    x = [point["x"] for point in valid_wave_points]
+    y = [point["y"] for point in valid_wave_points]
     return {
         "data": [
             {

--- a/src/portfolio_fdc/dashboard/view_models.py
+++ b/src/portfolio_fdc/dashboard/view_models.py
@@ -13,12 +13,17 @@ LEVEL_COLOR: dict[str, str] = {
 def sort_judge_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """NG > WARN > OK を優先し、同順位内は judged_at 降順に並べる。"""
 
-    def _key(row: dict[str, Any]) -> tuple[int, str]:
-        level = str(row.get("level", "")).upper()
-        judged_at = str(row.get("judged_at", ""))
-        return (LEVEL_PRIORITY.get(level, 9), judged_at)
+    rows_by_judged_at = sorted(
+        rows,
+        key=lambda row: str(row.get("judged_at", "")),
+        reverse=True,
+    )
 
-    return sorted(rows, key=_key)
+    def _key(row: dict[str, Any]) -> int:
+        level = str(row.get("level", "")).upper()
+        return LEVEL_PRIORITY.get(level, 9)
+
+    return sorted(rows_by_judged_at, key=_key)
 
 
 def format_range(low: Any, high: Any) -> str:

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import pathlib
 import sqlite3
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -425,6 +426,96 @@ def _not_found_error_response(*, message: str, details: dict[str, str]) -> JSONR
     )
 
 
+def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
+    """ProcessInfo.raw_csv_path からドリルダウン表示用の波形プレビューを返す。"""
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        row = con.execute(
+            "SELECT raw_csv_path FROM processInfo WHERE process_id = ?",
+            (process_id,),
+        ).fetchone()
+    finally:
+        con.close()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="process not found")
+
+    raw_path = row[0]
+    if raw_path is None:
+        return {
+            "process_id": process_id,
+            "source_path": None,
+            "points": [],
+        }
+
+    src = pathlib.Path(str(raw_path))
+    if not src.is_absolute():
+        src = pathlib.Path.cwd() / src
+
+    if not src.exists():
+        return {
+            "process_id": process_id,
+            "source_path": src.as_posix(),
+            "points": [],
+        }
+
+    try:
+        with src.open("r", encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+
+        start_row = 0
+        for idx, line in enumerate(lines[:200]):
+            if line.strip().upper().startswith("DATA"):
+                start_row = idx + 1
+                break
+
+        from io import StringIO
+
+        import pandas as pd  # Local import to avoid global import cost.
+
+        content = "".join(lines[start_row:])
+        frame = pd.read_csv(StringIO(content))
+        if frame.empty:
+            return {
+                "process_id": process_id,
+                "source_path": src.as_posix(),
+                "points": [],
+            }
+
+        x_col = frame.columns[0]
+        y_col = None
+        for col in frame.columns[1:]:
+            if pd.api.types.is_numeric_dtype(frame[col]):
+                y_col = col
+                break
+        if y_col is None:
+            return {
+                "process_id": process_id,
+                "source_path": src.as_posix(),
+                "points": [],
+            }
+
+        sample = frame[[x_col, y_col]].tail(limit)
+        points = [
+            {
+                "x": str(x),
+                "y": float(y),
+            }
+            for x, y in sample.to_records(index=False)
+        ]
+        return {
+            "process_id": process_id,
+            "source_path": src.as_posix(),
+            "points": points,
+        }
+    except Exception:
+        return {
+            "process_id": process_id,
+            "source_path": src.as_posix(),
+            "points": [],
+        }
+
+
 @app.get("/charts/history")
 def get_charts_history(
     chart_id: str | None = Query(
@@ -464,6 +555,44 @@ def get_charts_history(
         return {"ok": True, "data": [asdict(row) for row in rows]}
     except Exception as e:
         _raise_api_error(operation="GET /charts/history", error=e)
+
+
+@app.get("/charts/{chart_id}/points")
+def get_chart_points(
+    chart_id: str = Path(
+        min_length=1,
+        max_length=64,
+        pattern=CHART_ID_PATTERN,
+    ),
+    limit: int = Query(default=50, ge=1, le=500),
+):
+    """指定 chart に対応する最新特徴量点を返す。"""
+    chart_pk = _parse_chart_pk(chart_id)
+    if chart_pk is None:
+        raise HTTPException(status_code=400, detail="Invalid chart_id")
+
+    try:
+        rows = _chart_repository.find_chart_points(chart_pk, limit)
+        return {"ok": True, "data": [asdict(row) for row in rows]}
+    except Exception as e:
+        _raise_api_error(operation="GET /charts/{chart_id}/points", error=e)
+
+
+@app.get("/processes/{process_id}/waveform-preview")
+def get_process_waveform_preview(
+    process_id: str = Path(
+        min_length=1, max_length=CHARTS_FILTER_MAX_LENGTH, pattern=CHARTS_FILTER_PATTERN
+    ),
+    limit: int = Query(default=300, ge=10, le=2000),
+):
+    """process_id に紐づく元波形（raw_csv_path）のプレビューを返す。"""
+    try:
+        data = _build_waveform_preview(process_id, limit)
+        return {"ok": True, "data": data}
+    except HTTPException:
+        raise
+    except Exception as e:
+        _raise_api_error(operation="GET /processes/{process_id}/waveform-preview", error=e)
 
 
 @app.get("/judge/results")

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -36,7 +36,7 @@ from .chart_repository import (
     ChartsHistoryQueryCriteria,
     ChartsQueryCriteria,
 )
-from .db import MAIN_DB, TEMP_DB, _init_schema
+from .db import MAIN_DB, TEMP_DB, _connect, _init_schema
 from .judge_repository import (
     JudgeDataCorruptionError,
     JudgeRepository,
@@ -428,10 +428,10 @@ def _not_found_error_response(*, message: str, details: dict[str, str]) -> JSONR
 
 def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
     """ProcessInfo.raw_csv_path からドリルダウン表示用の波形プレビューを返す。"""
-    con = sqlite3.connect(MAIN_DB.as_posix())
+    con = _connect(MAIN_DB)
     try:
         row = con.execute(
-            "SELECT raw_csv_path FROM processInfo WHERE process_id = ?",
+            "SELECT raw_csv_path FROM ProcessInfo WHERE process_id = ?",
             (process_id,),
         ).fetchone()
     finally:
@@ -509,6 +509,11 @@ def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
             "points": points,
         }
     except Exception:
+        logger.exception(
+            "Failed to build waveform preview for process_id=%s source_path=%s",
+            process_id,
+            src.as_posix(),
+        )
         return {
             "process_id": process_id,
             "source_path": src.as_posix(),

--- a/src/portfolio_fdc/db_api/chart_repository.py
+++ b/src/portfolio_fdc/db_api/chart_repository.py
@@ -120,6 +120,16 @@ class ChartHistoryView:
     changed_at: str
 
 
+@dataclass(frozen=True)
+class ChartPointView:
+    """`GET /charts/{chart_id}/points` レスポンス 1 件分の DTO。"""
+
+    process_id: str
+    feature_value: float
+    process_start_ts: str
+    raw_csv_path: str | None
+
+
 class ChartRepository:
     """ChartsV2 から chart 一覧を取得するリポジトリ。"""
 
@@ -161,6 +171,27 @@ class ChartRepository:
             h.changed_by,
             h.changed_at
         FROM ChartsHistory h
+    """
+
+    _CHART_POINTS_SQL = """
+        SELECT
+            p.process_id,
+            p.feature_value,
+            pi.start_ts,
+            pi.raw_csv_path
+        FROM ChartsV2 c
+        INNER JOIN Parameters p
+            ON p.parameter = c.parameter
+           AND p.step_no = c.step_no
+           AND p.feature_type = c.feature_type
+        INNER JOIN ProcessInfo pi
+            ON pi.process_id = p.process_id
+           AND pi.tool_id = c.tool_id
+           AND pi.chamber_id = c.chamber_id
+           AND pi.recipe_id = c.recipe_id
+        WHERE c.id = ?
+        ORDER BY julianday(pi.start_ts) DESC, p.id DESC
+        LIMIT ?
     """
 
     _FILTERED_CHARTS_CTE = """
@@ -417,6 +448,16 @@ class ChartRepository:
 
         return [self._to_chart_history_view(row) for row in rows]
 
+    def find_chart_points(self, chart_pk: int, limit: int) -> list[ChartPointView]:
+        """指定 chart に対応する最新特徴量点を返す。"""
+        con = _connect(MAIN_DB)
+        try:
+            rows = con.execute(self._CHART_POINTS_SQL, (chart_pk, limit)).fetchall()
+        finally:
+            con.close()
+
+        return [self._to_chart_point_view(row) for row in rows]
+
     @staticmethod
     def _append_filter_condition(
         value: Any,
@@ -538,6 +579,17 @@ class ChartRepository:
             ),
             changed_by=None if changed_by is None else str(changed_by),
             changed_at=to_utc_millis(str(changed_at)),
+        )
+
+    @staticmethod
+    def _to_chart_point_view(row: tuple[Any, ...]) -> ChartPointView:
+        """DB 行を `ChartPointView` へ変換する。"""
+        process_id, feature_value, process_start_ts, raw_csv_path = row
+        return ChartPointView(
+            process_id=str(process_id),
+            feature_value=float(feature_value),
+            process_start_ts=to_utc_millis(str(process_start_ts)),
+            raw_csv_path=None if raw_csv_path is None else str(raw_csv_path),
         )
 
 

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -6,8 +6,12 @@ import pytest
 
 from portfolio_fdc.dashboard.api_client import (
     APIError,
+    get_active_charts,
     get_chart_points,
     get_charts,
+    get_charts_history,
+    get_judge_result,
+    get_judge_results,
     get_process_waveform_preview,
 )
 
@@ -114,3 +118,65 @@ def test_get_process_waveform_preview_returns_data(monkeypatch: pytest.MonkeyPat
 
     assert data["process_id"] == "P1"
     assert data["points"][0]["y"] == 1.2
+
+
+@pytest.mark.parametrize(
+    ("call", "expected_fragment"),
+    [
+        (lambda: get_charts("http://localhost:8000"), "/charts"),
+        (lambda: get_charts_history("http://localhost:8000"), "/charts/history"),
+        (
+            lambda: get_chart_points("http://localhost:8000", chart_id="CHART_1"),
+            "/charts/CHART_1/points",
+        ),
+        (lambda: get_judge_results("http://localhost:8000"), "/judge/results"),
+    ],
+)
+def test_list_getters_raise_api_error_for_invalid_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    call: Any,
+    expected_fragment: str,
+) -> None:
+    def _fake_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(200, {"ok": True, "data": {"unexpected": True}})
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _fake_get)
+
+    with pytest.raises(APIError) as exc_info:
+        call()
+
+    assert expected_fragment in exc_info.value.message
+    assert "expected list" in exc_info.value.message
+    assert "unexpected" in exc_info.value.message
+
+
+@pytest.mark.parametrize(
+    ("call", "expected_fragment"),
+    [
+        (lambda: get_active_charts("http://localhost:8000"), "/charts/active"),
+        (
+            lambda: get_process_waveform_preview("http://localhost:8000", process_id="P1"),
+            "/processes/P1/waveform-preview",
+        ),
+        (
+            lambda: get_judge_result("http://localhost:8000", result_id="JR_1"),
+            "/judge/results/JR_1",
+        ),
+    ],
+)
+def test_dict_getters_raise_api_error_for_invalid_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    call: Any,
+    expected_fragment: str,
+) -> None:
+    def _fake_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(200, {"ok": True, "data": ["unexpected"]})
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _fake_get)
+
+    with pytest.raises(APIError) as exc_info:
+        call()
+
+    assert expected_fragment in exc_info.value.message
+    assert "expected dict" in exc_info.value.message
+    assert "unexpected" in exc_info.value.message

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from portfolio_fdc.dashboard.api_client import (
+    APIError,
+    get_chart_points,
+    get_charts,
+    get_process_waveform_preview,
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def test_get_charts_returns_data_on_ok_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(200, {"ok": True, "data": [{"chart_id": "CHART_1"}]})
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _fake_get)
+
+    rows = get_charts("http://localhost:8000")
+
+    assert rows == [{"chart_id": "CHART_1"}]
+
+
+def test_get_charts_raises_api_error_for_error_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(
+            404,
+            {
+                "ok": False,
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": "judge result not found",
+                    "details": {"result_id": "JR_999"},
+                },
+            },
+        )
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _fake_get)
+
+    with pytest.raises(APIError) as exc_info:
+        get_charts("http://localhost:8000")
+
+    assert exc_info.value.code == "NOT_FOUND"
+    assert exc_info.value.message == "judge result not found"
+    assert exc_info.value.status_code == 404
+
+
+def test_get_charts_raises_api_error_for_detail_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(400, {"detail": "Invalid chart_id"})
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _fake_get)
+
+    with pytest.raises(APIError) as exc_info:
+        get_charts("http://localhost:8000")
+
+    assert exc_info.value.message == "Invalid chart_id"
+    assert exc_info.value.status_code == 400
+
+
+def test_get_chart_points_returns_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(
+            200,
+            {
+                "ok": True,
+                "data": [
+                    {
+                        "process_id": "P1",
+                        "feature_value": 2.3,
+                        "process_start_ts": "2026-04-19T00:00:00.000Z",
+                    }
+                ],
+            },
+        )
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _fake_get)
+
+    rows = get_chart_points("http://localhost:8000", chart_id="CHART_1", params={"limit": 30})
+
+    assert rows[0]["process_id"] == "P1"
+    assert rows[0]["feature_value"] == 2.3
+
+
+def test_get_process_waveform_preview_returns_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(
+            200,
+            {
+                "ok": True,
+                "data": {
+                    "process_id": "P1",
+                    "source_path": "data/raw.csv",
+                    "points": [{"x": "t1", "y": 1.2}],
+                },
+            },
+        )
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _fake_get)
+    data = get_process_waveform_preview(
+        "http://localhost:8000", process_id="P1", params={"limit": 100}
+    )
+
+    assert data["process_id"] == "P1"
+    assert data["points"][0]["y"] == 1.2

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from dash import html
 
-from portfolio_fdc.dashboard.app import load_data, refresh_chart_name_options
+from portfolio_fdc.dashboard.app import load_data, refresh_chart_name_options, validate_base_url
 
 
 def test_refresh_chart_name_options_keeps_dropdown_unselected_without_chart_id(
@@ -90,3 +90,33 @@ def test_load_data_renders_active_tab_after_load_click(
     assert isinstance(content, html.Div)
     assert content.children == "ACTIVE_RENDERED"
     assert error == ""
+
+
+def test_validate_base_url_accepts_localhost() -> None:
+    assert validate_base_url("http://localhost:8000") == "http://localhost:8000"
+
+
+def test_load_data_rejects_invalid_base_url() -> None:
+    content, error = load_data("active", 1, "file:///etc/passwd", "", "", "")
+
+    assert isinstance(content, html.Div)
+    assert error == "Invalid db_api base URL [INVALID_BASE_URL]"
+
+
+def test_refresh_chart_name_options_rejects_invalid_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    def _fake_get_charts(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal called
+        called = True
+        return [{"chart_id": "CHART_1", "chart_name": "Chart One"}]
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.app.get_charts", _fake_get_charts)
+
+    options, value = refresh_chart_name_options(1, "ftp://localhost:8000", "", "")
+
+    assert options == []
+    assert value is None
+    assert called is False

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from portfolio_fdc.dashboard.app import refresh_chart_name_options
+
+
+def test_refresh_chart_name_options_keeps_dropdown_unselected_without_chart_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_get_charts(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {"chart_id": "CHART_1", "chart_name": "Chart One"},
+            {"chart_id": "CHART_2", "chart_name": "Chart Two"},
+        ]
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.app.get_charts", _fake_get_charts)
+
+    options, value = refresh_chart_name_options(0, "http://localhost:8000", "", "")
+
+    assert [option["value"] for option in options] == ["CHART_1", "CHART_2"]
+    assert value is None
+
+
+def test_refresh_chart_name_options_preserves_explicit_chart_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_get_charts(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {"chart_id": "CHART_1", "chart_name": "Chart One"},
+            {"chart_id": "CHART_2", "chart_name": "Chart Two"},
+        ]
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.app.get_charts", _fake_get_charts)
+
+    options, value = refresh_chart_name_options(
+        0,
+        "http://localhost:8000",
+        "",
+        "CHART_2",
+    )
+
+    assert [option["value"] for option in options] == ["CHART_1", "CHART_2"]
+    assert value == "CHART_2"

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -128,7 +128,11 @@ def test_validate_base_url_rejects_credentialed_url() -> None:
         validate_base_url("http://user:pass@localhost:8000")
 
 
-def test_validate_base_url_rejects_zero_bind_host_by_default() -> None:
+def test_validate_base_url_rejects_zero_bind_host_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", "")
+
     with pytest.raises(APIError):
         validate_base_url("http://0.0.0.0:8000")
 
@@ -140,3 +144,6 @@ def test_validate_base_url_accepts_ipv6_loopback() -> None:
 def test_validate_base_url_rejects_out_of_range_port() -> None:
     with pytest.raises(APIError):
         validate_base_url("http://localhost:70000")
+
+    with pytest.raises(APIError):
+        validate_base_url("http://localhost:0")

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from dash import html
 
-from portfolio_fdc.dashboard.app import refresh_chart_name_options
+from portfolio_fdc.dashboard.app import load_data, refresh_chart_name_options
 
 
 def test_refresh_chart_name_options_keeps_dropdown_unselected_without_chart_id(
@@ -63,3 +64,29 @@ def test_refresh_chart_name_options_does_not_fetch_before_load_click(
     assert options == []
     assert value is None
     assert called is False
+
+
+def test_load_data_shows_prompt_before_first_load_click() -> None:
+    content, error = load_data("active", 0, "http://localhost:8000", "", "", "")
+
+    assert isinstance(content, html.Div)
+    assert content.children == "Press Load to fetch data"
+    assert error == ""
+
+
+def test_load_data_renders_active_tab_after_load_click(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_render_active_tab(*_args: Any, **_kwargs: Any) -> html.Div:
+        return html.Div("ACTIVE_RENDERED")
+
+    monkeypatch.setattr(
+        "portfolio_fdc.dashboard.app._render_active_tab",
+        _fake_render_active_tab,
+    )
+
+    content, error = load_data("active", 1, "http://localhost:8000", "", "", "")
+
+    assert isinstance(content, html.Div)
+    assert content.children == "ACTIVE_RENDERED"
+    assert error == ""

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -18,7 +18,7 @@ def test_refresh_chart_name_options_keeps_dropdown_unselected_without_chart_id(
 
     monkeypatch.setattr("portfolio_fdc.dashboard.app.get_charts", _fake_get_charts)
 
-    options, value = refresh_chart_name_options(0, "http://localhost:8000", "", "")
+    options, value = refresh_chart_name_options(1, "http://localhost:8000", "", "")
 
     assert [option["value"] for option in options] == ["CHART_1", "CHART_2"]
     assert value is None
@@ -36,7 +36,7 @@ def test_refresh_chart_name_options_preserves_explicit_chart_id(
     monkeypatch.setattr("portfolio_fdc.dashboard.app.get_charts", _fake_get_charts)
 
     options, value = refresh_chart_name_options(
-        0,
+        1,
         "http://localhost:8000",
         "",
         "CHART_2",
@@ -44,3 +44,22 @@ def test_refresh_chart_name_options_preserves_explicit_chart_id(
 
     assert [option["value"] for option in options] == ["CHART_1", "CHART_2"]
     assert value == "CHART_2"
+
+
+def test_refresh_chart_name_options_does_not_fetch_before_load_click(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    def _fake_get_charts(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal called
+        called = True
+        return [{"chart_id": "CHART_1", "chart_name": "Chart One"}]
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.app.get_charts", _fake_get_charts)
+
+    options, value = refresh_chart_name_options(0, "http://localhost:8000", "", "")
+
+    assert options == []
+    assert value is None
+    assert called is False

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -131,3 +131,12 @@ def test_validate_base_url_rejects_credentialed_url() -> None:
 def test_validate_base_url_rejects_zero_bind_host_by_default() -> None:
     with pytest.raises(APIError):
         validate_base_url("http://0.0.0.0:8000")
+
+
+def test_validate_base_url_accepts_ipv6_loopback() -> None:
+    assert validate_base_url("http://[::1]:8000") == "http://[::1]:8000"
+
+
+def test_validate_base_url_rejects_out_of_range_port() -> None:
+    with pytest.raises(APIError):
+        validate_base_url("http://localhost:70000")

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from dash import html
 
+from portfolio_fdc.dashboard.api_client import APIError
 from portfolio_fdc.dashboard.app import load_data, refresh_chart_name_options, validate_base_url
 
 
@@ -120,3 +121,13 @@ def test_refresh_chart_name_options_rejects_invalid_base_url(
     assert options == []
     assert value is None
     assert called is False
+
+
+def test_validate_base_url_rejects_credentialed_url() -> None:
+    with pytest.raises(APIError):
+        validate_base_url("http://user:pass@localhost:8000")
+
+
+def test_validate_base_url_rejects_zero_bind_host_by_default() -> None:
+    with pytest.raises(APIError):
+        validate_base_url("http://0.0.0.0:8000")

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -128,7 +128,7 @@ def test_validate_base_url_rejects_credentialed_url() -> None:
         validate_base_url("http://user:pass@localhost:8000")
 
 
-def test_validate_base_url_rejects_zero_bind_host_by_default(
+def test_validate_base_url_rejects_zero_bind_host_when_allowed_hosts_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", "")
@@ -141,7 +141,7 @@ def test_validate_base_url_accepts_ipv6_loopback() -> None:
     assert validate_base_url("http://[::1]:8000") == "http://[::1]:8000"
 
 
-def test_validate_base_url_rejects_out_of_range_port() -> None:
+def test_validate_base_url_rejects_invalid_and_zero_ports() -> None:
     with pytest.raises(APIError):
         validate_base_url("http://localhost:70000")
 

--- a/tests/test_dashboard_view_models.py
+++ b/tests/test_dashboard_view_models.py
@@ -1,0 +1,117 @@
+from portfolio_fdc.dashboard.view_models import (
+    build_chart_name,
+    chart_band_figure,
+    chart_points_figure,
+    empty_drilldown_figure,
+    sort_judge_rows,
+    spc_band_with_points_figure,
+    waveform_figure,
+)
+
+
+def test_sort_judge_rows_prioritizes_ng_warn_ok() -> None:
+    rows = [
+        {"result_id": "JR_1", "level": "OK", "judged_at": "2026-04-17T00:00:00.000Z"},
+        {"result_id": "JR_2", "level": "WARN", "judged_at": "2026-04-17T00:00:01.000Z"},
+        {"result_id": "JR_3", "level": "NG", "judged_at": "2026-04-17T00:00:02.000Z"},
+    ]
+
+    sorted_rows = sort_judge_rows(rows)
+
+    assert [row["result_id"] for row in sorted_rows] == ["JR_3", "JR_2", "JR_1"]
+
+
+def test_chart_band_figure_contains_center_warning_critical() -> None:
+    figure = chart_band_figure(
+        {
+            "warning_lcl": 1.4,
+            "warning_ucl": 2.6,
+            "critical_lcl": 1.2,
+            "critical_ucl": 2.8,
+        }
+    )
+
+    assert "data" in figure
+    names = [trace["name"] for trace in figure["data"]]
+    assert "Center" in names
+    assert "Warning LCL" in names
+    assert "Critical UCL" in names
+
+
+def test_build_chart_name_uses_explicit_name_when_present() -> None:
+    row = {
+        "chart_name": "Etch dc_bias step1 mean",
+        "chart_id": "CHART_10",
+    }
+
+    assert build_chart_name(row) == "Etch dc_bias step1 mean"
+
+
+def test_build_chart_name_falls_back_to_composed_name() -> None:
+    row = {
+        "recipe_id": "RCP_A",
+        "parameter": "dc_bias",
+        "step_no": 1,
+        "feature_type": "mean",
+        "chart_id": "CHART_10",
+    }
+
+    assert build_chart_name(row) == "RCP_A / dc_bias / step:1 / mean (CHART_10)"
+
+
+def test_chart_points_figure_contains_feature_and_threshold_lines() -> None:
+    figure = chart_points_figure(
+        {
+            "warning_lcl": 1.4,
+            "warning_ucl": 2.6,
+            "critical_lcl": 1.2,
+            "critical_ucl": 2.8,
+        },
+        [
+            {
+                "process_id": "P1",
+                "feature_value": 2.1,
+                "process_start_ts": "2026-04-19T00:00:00.000Z",
+            },
+            {
+                "process_id": "P2",
+                "feature_value": 2.4,
+                "process_start_ts": "2026-04-19T00:10:00.000Z",
+            },
+        ],
+    )
+
+    names = [trace["name"] for trace in figure["data"]]
+    assert "Feature value" in names
+    assert "Warning LCL" in names
+    assert "Critical UCL" in names
+
+
+def test_spc_band_with_points_figure_contains_feature_trace_and_customdata() -> None:
+    figure = spc_band_with_points_figure(
+        {
+            "warning_lcl": 1.4,
+            "warning_ucl": 2.6,
+            "critical_lcl": 1.2,
+            "critical_ucl": 2.8,
+        },
+        [
+            {
+                "process_id": "P1",
+                "feature_value": 2.1,
+                "process_start_ts": "2026-04-19T00:00:00.000Z",
+            }
+        ],
+    )
+
+    assert figure["data"][0]["name"] == "Feature value"
+    assert figure["data"][0]["customdata"] == ["P1"]
+
+
+def test_waveform_figure_and_empty_drilldown() -> None:
+    empty = empty_drilldown_figure("Click")
+    assert empty["layout"]["title"] == "Raw Waveform Drilldown"
+
+    wf = waveform_figure([{"x": "t1", "y": 1.0}, {"x": "t2", "y": 2.0}], "P1")
+    assert wf["layout"]["title"] == "Raw Waveform Preview (P1)"
+    assert wf["data"][0]["name"] == "Raw waveform"

--- a/tests/test_dashboard_view_models.py
+++ b/tests/test_dashboard_view_models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from portfolio_fdc.dashboard.view_models import (
     build_chart_name,
     chart_band_figure,
@@ -24,6 +26,18 @@ def test_sort_judge_rows_prioritizes_ng_warn_ok() -> None:
 def test_sort_judge_rows_same_level_descending_judged_at() -> None:
     rows = [
         {"result_id": "JR_1", "level": "WARN", "judged_at": "2026-04-17T00:00:00.000Z"},
+        {"result_id": "JR_2", "level": "WARN", "judged_at": "2026-04-17T00:00:02.000Z"},
+        {"result_id": "JR_3", "level": "WARN", "judged_at": "2026-04-17T00:00:01.000Z"},
+    ]
+
+    sorted_rows = sort_judge_rows(rows)
+
+    assert [row["result_id"] for row in sorted_rows] == ["JR_2", "JR_3", "JR_1"]
+
+
+def test_sort_judge_rows_places_missing_judged_at_last_within_level() -> None:
+    rows: list[dict[str, Any]] = [
+        {"result_id": "JR_1", "level": "WARN", "judged_at": None},
         {"result_id": "JR_2", "level": "WARN", "judged_at": "2026-04-17T00:00:02.000Z"},
         {"result_id": "JR_3", "level": "WARN", "judged_at": "2026-04-17T00:00:01.000Z"},
     ]
@@ -112,6 +126,38 @@ def test_chart_points_figure_contains_feature_and_threshold_lines() -> None:
     assert "Critical UCL" in names
 
 
+def test_chart_points_figure_ignores_non_numeric_feature_values() -> None:
+    figure = chart_points_figure(
+        {
+            "warning_lcl": "1.4",
+            "warning_ucl": "2.6",
+            "critical_lcl": "1.2",
+            "critical_ucl": "2.8",
+        },
+        [
+            {
+                "process_id": "P1",
+                "feature_value": "abc",
+                "process_start_ts": "2026-04-19T00:00:00.000Z",
+            },
+            {
+                "process_id": "P2",
+                "feature_value": "",
+                "process_start_ts": "2026-04-19T00:10:00.000Z",
+            },
+            {
+                "process_id": "P3",
+                "feature_value": "2.4",
+                "process_start_ts": "2026-04-19T00:20:00.000Z",
+            },
+        ],
+    )
+
+    feature_trace = figure["data"][0]
+    assert feature_trace["name"] == "Feature value"
+    assert feature_trace["y"] == [2.4]
+
+
 def test_spc_band_with_points_figure_contains_feature_trace_and_customdata() -> None:
     figure = spc_band_with_points_figure(
         {
@@ -140,3 +186,16 @@ def test_waveform_figure_and_empty_drilldown() -> None:
     wf = waveform_figure([{"x": "t1", "y": 1.0}, {"x": "t2", "y": 2.0}], "P1")
     assert wf["layout"]["title"] == "Raw Waveform Preview (P1)"
     assert wf["data"][0]["name"] == "Raw waveform"
+
+
+def test_waveform_figure_ignores_invalid_points() -> None:
+    wf = waveform_figure(
+        [
+            {"x": "t1", "y": "abc"},
+            {"x": "t2", "y": ""},
+            {"x": "t3", "y": "1.5"},
+        ],
+        "P1",
+    )
+
+    assert wf["data"][0]["y"] == [1.5]

--- a/tests/test_dashboard_view_models.py
+++ b/tests/test_dashboard_view_models.py
@@ -71,6 +71,19 @@ def test_build_chart_name_falls_back_to_composed_name() -> None:
     assert build_chart_name(row) == "RCP_A / dc_bias / step:1 / mean (CHART_10)"
 
 
+def test_build_chart_name_preserves_falsy_value_step_no_zero() -> None:
+    """Verify that step_no=0 is displayed as 0, not as "-"."""
+    row = {
+        "recipe_id": "RCP_B",
+        "parameter": "voltage",
+        "step_no": 0,
+        "feature_type": "median",
+        "chart_id": "CHART_20",
+    }
+
+    assert build_chart_name(row) == "RCP_B / voltage / step:0 / median (CHART_20)"
+
+
 def test_chart_points_figure_contains_feature_and_threshold_lines() -> None:
     figure = chart_points_figure(
         {

--- a/tests/test_dashboard_view_models.py
+++ b/tests/test_dashboard_view_models.py
@@ -21,6 +21,18 @@ def test_sort_judge_rows_prioritizes_ng_warn_ok() -> None:
     assert [row["result_id"] for row in sorted_rows] == ["JR_3", "JR_2", "JR_1"]
 
 
+def test_sort_judge_rows_same_level_descending_judged_at() -> None:
+    rows = [
+        {"result_id": "JR_1", "level": "WARN", "judged_at": "2026-04-17T00:00:00.000Z"},
+        {"result_id": "JR_2", "level": "WARN", "judged_at": "2026-04-17T00:00:02.000Z"},
+        {"result_id": "JR_3", "level": "WARN", "judged_at": "2026-04-17T00:00:01.000Z"},
+    ]
+
+    sorted_rows = sort_judge_rows(rows)
+
+    assert [row["result_id"] for row in sorted_rows] == ["JR_2", "JR_3", "JR_1"]
+
+
 def test_chart_band_figure_contains_center_warning_critical() -> None:
     figure = chart_band_figure(
         {


### PR DESCRIPTION
## Summary
- add the read-only dashboard baseline for charts, active charts, history, and judge result browsing
- add dashboard API client and view model helpers for chart naming, SPC rendering, and waveform drilldown
- extend db_api with chart point and waveform preview endpoints used by the dashboard
- add dashboard-focused tests and dashboard dependencies

## Testing
- pre-commit hooks on commit
- mypy src/portfolio_fdc/dashboard/view_models.py src/portfolio_fdc/dashboard/api_client.py src/portfolio_fdc/dashboard/app.py src/portfolio_fdc/db_api/app.py src/portfolio_fdc/db_api/chart_repository.py tests/test_dashboard_api_client.py tests/test_dashboard_view_models.py

Refs #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 概要
ダッシュボードの読み取り専用ベースラインと waveform ドリルダウンを追加。Dash ベースの Read-only UI（Charts, Active, History, Judge Results）、ダッシュボード向け API クライアントとビュー・モデル、ならびに db_api のチャートポイント／waveform プレビュー用エンドポイントを実装。

## 主な変更（短）
- ドキュメント: Phase‑1 仕様追加（docs/issues/child-dashboard-read-only-baseline.md、docs/issues/child-judge-mvp.md）。
- 依存追加: pyproject.toml に dash>=2.18, plotly>=5.24 を追加。
- ダッシュボード:
  - src/portfolio_fdc/dashboard/api_client.py: APIError 型、応答エンベロープ検査、UTC ミリ秒パース、/charts 等の GET ヘルパー（レスポンス形状検証含む）。
  - src/portfolio_fdc/dashboard/app.py: Dash アプリ（タブ式 UI、URL クエリ同期、Load ボタン遅延ロード、validate_base_url によるベース URL 検証、各種コールバック、Active→ドリルダウン、__main__ 起動）。
    - ベース URL 検証を厳格化（認証情報付き URL 禁止、非 HTTP(S) 禁止、パス/クエリ/フラグメント禁止、許可ホストリスト・DNS 解決と IP 範囲チェック、ゼロバインド/不正ポート拒否）。
- ビュー・モデル:
  - src/portfolio_fdc/dashboard/view_models.py: 判定ソート、チャート名構築、safe_cast_float、閾値バンド/SPC/ポイント/波形図生成ヘルパー（Plotly 風図辞書生成）。
- db_api:
  - src/portfolio_fdc/db_api/chart_repository.py: ChartPointView DTO と find_chart_points() 追加。
  - src/portfolio_fdc/db_api/app.py: GET /charts/{chart_id}/points と GET /processes/{process_id}/waveform-preview を追加。waveform preview は ProcessInfo.raw_csv_path を参照してサーバ側でローカル CSV を検査・pandas で解析（パス正規化・存在チェック・DATA... ヘッダ検出）。
- テスト・型チェック:
  - 新規テスト: tests/test_dashboard_api_client.py、tests/test_dashboard_view_models.py、tests/test_dashboard_app.py。該当ファイルで mypy 実行。pre-commit フック実行済み。

## リスク（要確認・短）
- サーバ側ファイルアクセス（waveform preview）:
  - raw_csv_path のサーバ側読み込みはディレクトリトラバーサル、任意ファイル露出、権限エラー、大容量ファイルによるリソース枯渇のリスクがある。現状は存在チェック・相対パス正規化・ヘッダ検出のみで、アクセス制限や読み込みコスト制御が不十分。
- ベース URL 検証の運用誤差:
  - DNS 解決や厳格な許可ホスト/IP 制限により正当なターゲットが誤って拒否される可能性。許可リスト管理手順が必要。
- API エンベロープ依存:
  - api_client が {"ok": True, "data": ...} 形式に厳密に依存しており、バックエンド側の小さな契約変更でエラーが発生しやすい。
- コールバック複雑性:
  - app.py の多数の相互依存コールバックは状態不整合や競合条件、未捕捉例外の温床になり得る。
- CSV 処理の安定性:
  - pandas 読み込みにタイムアウト／メモリ制御が無いため、大容量や破損ファイルでサービスに影響を与える恐れがある。

## テストギャップ（優先度順・短）
1. E2E UI 統合テスト（タブ遷移、URL クエリ同期、Load→Charts→Active→Drilldown の正常フロー）。
2. db_api 異常系テスト（/charts/{id}/points と /processes/{id}/waveform-preview の 404/5xx/タイムアウト、破損・ヘッダ欠如・非数値列、大容量ファイル）。
3. ファイルアクセス安全性テスト（raw_csv_path のトラバーサル防止、アクセス権エラー、サンドボックス境界、読み込みサイズ上限）。
4. API 契約互換テスト（dashboard.api_client と db_api の envelope/フィールド形状の自動化検証）。
5. 並行操作／状態競合テスト（複数ユーザ・古い URL パラメータ適用でのコールバック競合、選択維持の整合性）。
6. リソース制限と耐久性検証（pandas 読み込みの時間・メモリ制限、ストリーミング/チャンク処理、タイムアウト導入の検討）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->