### PR TITLE
test: #160 _path_segmentの特殊文字エンコード動作をテスト

### DIFF
--- a/tests/dashboard/test_dashboard_api_client.py
+++ b/tests/dashboard/test_dashboard_api_client.py
@@ -182,9 +182,12 @@ def test_dict_getters_raise_api_error_for_invalid_shape(
 
 def test_path_segment_encodes_special_chars(monkeypatch):
     # chart_idに/や%など特殊文字を含めた場合のエンドポイントパスを検証
-    called = {}
 
-    def _fake_get(url, *args, **kwargs):
+    import urllib.parse
+
+    called: dict[str, Any] = {}
+
+    def _fake_get(url: str, *args, **kwargs) -> _FakeResponse:
         called["url"] = url
         # レスポンスは最低限でOK
         return _FakeResponse(200, {"ok": True, "data": []})
@@ -194,5 +197,6 @@ def test_path_segment_encodes_special_chars(monkeypatch):
     # / → %2F, % → %25 など
     chart_id = "CHART/1%"
     get_chart_points("http://localhost:8000", chart_id=chart_id)
-    # 呼び出しURLのパス部分を検証
-    assert "/charts/CHART%2F1%25/points" in called["url"]
+    # 呼び出しURLのパス部分を厳密に検証
+    parsed = urllib.parse.urlparse(called["url"])
+    assert parsed.path == "/charts/CHART%2F1%25/points"

--- a/tests/dashboard/test_dashboard_api_client.py
+++ b/tests/dashboard/test_dashboard_api_client.py
@@ -178,3 +178,21 @@ def test_dict_getters_raise_api_error_for_invalid_shape(
 
     assert expected_fragment in exc_info.value.message
     assert "expected dict" in exc_info.value.message
+
+
+def test_path_segment_encodes_special_chars(monkeypatch):
+    # chart_idに/や%など特殊文字を含めた場合のエンドポイントパスを検証
+    called = {}
+
+    def _fake_get(url, *args, **kwargs):
+        called["url"] = url
+        # レスポンスは最低限でOK
+        return _FakeResponse(200, {"ok": True, "data": []})
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _fake_get)
+
+    # / → %2F, % → %25 など
+    chart_id = "CHART/1%"
+    get_chart_points("http://localhost:8000", chart_id=chart_id)
+    # 呼び出しURLのパス部分を検証
+    assert "/charts/CHART%2F1%25/points" in called["url"]


### PR DESCRIPTION


## What

- `_path_segment()` の特殊文字（/・% など）エンコード動作をテスト
- `get_chart_points` で特殊文字を含む `chart_id` を指定した場合のリクエストパス生成を検証

## Why

- Issue #160 で指摘された、特殊文字を含むIDのURLエンコード動作のテストギャップを解消するため

## How

- test_dashboard_api_client.py に
  - `/` や `%` を含む `chart_id` を使った場合に `/charts/CHART%2F1%25/points` となることを検証するテストを追加
  - requests.get を monkeypatch し、実際のリクエストパスを検証

## Checklist

- [x] Tests added/updated
- [x] ruff/mypy/pytest pass locally
- [x] CodeRabbit comments addressed (or resolved with rationale)

---

close #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## PR 175: `_path_segment()` 特殊文字エンコード動作テスト追加

- 概要
  - Issue #160 のテストギャップを解消するため、`_path_segment()` による特殊文字のURLエンコード動作を検証するテストを追加。
  - `tests/dashboard/test_dashboard_api_client.py` に `test_path_segment_encodes_special_chars()` を追加し、`requests.get` を monkeypatch して実際のリクエストパスを検証。
  - テストは `chart_id="CHART/1%"` を使い、生成されるパスが正しく `/charts/CHART%2F1%25/points` となることをアサート。

- 変更点
  - テストのみの追加（+18 行程度）。実装コードや公開APIの変更はなし。

- リスク・テストギャップ
  - カバレッジが限定的：`chart_id` の単一パターンのみ検証しており、`process_id` / `result_id` に対する呼び出しは未カバー。
  - 特殊文字の範囲が狭い：`/`・`%` のみで、`?`、`#`、`&`、`+`、`@` 等や空文字・長大文字列は未検証。
  - エッジケース未検証：Unicode (非ASCII) や二重エンコードの回避、既にエンコード済み入力の取り扱いなどが確認されていない。
  - テスト手法の注意点：monkeypatch でリクエストを捕捉する方式は有効だが、将来の実装変更（内部で別のHTTPクライアントを採用）でテストが無効化される可能性がある。

- 意図
  - `urllib.parse.quote` によるパスセグメントの期待値を明示的に検証し、Issue #160 をクローズすることを意図。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->