### PR TITLE
test: #159 dashboard base_url セキュリティロジックのテストギャップ解消（パス・クエリ・許可リスト・ip_ur…

### DIFF
--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 from typing import Any
 
 import pytest
@@ -147,3 +148,54 @@ def test_validate_base_url_rejects_invalid_and_zero_ports() -> None:
 
     with pytest.raises(APIError):
         validate_base_url("http://localhost:0")
+
+
+# --- 以下 #159 テストギャップ対応 ---
+
+
+def test_validate_base_url_rejects_path_query_fragment() -> None:
+    # パス付き
+    with pytest.raises(APIError):
+        validate_base_url("http://localhost:8000/api")
+    # クエリ付き
+    with pytest.raises(APIError):
+        validate_base_url("http://localhost:8000?foo=bar")
+    # フラグメント付き
+    with pytest.raises(APIError):
+        validate_base_url("http://localhost:8000#frag")
+
+
+def test_validate_base_url_allowed_hosts_env(monkeypatch):
+    # 許可リスト追加ホストの動作確認
+    monkeypatch.setenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", "example.com")
+    # example.comが解決できる場合のみテスト
+    try:
+        socket.gethostbyname("example.com")
+    except Exception:
+        pytest.skip("example.comが解決できない環境のためスキップ")
+    # 許可リストに含まれる場合は_is_restricted_ipチェックをスキップ
+    url = "http://example.com:80"
+    result = validate_base_url(url)
+    assert result[1] == "example.com"
+
+
+def test_validate_base_url_returns_correct_hostname() -> None:
+    # 戻り値[1]が正規化済みhostname
+    assert validate_base_url("http://LOCALHOST:8000")[1] == "localhost"
+    assert validate_base_url("http://127.0.0.1:8000")[1] == "127.0.0.1"
+
+
+def test_validate_base_url_ip_url_conversion(monkeypatch):
+    # 非localhost外部URLのip_url変換
+    # 例: github.com (外部IPに変換されること)
+    monkeypatch.delenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", raising=False)
+    try:
+        socket.gethostbyname("github.com")
+    except Exception:
+        pytest.skip("github.comが解決できない環境のためスキップ")
+    url = "http://github.com:80"
+    ip_url, hostname = validate_base_url(url)
+    # ip_urlは http://[IP]:80 または http://IP:80 形式
+    assert ip_url.startswith("http://")
+    assert ip_url.endswith(":80")
+    assert hostname == "github.com"

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -166,17 +166,25 @@ def test_validate_base_url_rejects_path_query_fragment() -> None:
 
 
 def test_validate_base_url_allowed_hosts_env(monkeypatch):
-    # 許可リスト追加ホストの動作確認
-    monkeypatch.setenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", "example.com")
-    # example.comが解決できる場合のみテスト
-    try:
-        socket.gethostbyname("example.com")
-    except Exception:
-        pytest.skip("example.comが解決できない環境のためスキップ")
-    # 許可リストに含まれる場合は_is_restricted_ipチェックをスキップ
-    url = "http://example.com:80"
+    # 許可リスト追加ホストの動作確認（mockでrestricted IPを返す）
+    test_host = "example.com"
+    url = f"http://{test_host}:80"
+
+    # restricted IP (127.0.0.1) を返すようにmock
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", port)),
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    # 許可リスト未設定ならreject（_is_restricted_ip分岐）
+    monkeypatch.delenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", raising=False)
+    with pytest.raises(APIError):
+        validate_base_url(url)
+    # 許可リストに含めれば通る
+    monkeypatch.setenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", test_host)
     result = validate_base_url(url)
-    assert result[1] == "example.com"
+    assert result[1] == test_host
 
 
 def test_validate_base_url_returns_correct_hostname() -> None:
@@ -186,16 +194,18 @@ def test_validate_base_url_returns_correct_hostname() -> None:
 
 
 def test_validate_base_url_ip_url_conversion(monkeypatch):
-    # 非localhost外部URLのip_url変換
-    # 例: github.com (外部IPに変換されること)
+    # 非localhost外部URLのip_url変換（mockで固定IP返却）
     monkeypatch.delenv("PORTFOLIO_DB_API_ALLOWED_HOSTS", raising=False)
-    try:
-        socket.gethostbyname("github.com")
-    except Exception:
-        pytest.skip("github.comが解決できない環境のためスキップ")
-    url = "http://github.com:80"
+    test_host = "github.com"
+    url = f"http://{test_host}:80"
+
+    # 固定IP（8.8.8.8: Google Public DNS）を返すようにmock
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port)),
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
     ip_url, hostname = validate_base_url(url)
-    # ip_urlは http://[IP]:80 または http://IP:80 形式
-    assert ip_url.startswith("http://")
-    assert ip_url.endswith(":80")
-    assert hostname == "github.com"
+    assert ip_url == "http://8.8.8.8:80"
+    assert hostname == test_host


### PR DESCRIPTION

## What

- `dashboard/base_url.py` のセキュリティ重要ロジック（SSRF防止等）に関するテストギャップを解消
- パス・クエリ・フラグメント付きURLの拒否、許可リスト追加ホスト、戻り値hostname検証、外部URLのip_url変換など未カバーケースのテストを追加

## Why

- Issue [#159](https://github.com/mdht-daiki/fdc-logger-toolkit/issues/159) で指摘された通り、セキュリティ上重要なバリデーションの網羅的なテストが不足していたため

## How

- test_dashboard_app.py に以下のテストを追加
  - パス・クエリ・フラグメント付きURLの拒否
  - `PORTFOLIO_DB_API_ALLOWED_HOSTS` 環境変数による許可リスト追加ホストの動作確認
  - 戻り値のインデックス `[1]`（正規化済みhostname）の正しさの検証
  - 非localhostの外部URLにおける `ip_url` 変換（SSRFコアロジック）

## Checklist

- [x] Tests added/updated
- [x] ruff/mypy/pytest pass locally
- [x] CodeRabbit comments addressed (or resolved with rationale)

---

close #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## テスト追加内容（要点）
- パス・クエリ・フラグメント付きURLの拒否を追加で検証（/api、?foo=bar、#frag）
- 環境変数 PORTFOLIO_DB_API_ALLOWED_HOSTS による許可ホスト追加の動作確認（example.com を許可）
- validate_base_url の戻り値インデックス [1]（正規化済ホスト名）の検証（大文字LOCALHOST→localhost、数値IP保持）
- 非localhost 外部ホストに対する ip_url 変換（SSRF防止コアロジック）を DNS 解決をモックして検証（例: ホストを IP 埋込 URL に変換）

## リスク・テストギャップ
- カンマ区切りでの複数許可ホスト（PORTFOLIO_DB_API_ALLOWED_HOSTS の複数指定）を検証するテストが欠落
- IPv6 のブラケット形式（[IP]:port）や IPv6 解決後の戻り値フォーマットの網羅テストがない
- 許可リストに外部ホストが追加された場合の副作用（期待どおりに制限が緩和されるか、想定外の許可が発生しないか）の追加検証が不足
- ポート未指定時の既定ポート（80/443）やポート解決に関する明示的テストがない

## 備考
- DNS 依存性はテスト内で socket.getaddrinfo をモックして排除しており、ネットワーク分離環境でも安定して実行できるように配慮されている。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->