### PR TITLE
test: dashboardサービス群の分岐・異常系網羅テスト追加 (#158)

### DIFF
--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -295,6 +295,36 @@ def test_chart_name_option_service_validate_base_url_apierror(logger, deps, capl
     assert selected is None
 
 
+def test_chart_name_option_service_recipe_id_omitted(logger, deps):
+    service = ChartNameOptionService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
+    service.refresh_chart_name_options(1, "base_url", "", "c1")
+    # recipe_idが空の場合、paramsに含まれない
+    called_args = deps.get_charts.call_args[1]["params"]
+    assert "recipe_id" not in called_args
+
+
+def test_chart_name_option_service_selected_none_when_not_found(logger, deps):
+    service = ChartNameOptionService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
+    options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "not_found")
+    assert options
+    assert selected is None
+
+
+def test_active_drilldown_service_validate_base_url_tuple(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    # validate_base_urlがtupleを返す場合の分岐網羅
+    deps.validate_base_url.return_value = ("safe_url", "dummy")
+    deps.get_process_waveform_preview.return_value = {"points": [{"y": 1}, {"y": 2}, {"y": 3}]}
+    click_data = {"points": [{"customdata": "pid"}]}
+    result = service.render_active_drilldown(click_data, "base_url")
+    deps.get_process_waveform_preview.assert_called_with("safe_url", "pid", params={"limit": 500})
+    assert result["data"]
+
+
 def test_chart_name_option_service_get_charts_apierror(logger, deps, caplog):
     service = ChartNameOptionService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
@@ -303,35 +333,6 @@ def test_chart_name_option_service_get_charts_apierror(logger, deps, caplog):
         options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
     assert options == []
     assert selected is None
-
-    def test_chart_name_option_service_recipe_id_omitted(logger, deps):
-        service = ChartNameOptionService(logger, deps)
-        deps.validate_base_url.return_value = "safe_url"
-        deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
-        service.refresh_chart_name_options(1, "base_url", "", "c1")
-        # recipe_idが空の場合、paramsに含まれない
-        called_args = deps.get_charts.call_args[1]["params"]
-        assert "recipe_id" not in called_args
-
-    def test_chart_name_option_service_selected_none_when_not_found(logger, deps):
-        service = ChartNameOptionService(logger, deps)
-        deps.validate_base_url.return_value = "safe_url"
-        deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
-        options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "not_found")
-        assert options
-        assert selected is None
-
-    def test_active_drilldown_service_validate_base_url_tuple(logger, deps):
-        service = ActiveDrilldownService(logger, deps)
-        # validate_base_urlがtupleを返す場合の分岐網羅
-        deps.validate_base_url.return_value = ("safe_url", "dummy")
-        deps.get_process_waveform_preview.return_value = {"points": [1, 2, 3]}
-        click_data = {"points": [{"customdata": "pid"}]}
-        result = service.render_active_drilldown(click_data, "base_url")
-        deps.get_process_waveform_preview.assert_called_with(
-            "safe_url", "pid", params={"limit": 500}
-        )
-        assert result["data"]
 
 
 def test_navigation_service_select_chart_from_table_none_cases():

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -49,6 +49,40 @@ def test_active_drilldown_service_process_id_invalid(logger, deps):
     assert "Only feature points" in result["layout"]["annotations"][0]["text"]
 
 
+def test_active_drilldown_service_validate_base_url_apierror(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    deps.validate_base_url.side_effect = APIError("msg")
+    click_data = {"points": [{"customdata": "pid"}]}
+    result = service.render_active_drilldown(click_data, "base_url")
+    text = result["layout"]["annotations"][0]["text"]
+    assert "Failed to load waveform" in text
+    assert "msg" in text
+
+
+def test_active_drilldown_service_preview_not_dict(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    # previewがstr
+    deps.get_process_waveform_preview.return_value = "not_a_dict"
+    click_data = {"points": [{"customdata": "pid"}]}
+    result = service.render_active_drilldown(click_data, "base_url")
+    text = result["layout"]["annotations"][0]["text"]
+    assert "No waveform preview data" in text or "No waveform" in text
+    # previewがlist
+    deps.get_process_waveform_preview.return_value = [1, 2, 3]
+    result = service.render_active_drilldown(click_data, "base_url")
+    text = result["layout"]["annotations"][0]["text"]
+    assert "No waveform preview data" in text or "No waveform" in text
+
+
+def test_active_drilldown_service_customdata_empty_string(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    click_data = {"points": [{"customdata": ""}]}
+    result = service.render_active_drilldown(click_data, "base_url")
+    text = result["layout"]["annotations"][0]["text"]
+    assert "Only feature points" in text
+
+
 def test_active_drilldown_service_apierror(logger, deps):
     service = ActiveDrilldownService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
@@ -105,6 +139,16 @@ def test_chart_name_option_service_get_charts_unexpected_exception(logger, deps,
 
 
 def test_navigation_service_move_to_active_by_chart_name():
+    def test_navigation_service_move_to_active_by_chart_name_recipe_id_omitted():
+        service = NavigationService()
+        tab, chart_id, search = service.move_to_active_by_chart_name("c1", "", "")
+        import urllib.parse
+
+        parsed = urllib.parse.parse_qs(search.lstrip("?"))
+        assert "recipe_id" not in parsed
+        assert parsed["tab"] == ["active"]
+        assert parsed["chart_id"] == ["c1"]
+
     import urllib.parse
 
     service = NavigationService()
@@ -224,6 +268,16 @@ def test_url_filter_service_sync_filters_from_url_none():
 
 
 def test_url_filter_service_sync_filters_from_url_partial_keys():
+    def test_url_filter_service_tab_judge():
+        service = UrlFilterService()
+        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
+            "?tab=judge&recipe_id=r1&chart_id=c1&result_id=res1"
+        )
+        assert tab == "judge"
+        assert recipe_id == "r1"
+        assert chart_id == "c1"
+        assert result_id == "res1"
+
     service = UrlFilterService()
     # recipe_idのみ
     tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?recipe_id=r1")

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -262,3 +262,50 @@ def test_tab_load_service_unexpected_exception(logger, deps, caplog):
         r.levelname == "ERROR" and "Unexpected error in load_data callback" in r.getMessage()
         for r in caplog.records
     )
+
+
+def test_navigation_service_select_chart_from_table_none_cases():
+    service = NavigationService()
+    from dash import no_update
+
+    # active_cell=None
+    assert service.select_chart_from_table(None, [{"chart_id": "c1"}]) is no_update
+    # data=None
+    assert service.select_chart_from_table({"row": 0}, None) is no_update
+
+
+def test_navigation_service_select_chart_from_table_row_idx_cases():
+    service = NavigationService()
+    from dash import no_update
+
+    data = [{"chart_id": "c1"}, {"chart_id": "c2"}]
+    # row_idx out of range
+    assert service.select_chart_from_table({"row": 2}, data) is no_update
+    # row_idx negative
+    assert service.select_chart_from_table({"row": -1}, data) is no_update
+    # row_idx not int
+    assert service.select_chart_from_table({"row": "0"}, data) is no_update
+
+
+def test_navigation_service_select_chart_from_table_chart_id_empty():
+    service = NavigationService()
+    from dash import no_update
+
+    data = [{"chart_id": ""}]
+    assert service.select_chart_from_table({"row": 0}, data) is no_update
+
+
+def test_navigation_service_select_chart_from_table_normal():
+    service = NavigationService()
+    data = [{"chart_id": "c1"}, {"chart_id": "c2"}]
+    assert service.select_chart_from_table({"row": 1}, data) == "c2"
+
+
+def test_navigation_service_sync_active_selected_base_url():
+    service = NavigationService()
+    from src.portfolio_fdc.dashboard.base_url import DEFAULT_DB_API_BASE_URL
+
+    # 空文字列→デフォルト
+    assert service.sync_active_selected_base_url("") == DEFAULT_DB_API_BASE_URL
+    # 非空はそのまま
+    assert service.sync_active_selected_base_url("http://example.com") == "http://example.com"

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -1,0 +1,237 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.portfolio_fdc.dashboard.services.active_drilldown import ActiveDrilldownService
+from src.portfolio_fdc.dashboard.services.chart_name_options import ChartNameOptionService
+from src.portfolio_fdc.dashboard.services.navigation import NavigationService
+from src.portfolio_fdc.dashboard.services.tab_load import TabLoadService
+from src.portfolio_fdc.dashboard.services.url_filters import UrlFilterService
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test")
+
+
+@pytest.fixture
+def deps():
+    return MagicMock()
+
+
+def test_active_drilldown_service_render_active_drilldown(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    # click_dataがNoneの場合
+    result = service.render_active_drilldown(None, "base_url")
+    assert "Click a point" in result["layout"]["annotations"][0]["text"]
+
+
+def test_active_drilldown_service_points_empty(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    # pointsが空リスト
+    result = service.render_active_drilldown({"points": []}, "base_url")
+    assert "feature point" in result["layout"]["annotations"][0]["text"]
+
+
+def test_active_drilldown_service_point_not_dict(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    # points[0]がdictでない
+    result = service.render_active_drilldown({"points": [123]}, "base_url")
+    assert "Only feature points" in result["layout"]["annotations"][0]["text"]
+
+
+def test_active_drilldown_service_process_id_invalid(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    # process_idがstrでない
+    result = service.render_active_drilldown({"points": [{"customdata": 123}]}, "base_url")
+    assert "Only feature points" in result["layout"]["annotations"][0]["text"]
+
+
+def test_active_drilldown_service_apierror(logger, deps):
+    service = ActiveDrilldownService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.get_process_waveform_preview.side_effect = __import__(
+        "src.portfolio_fdc.dashboard.api_client"
+    ).portfolio_fdc.dashboard.api_client.APIError("msg")
+    # APIError発生時
+    click_data = {"points": [{"customdata": "pid"}]}
+    result = service.render_active_drilldown(click_data, "base_url")
+    assert "Failed to load waveform" in result["layout"]["annotations"][0]["text"]
+
+
+def test_active_drilldown_service_unexpected_exception(logger, deps, caplog):
+    service = ActiveDrilldownService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.get_process_waveform_preview.side_effect = Exception("unexpected")
+    click_data = {"points": [{"customdata": "pid"}]}
+    with caplog.at_level("ERROR"):
+        result = service.render_active_drilldown(click_data, "base_url")
+    assert "unexpected error" in result["layout"]["annotations"][0]["text"]
+    assert any(
+        "Unexpected error while rendering active drilldown" in r for r in caplog.text.splitlines()
+    )
+
+
+def test_chart_name_option_service_refresh_chart_name_options(logger, deps):
+    service = ChartNameOptionService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
+    options, _ = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
+    assert isinstance(options, list)
+
+
+def test_chart_name_option_service_get_charts_unexpected_exception(logger, deps, caplog):
+    service = ChartNameOptionService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.get_charts.side_effect = Exception("unexpected")
+    with caplog.at_level("ERROR"):
+        options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
+    assert options == []
+    assert selected is None
+    assert any(
+        "Unexpected error while refreshing chart options" in r for r in caplog.text.splitlines()
+    )
+
+
+def test_navigation_service_move_to_active_by_chart_name():
+    service = NavigationService()
+    tab, chart_id, search = service.move_to_active_by_chart_name("c1", "r1", "")
+    assert tab == "active"
+    assert chart_id == "c1"
+    assert search.startswith("?")
+
+
+def test_navigation_service_selected_chart_id_none():
+    service = NavigationService()
+    # Noneの場合
+    tab, chart_id, search = service.move_to_active_by_chart_name(None, "r1", "")
+    from dash import no_update
+
+    assert tab is no_update
+    assert chart_id is no_update
+    assert search is no_update
+
+
+def test_navigation_service_selected_chart_id_empty():
+    service = NavigationService()
+    # 空文字の場合
+    tab, chart_id, search = service.move_to_active_by_chart_name("", "r1", "")
+    from dash import no_update
+
+    assert tab is no_update
+    assert chart_id is no_update
+    assert search is no_update
+
+
+def test_navigation_service_current_search_equal():
+    service = NavigationService()
+    # current_searchが一致する場合
+    params = {"tab": "active", "chart_id": "c1", "recipe_id": "r1"}
+    from urllib.parse import urlencode
+
+    current_search = f"?{urlencode(params)}"
+    tab, chart_id, search = service.move_to_active_by_chart_name("c1", "r1", current_search)
+    from dash import no_update
+
+    assert tab is no_update
+    assert chart_id is no_update
+    assert search is no_update
+
+
+def test_tab_load_service_load_data(logger, deps):
+    service = TabLoadService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.render_charts_tab.return_value = ("charts", "")
+    result, _ = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    assert result == ("charts", "") or hasattr(result, "children")
+
+
+def test_url_filter_service_sync_filters_from_url():
+    service = UrlFilterService()
+    tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
+        "?tab=active&recipe_id=r1&chart_id=c1&result_id=res1"
+    )
+    assert tab == "active"
+    assert recipe_id == "r1"
+    assert chart_id == "c1"
+    assert result_id == "res1"
+
+
+def test_url_filter_service_invalid_tab():
+    service = UrlFilterService()
+    # 不正なタブ値は"charts"にフォールバック
+    tab, *_ = service.sync_filters_from_url("?tab=invalid&recipe_id=r&chart_id=c&result_id=res")
+    assert tab == "charts"
+
+
+def test_url_filter_service_empty_string():
+    service = UrlFilterService()
+    # 空文字列は全て空返却（tabは"charts"）
+    tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("")
+    assert tab == "charts"
+    assert recipe_id == ""
+    assert chart_id == ""
+    assert result_id == ""
+
+
+def test_url_filter_service_url_encoded():
+    service = UrlFilterService()
+    # URLエンコードされたクエリ
+    tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
+        "?tab=history&recipe_id=r%201&chart_id=c%2F1&result_id=res%3D1"
+    )
+    assert tab == "history"
+    assert recipe_id == "r 1"
+    assert chart_id == "c/1"
+    assert result_id == "res=1"
+
+
+def test_tab_load_service_tab_branches(logger, deps):
+    service = TabLoadService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.render_charts_tab.return_value = ("charts", "")
+    deps.render_active_tab.return_value = ("active", "")
+    deps.render_history_tab.return_value = ("history", "")
+    deps.render_judge_tab.return_value = ("judge", "")
+    # charts
+    result, _ = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    assert result == ("charts", "") or hasattr(result, "children")
+    # active
+    result, _ = service.load_data("active", 1, "base_url", "r1", "c1", "res1")
+    assert result == ("active", "") or hasattr(result, "children")
+    # history
+    result, _ = service.load_data("history", 1, "base_url", "r1", "c1", "res1")
+    assert result == ("history", "") or hasattr(result, "children")
+    # judge
+    result, _ = service.load_data("judge", 1, "base_url", "r1", "c1", "res1")
+    assert result == ("judge", "") or hasattr(result, "children")
+
+
+def test_tab_load_service_apierror_code_and_no_code(logger, deps):
+    service = TabLoadService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    # codeあり
+    api_error = __import__(
+        "src.portfolio_fdc.dashboard.api_client"
+    ).portfolio_fdc.dashboard.api_client.APIError("msg", code="E001")
+    deps.render_charts_tab.side_effect = api_error
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    assert "E001" in msg
+    # codeなし
+    api_error2 = __import__(
+        "src.portfolio_fdc.dashboard.api_client"
+    ).portfolio_fdc.dashboard.api_client.APIError("msg2")
+    deps.render_charts_tab.side_effect = api_error2
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    assert "msg2" in msg and "[" not in msg
+
+
+def test_tab_load_service_unexpected_exception(logger, deps, caplog):
+    service = TabLoadService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.render_charts_tab.side_effect = Exception("unexpected")
+    with caplog.at_level("ERROR"):
+        result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    assert "Unexpected error while loading dashboard data" in msg
+    assert any("Unexpected error in load_data callback" in r for r in caplog.text.splitlines())

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -71,7 +71,9 @@ def test_active_drilldown_service_unexpected_exception(logger, deps, caplog):
         result = service.render_active_drilldown(click_data, "base_url")
     assert "unexpected error" in result["layout"]["annotations"][0]["text"]
     assert any(
-        "Unexpected error while rendering active drilldown" in r for r in caplog.text.splitlines()
+        r.levelname == "ERROR"
+        and "Unexpected error while rendering active drilldown" in r.getMessage()
+        for r in caplog.records
     )
 
 
@@ -96,16 +98,25 @@ def test_chart_name_option_service_get_charts_unexpected_exception(logger, deps,
     assert options == []
     assert selected is None
     assert any(
-        "Unexpected error while refreshing chart options" in r for r in caplog.text.splitlines()
+        r.levelname == "ERROR"
+        and "Unexpected error while refreshing chart options" in r.getMessage()
+        for r in caplog.records
     )
 
 
 def test_navigation_service_move_to_active_by_chart_name():
+    import urllib.parse
+
     service = NavigationService()
     tab, chart_id, search = service.move_to_active_by_chart_name("c1", "r1", "")
     assert tab == "active"
     assert chart_id == "c1"
     assert search.startswith("?")
+    # searchの内容を厳密に検証
+    parsed = urllib.parse.parse_qs(search.lstrip("?"))
+    assert parsed["tab"] == ["active"]
+    assert parsed["chart_id"] == ["c1"]
+    assert parsed["recipe_id"] == ["r1"]
 
 
 def test_navigation_service_selected_chart_id_none():
@@ -236,4 +247,7 @@ def test_tab_load_service_unexpected_exception(logger, deps, caplog):
     with caplog.at_level("ERROR"):
         result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
     assert "Unexpected error while loading dashboard data" in msg
-    assert any("Unexpected error in load_data callback" in r for r in caplog.text.splitlines())
+    assert any(
+        r.levelname == "ERROR" and "Unexpected error in load_data callback" in r.getMessage()
+        for r in caplog.records
+    )

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -167,8 +167,9 @@ def test_tab_load_service_load_data(logger, deps):
 
     deps.validate_base_url.return_value = "safe_url"
     deps.render_charts_tab.return_value = ("charts", "")
-    result, _ = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
     assert result == ("charts", "")
+    assert msg == ""
 
 
 def test_url_filter_service_sync_filters_from_url():
@@ -200,6 +201,40 @@ def test_url_filter_service_empty_string():
 
 
 def test_url_filter_service_url_encoded():
+    def test_url_filter_service_sync_filters_from_url_none():
+        service = UrlFilterService()
+        # Noneの場合
+        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(None)
+        assert tab == "charts"
+        assert recipe_id == ""
+        assert chart_id == ""
+        assert result_id == ""
+
+    def test_url_filter_service_sync_filters_from_url_partial_keys():
+        service = UrlFilterService()
+        # recipe_idのみ
+        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?recipe_id=r1")
+        assert tab == "charts"
+        assert recipe_id == "r1"
+        assert chart_id == ""
+        assert result_id == ""
+
+        # tab, chart_idのみ
+        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
+            "?tab=history&chart_id=c1"
+        )
+        assert tab == "history"
+        assert recipe_id == ""
+        assert chart_id == "c1"
+        assert result_id == ""
+
+        # tabが不正かつ他キーなし
+        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?tab=invalid")
+        assert tab == "charts"
+        assert recipe_id == ""
+        assert chart_id == ""
+        assert result_id == ""
+
     service = UrlFilterService()
     # URLエンコードされたクエリ
     tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
@@ -219,17 +254,21 @@ def test_tab_load_service_tab_branches(logger, deps):
     deps.render_history_tab.return_value = ("history", "")
     deps.render_judge_tab.return_value = ("judge", "")
     # charts
-    result, _ = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
     assert result == ("charts", "")
+    assert msg == ""
     # active
-    result, _ = service.load_data("active", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("active", 1, "base_url", "r1", "c1", "res1")
     assert result == ("active", "")
+    assert msg == ""
     # history
-    result, _ = service.load_data("history", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("history", 1, "base_url", "r1", "c1", "res1")
     assert result == ("history", "")
+    assert msg == ""
     # judge
-    result, _ = service.load_data("judge", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("judge", 1, "base_url", "r1", "c1", "res1")
     assert result == ("judge", "")
+    assert msg == ""
 
 
 def test_tab_load_service_apierror_code_and_no_code(logger, deps):

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -279,12 +279,12 @@ def test_tab_load_service_apierror_code_and_no_code(logger, deps):
     api_error = APIError("msg", code="E001")
     deps.render_charts_tab.side_effect = api_error
     result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
-    assert "E001" in msg
+    assert msg == "msg [E001]"
     # codeなし
     api_error2 = APIError("msg2")
     deps.render_charts_tab.side_effect = api_error2
     result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
-    assert "msg2" in msg and "[" not in msg
+    assert msg == "msg2"
 
 
 def test_tab_load_service_unexpected_exception(logger, deps, caplog):
@@ -347,6 +347,42 @@ def test_chart_name_option_service_recipe_id_omitted(logger, deps):
 
 
 def test_chart_name_option_service_selected_none_when_not_found(logger, deps):
+    def test_chart_name_option_service_validate_base_url_tuple(logger, deps):
+        service = ChartNameOptionService(logger, deps)
+        # validate_base_urlがtupleを返す場合の分岐網羅
+        deps.validate_base_url.return_value = ("safe_url", "dummy")
+        deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
+        options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
+        assert isinstance(options, list)
+        assert len(options) == 1
+        assert options[0]["value"] == "c1"
+        assert "name1" in options[0]["label"]
+        assert selected == "c1"
+
+    def test_tab_load_service_validate_base_url_tuple(logger, deps):
+        service = TabLoadService(logger, deps)
+        deps.validate_base_url.return_value = ("safe_url", "dummy")
+        deps.render_charts_tab.return_value = ("charts", "")
+        deps.render_active_tab.return_value = ("active", "")
+        deps.render_history_tab.return_value = ("history", "")
+        deps.render_judge_tab.return_value = ("judge", "")
+        # charts
+        result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+        assert result == ("charts", "")
+        assert msg == ""
+        # active
+        result, msg = service.load_data("active", 1, "base_url", "r1", "c1", "res1")
+        assert result == ("active", "")
+        assert msg == ""
+        # history
+        result, msg = service.load_data("history", 1, "base_url", "r1", "c1", "res1")
+        assert result == ("history", "")
+        assert msg == ""
+        # judge
+        result, msg = service.load_data("judge", 1, "base_url", "r1", "c1", "res1")
+        assert result == ("judge", "")
+        assert msg == ""
+
     service = ChartNameOptionService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
     deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -67,7 +67,7 @@ def test_active_drilldown_service_unexpected_exception(logger, deps, caplog):
     deps.validate_base_url.return_value = "safe_url"
     deps.get_process_waveform_preview.side_effect = Exception("unexpected")
     click_data = {"points": [{"customdata": "pid"}]}
-    with caplog.at_level("ERROR"):
+    with caplog.at_level(logging.ERROR, logger="test"):
         result = service.render_active_drilldown(click_data, "base_url")
     assert "unexpected error" in result["layout"]["annotations"][0]["text"]
     assert any(
@@ -93,7 +93,7 @@ def test_chart_name_option_service_get_charts_unexpected_exception(logger, deps,
     service = ChartNameOptionService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
     deps.get_charts.side_effect = Exception("unexpected")
-    with caplog.at_level("ERROR"):
+    with caplog.at_level(logging.ERROR, logger="test"):
         options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
     assert options == []
     assert selected is None
@@ -244,8 +244,19 @@ def test_tab_load_service_unexpected_exception(logger, deps, caplog):
     service = TabLoadService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
     deps.render_charts_tab.side_effect = Exception("unexpected")
-    with caplog.at_level("ERROR"):
+    with caplog.at_level(logging.ERROR, logger="test"):
         result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+
+    def test_active_drilldown_service_validate_base_url_tuple(logger, deps):
+        service = ActiveDrilldownService(logger, deps)
+        # validate_base_urlがtupleを返す場合の分岐網羅
+        deps.validate_base_url.return_value = ("safe_url", "dummy")
+        deps.get_process_waveform_preview.return_value = {"points": [1, 2, 3]}
+        click_data = {"points": [{"customdata": "pid"}]}
+        result = service.render_active_drilldown(click_data, "base_url")
+        # waveform_figureが返る（pointsが渡る）
+        assert result["data"]
+
     assert "Unexpected error while loading dashboard data" in msg
     assert any(
         r.levelname == "ERROR" and "Unexpected error in load_data callback" in r.getMessage()

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -158,6 +158,13 @@ def test_navigation_service_current_search_equal():
 
 def test_tab_load_service_load_data(logger, deps):
     service = TabLoadService(logger, deps)
+    # n_clicks=0 early return
+    result, msg = service.load_data("charts", 0, "base_url", "r1", "c1", "res1")
+    from dash import html
+
+    assert isinstance(result, html.Div)
+    assert "Press Load" in result.children
+
     deps.validate_base_url.return_value = "safe_url"
     deps.render_charts_tab.return_value = ("charts", "")
     result, _ = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
@@ -246,6 +253,73 @@ def test_tab_load_service_unexpected_exception(logger, deps, caplog):
     deps.render_charts_tab.side_effect = Exception("unexpected")
     with caplog.at_level(logging.ERROR, logger="test"):
         result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    assert "Unexpected error while loading dashboard data" in msg
+    assert any(
+        r.levelname == "ERROR" and "Unexpected error in load_data callback" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_tab_load_service_validate_base_url_apierror(logger, deps):
+    service = TabLoadService(logger, deps)
+    deps.validate_base_url.side_effect = APIError("msg", code="E001")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    assert msg == "msg [E001]"
+    deps.validate_base_url.side_effect = APIError("msg2")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    assert msg == "msg2"
+
+
+def test_tab_load_service_unknown_tab_fallback(logger, deps):
+    service = TabLoadService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.render_judge_tab.return_value = ("judge", "")
+    # 未知タブはjudge_tabにフォールバック
+    result, _ = service.load_data("unknown", 1, "base_url", "r1", "c1", "res1")
+    assert result == ("judge", "")
+
+
+def test_chart_name_option_service_n_clicks_zero(logger, deps):
+    service = ChartNameOptionService(logger, deps)
+    options, selected = service.refresh_chart_name_options(0, "base_url", "r1", "c1")
+    assert options == []
+    assert selected is None
+
+
+def test_chart_name_option_service_validate_base_url_apierror(logger, deps, caplog):
+    service = ChartNameOptionService(logger, deps)
+    deps.validate_base_url.side_effect = APIError("msg", code="E001")
+    with caplog.at_level(logging.ERROR, logger="test"):
+        options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
+    assert options == []
+    assert selected is None
+
+
+def test_chart_name_option_service_get_charts_apierror(logger, deps, caplog):
+    service = ChartNameOptionService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.get_charts.side_effect = APIError("msg2")
+    with caplog.at_level(logging.ERROR, logger="test"):
+        options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
+    assert options == []
+    assert selected is None
+
+    def test_chart_name_option_service_recipe_id_omitted(logger, deps):
+        service = ChartNameOptionService(logger, deps)
+        deps.validate_base_url.return_value = "safe_url"
+        deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
+        service.refresh_chart_name_options(1, "base_url", "", "c1")
+        # recipe_idが空の場合、paramsに含まれない
+        called_args = deps.get_charts.call_args[1]["params"]
+        assert "recipe_id" not in called_args
+
+    def test_chart_name_option_service_selected_none_when_not_found(logger, deps):
+        service = ChartNameOptionService(logger, deps)
+        deps.validate_base_url.return_value = "safe_url"
+        deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
+        options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "not_found")
+        assert options
+        assert selected is None
 
     def test_active_drilldown_service_validate_base_url_tuple(logger, deps):
         service = ActiveDrilldownService(logger, deps)
@@ -254,14 +328,10 @@ def test_tab_load_service_unexpected_exception(logger, deps, caplog):
         deps.get_process_waveform_preview.return_value = {"points": [1, 2, 3]}
         click_data = {"points": [{"customdata": "pid"}]}
         result = service.render_active_drilldown(click_data, "base_url")
-        # waveform_figureが返る（pointsが渡る）
+        deps.get_process_waveform_preview.assert_called_with(
+            "safe_url", "pid", params={"limit": 500}
+        )
         assert result["data"]
-
-    assert "Unexpected error while loading dashboard data" in msg
-    assert any(
-        r.levelname == "ERROR" and "Unexpected error in load_data callback" in r.getMessage()
-        for r in caplog.records
-    )
 
 
 def test_navigation_service_select_chart_from_table_none_cases():

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from src.portfolio_fdc.dashboard.api_client import APIError
 from src.portfolio_fdc.dashboard.services.active_drilldown import ActiveDrilldownService
 from src.portfolio_fdc.dashboard.services.chart_name_options import ChartNameOptionService
 from src.portfolio_fdc.dashboard.services.navigation import NavigationService
@@ -51,13 +52,14 @@ def test_active_drilldown_service_process_id_invalid(logger, deps):
 def test_active_drilldown_service_apierror(logger, deps):
     service = ActiveDrilldownService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
-    deps.get_process_waveform_preview.side_effect = __import__(
-        "src.portfolio_fdc.dashboard.api_client"
-    ).portfolio_fdc.dashboard.api_client.APIError("msg")
+    deps.get_process_waveform_preview.side_effect = APIError("msg")
     # APIError発生時
     click_data = {"points": [{"customdata": "pid"}]}
     result = service.render_active_drilldown(click_data, "base_url")
-    assert "Failed to load waveform" in result["layout"]["annotations"][0]["text"]
+    # 厳密にAPIError.messageが含まれることを検証
+    text = result["layout"]["annotations"][0]["text"]
+    assert "Failed to load waveform" in text
+    assert "msg" in text
 
 
 def test_active_drilldown_service_unexpected_exception(logger, deps, caplog):
@@ -77,8 +79,12 @@ def test_chart_name_option_service_refresh_chart_name_options(logger, deps):
     service = ChartNameOptionService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
     deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
-    options, _ = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
+    options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
     assert isinstance(options, list)
+    assert len(options) == 1
+    assert options[0]["value"] == "c1"
+    assert "name1" in options[0]["label"]
+    assert selected == "c1"
 
 
 def test_chart_name_option_service_get_charts_unexpected_exception(logger, deps, caplog):
@@ -144,7 +150,7 @@ def test_tab_load_service_load_data(logger, deps):
     deps.validate_base_url.return_value = "safe_url"
     deps.render_charts_tab.return_value = ("charts", "")
     result, _ = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
-    assert result == ("charts", "") or hasattr(result, "children")
+    assert result == ("charts", "")
 
 
 def test_url_filter_service_sync_filters_from_url():
@@ -196,32 +202,28 @@ def test_tab_load_service_tab_branches(logger, deps):
     deps.render_judge_tab.return_value = ("judge", "")
     # charts
     result, _ = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
-    assert result == ("charts", "") or hasattr(result, "children")
+    assert result == ("charts", "")
     # active
     result, _ = service.load_data("active", 1, "base_url", "r1", "c1", "res1")
-    assert result == ("active", "") or hasattr(result, "children")
+    assert result == ("active", "")
     # history
     result, _ = service.load_data("history", 1, "base_url", "r1", "c1", "res1")
-    assert result == ("history", "") or hasattr(result, "children")
+    assert result == ("history", "")
     # judge
     result, _ = service.load_data("judge", 1, "base_url", "r1", "c1", "res1")
-    assert result == ("judge", "") or hasattr(result, "children")
+    assert result == ("judge", "")
 
 
 def test_tab_load_service_apierror_code_and_no_code(logger, deps):
     service = TabLoadService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
     # codeあり
-    api_error = __import__(
-        "src.portfolio_fdc.dashboard.api_client"
-    ).portfolio_fdc.dashboard.api_client.APIError("msg", code="E001")
+    api_error = APIError("msg", code="E001")
     deps.render_charts_tab.side_effect = api_error
     result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
     assert "E001" in msg
     # codeなし
-    api_error2 = __import__(
-        "src.portfolio_fdc.dashboard.api_client"
-    ).portfolio_fdc.dashboard.api_client.APIError("msg2")
+    api_error2 = APIError("msg2")
     deps.render_charts_tab.side_effect = api_error2
     result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
     assert "msg2" in msg and "[" not in msg

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -164,6 +164,7 @@ def test_tab_load_service_load_data(logger, deps):
 
     assert isinstance(result, html.Div)
     assert "Press Load" in result.children
+    assert msg == ""
 
     deps.validate_base_url.return_value = "safe_url"
     deps.render_charts_tab.return_value = ("charts", "")
@@ -201,40 +202,6 @@ def test_url_filter_service_empty_string():
 
 
 def test_url_filter_service_url_encoded():
-    def test_url_filter_service_sync_filters_from_url_none():
-        service = UrlFilterService()
-        # Noneの場合
-        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(None)
-        assert tab == "charts"
-        assert recipe_id == ""
-        assert chart_id == ""
-        assert result_id == ""
-
-    def test_url_filter_service_sync_filters_from_url_partial_keys():
-        service = UrlFilterService()
-        # recipe_idのみ
-        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?recipe_id=r1")
-        assert tab == "charts"
-        assert recipe_id == "r1"
-        assert chart_id == ""
-        assert result_id == ""
-
-        # tab, chart_idのみ
-        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
-            "?tab=history&chart_id=c1"
-        )
-        assert tab == "history"
-        assert recipe_id == ""
-        assert chart_id == "c1"
-        assert result_id == ""
-
-        # tabが不正かつ他キーなし
-        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?tab=invalid")
-        assert tab == "charts"
-        assert recipe_id == ""
-        assert chart_id == ""
-        assert result_id == ""
-
     service = UrlFilterService()
     # URLエンコードされたクエリ
     tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
@@ -244,6 +211,40 @@ def test_url_filter_service_url_encoded():
     assert recipe_id == "r 1"
     assert chart_id == "c/1"
     assert result_id == "res=1"
+
+
+def test_url_filter_service_sync_filters_from_url_none():
+    service = UrlFilterService()
+    # Noneの場合
+    tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(None)
+    assert tab == "charts"
+    assert recipe_id == ""
+    assert chart_id == ""
+    assert result_id == ""
+
+
+def test_url_filter_service_sync_filters_from_url_partial_keys():
+    service = UrlFilterService()
+    # recipe_idのみ
+    tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?recipe_id=r1")
+    assert tab == "charts"
+    assert recipe_id == "r1"
+    assert chart_id == ""
+    assert result_id == ""
+
+    # tab, chart_idのみ
+    tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?tab=history&chart_id=c1")
+    assert tab == "history"
+    assert recipe_id == ""
+    assert chart_id == "c1"
+    assert result_id == ""
+
+    # tabが不正かつ他キーなし
+    tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?tab=invalid")
+    assert tab == "charts"
+    assert recipe_id == ""
+    assert chart_id == ""
+    assert result_id == ""
 
 
 def test_tab_load_service_tab_branches(logger, deps):

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -315,8 +315,9 @@ def test_tab_load_service_unknown_tab_fallback(logger, deps):
     deps.validate_base_url.return_value = "safe_url"
     deps.render_judge_tab.return_value = ("judge", "")
     # 未知タブはjudge_tabにフォールバック
-    result, _ = service.load_data("unknown", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("unknown", 1, "base_url", "r1", "c1", "res1")
     assert result == ("judge", "")
+    assert msg == ""
 
 
 def test_chart_name_option_service_n_clicks_zero(logger, deps):


### PR DESCRIPTION


## What

- dashboard配下のserviceクラス（ActiveDrilldownService, ChartNameOptionService, NavigationService, TabLoadService, UrlFilterService）に対し、分岐・異常系・logger出力を網羅するテストを追加

## Why

- サービス層の分岐・異常系の動作保証とリファクタリング耐性向上のため
- 例外発生時のlogger出力やフォールバック動作も含めて自動テストで担保するため

## How

- 各サービスの正常系・異常系・logger出力をpytest+mock/caplogで検証
- 不正値・空値・例外発生時の分岐網羅
- ruff/mypy/pytestを全てパスするようにフォーマット・型チェックも対応

## Checklist

- [x] Tests added/updated
- [x] ruff/mypy/pytest pass locally
- [x] CodeRabbit comments addressed (or resolved with rationale)

close #158


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ダッシュボードサービス群の分岐・異常系テスト追加（更新版）

- 実装概要
  - 追加ファイル: tests/dashboard/test_services.py（約 +513 行）
  - 対象: src/portfolio_fdc/dashboard/services/ の 5 クラス
    - ActiveDrilldownService, ChartNameOptionService, NavigationService, TabLoadService, UrlFilterService
  - 手法: pytest + MagicMock/monkeypatch + caplog を使用し、正常系・異常系・ログ出力・フォールバック動作を検証
  - 公開API変更: なし（テスト追加のみ）
  - 閉じる issue: #158 をクローズ予定

- 主なカバレッジ（追加／強化点）
  - ActiveDrilldownService
    - click_data=None、points 空／非dict、customdata/preview 欠損・非dict のフォールバックを検証
    - deps.get_process_waveform_preview の APIError／一般例外時の注釈文言と logger.exception の発生（ERROR ログ）を検証
    - validate_base_url が tuple を返す経路での base_url 解決と params={"limit":500} 伝播を検証
  - ChartNameOptionService
    - n_clicks=0 の早期リターン、validate_base_url/get_charts の APIError 時の空 options/selected=None を検証
    - recipe_id 空時に params を省略する挙動、chart_id 非存在時の selected=None を検証
    - get_charts 等での予期せぬ例外発生時に ERROR ログが出力されることを検証
  - NavigationService
    - move_to_active_by_chart_name のクエリ生成（recipe_id 空の省略含む）と dash.no_update 判定（chart_id None/""、current_search 一致時）を検証
    - select_chart_from_table: active_cell/data None、行インデックスの範囲外・負数・非整数、chart_id 空の早期リターンと正常選択を検証
    - sync_active_selected_base_url で空文字を DEFAULT_DB_API_BASE_URL に置換する挙動を確認
  - TabLoadService
    - n_clicks=0 の早期リターン、tabs（charts/active/history/judge）分岐および未知 tab の judge フォールバックを検証
    - APIError の code 有無でのメッセージ差分（例: "msg [E001]"）を検証、一般例外時の ERROR ログ検証
    - validate_base_url が APIError を返すケースのメッセージ整形を検証
  - UrlFilterService
    - フル／部分クエリの解析、無効 tab の charts フォールバック、空文字/None の空ID配列扱い、URL デコード、部分キーのみ存在するケースを検証

- PR内で対応済みの指摘（リスク軽減）
  - caplog の logger 取りこぼしリスクに配慮（テストで明示的に logger 指定／caplog.at_level を想定）してログ検証精度を向上
  - deps.validate_base_url の MagicMock 既定戻り値問題へ、各テストで明示的な戻り値設定を行い tuple/非tuple 分岐を確実にカバー
  - 初期自動解析の誤認（ChartNameOptionService の APIError が必ずログを出す想定）は実装確認により修正済

- 残存するリスク・未カバーのテストギャップ（優先度）
  - 高
    - NavigationService: select_chart_from_table のさらに細かい境界・型異常（非整数インデックスや current_search の微妙な一致条件）の追加網羅
  - 中
    - validate_base_url の多様な戻り値（tuple/None/特殊値）や APIError のバリエーションを各サービスでより細かく網羅
    - TabLoadService / ChartNameOptionService の追加例外パターン（get_charts の別例外など）や n_clicks 周辺の境界値テスト
  - 低
    - ActiveDrilldownService のハッピーパスでの waveform/figure 内容の深い検証や points/customdata の複合ケース網羅

- 推奨事項
  - テスト内フィクスチャ／ヘルパの整理で可読性と CI 安定性を向上させることを推奨
  - caplog と MagicMock の既定設定は CI 環境で誤検出の原因になり得るため、各テストでの明示的 logger 指定と戻り値固定を継続徹底することを推奨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->