### PR TITLE
test: コールバック・api_clientユーティリティ・view_modelsのテストギャップ解消 (#153, #161)

### DIFF
--- a/tests/dashboard/test_dashboard_api_client.py
+++ b/tests/dashboard/test_dashboard_api_client.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+import requests
 
 from portfolio_fdc.dashboard.api_client import (
     APIError,
+    _request_envelope,
     get_active_charts,
     get_chart_points,
     get_charts,
@@ -13,6 +15,8 @@ from portfolio_fdc.dashboard.api_client import (
     get_judge_result,
     get_judge_results,
     get_process_waveform_preview,
+    parse_api_error,
+    parse_utc_millis,
 )
 
 
@@ -200,3 +204,84 @@ def test_path_segment_encodes_special_chars(monkeypatch):
     # 呼び出しURLのパス部分を厳密に検証
     parsed = urllib.parse.urlparse(called["url"])
     assert parsed.path == "/charts/CHART%2F1%25/points"
+
+
+# --- #153: parse_utc_millis ---
+
+
+def test_parse_utc_millis_returns_dash_for_none() -> None:
+    assert parse_utc_millis(None) == "-"
+
+
+def test_parse_utc_millis_returns_dash_for_empty_string() -> None:
+    assert parse_utc_millis("") == "-"
+
+
+def test_parse_utc_millis_converts_z_suffix_to_utc() -> None:
+    result = parse_utc_millis("2026-04-19T00:00:00.123Z")
+    assert result == "2026-04-19 00:00:00.123 UTC"
+
+
+def test_parse_utc_millis_converts_string_without_millis() -> None:
+    result = parse_utc_millis("2026-04-19T00:00:00Z")
+    assert result == "2026-04-19 00:00:00.000 UTC"
+
+
+def test_parse_utc_millis_returns_original_for_invalid_string() -> None:
+    result = parse_utc_millis("not-a-timestamp")
+    assert result == "not-a-timestamp"
+
+
+def test_parse_utc_millis_converts_non_utc_timezone_to_utc() -> None:
+    # +09:00 → UTC (9時間引く)
+    result = parse_utc_millis("2026-04-19T09:00:00.000+09:00")
+    assert result == "2026-04-19 00:00:00.000 UTC"
+
+
+# --- #153: parse_api_error ---
+
+
+def test_parse_api_error_with_error_envelope_returns_code_and_message() -> None:
+    payload = {"error": {"code": "NOT_FOUND", "message": "resource not found"}}
+    err = parse_api_error(payload, 404)
+    assert err.code == "NOT_FOUND"
+    assert err.message == "resource not found"
+    assert err.status_code == 404
+
+
+def test_parse_api_error_with_detail_key_returns_detail_message() -> None:
+    payload = {"detail": "Invalid input"}
+    err = parse_api_error(payload, 400)
+    assert err.message == "Invalid input"
+    assert err.status_code == 400
+
+
+def test_parse_api_error_with_no_error_or_detail_returns_generic() -> None:
+    payload: dict[str, Any] = {"ok": False}
+    err = parse_api_error(payload, 500)
+    assert err.message == "API error (status=500)"
+    assert err.status_code == 500
+
+
+def test_parse_api_error_with_non_dict_payload_returns_generic() -> None:
+    err = parse_api_error(None, 503)  # type: ignore[arg-type]
+    assert err.message == "API error (status=503)"
+    assert err.status_code == 503
+
+
+# --- #153: _request_envelope ネットワークエラー ---
+
+
+def test_request_envelope_converts_request_exception_to_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_network_error(*_args: Any, **_kwargs: Any) -> None:
+        raise requests.RequestException("connection refused")
+
+    monkeypatch.setattr("portfolio_fdc.dashboard.api_client.requests.get", _raise_network_error)
+
+    with pytest.raises(APIError) as exc_info:
+        _request_envelope("http://localhost:8000", "/charts")
+
+    assert "Network error" in exc_info.value.message
+    assert "connection refused" in exc_info.value.message

--- a/tests/dashboard/test_dashboard_api_client.py
+++ b/tests/dashboard/test_dashboard_api_client.py
@@ -264,7 +264,7 @@ def test_parse_api_error_with_no_error_or_detail_returns_generic() -> None:
 
 
 def test_parse_api_error_with_non_dict_payload_returns_generic() -> None:
-    err = parse_api_error(None, 503)  # type: ignore[arg-type]
+    err = parse_api_error(None, 503)
     assert err.message == "API error (status=503)"
     assert err.status_code == 503
 

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -7,7 +7,16 @@ import pytest
 from dash import html
 
 from portfolio_fdc.dashboard.api_client import APIError
-from portfolio_fdc.dashboard.app import load_data, refresh_chart_name_options, validate_base_url
+from portfolio_fdc.dashboard.app import (
+    load_data,
+    move_to_active_by_chart_name,
+    refresh_chart_name_options,
+    render_active_drilldown,
+    select_chart_from_table,
+    sync_active_selected_base_url,
+    sync_filters_from_url,
+    validate_base_url,
+)
 
 
 def test_refresh_chart_name_options_keeps_dropdown_unselected_without_chart_id(
@@ -209,3 +218,149 @@ def test_validate_base_url_ip_url_conversion(monkeypatch):
     ip_url, hostname = validate_base_url(url)
     assert ip_url == "http://8.8.8.8:80"
     assert hostname == test_host
+
+
+# --- #153 / #161: sync_filters_from_url ---
+
+
+def test_sync_filters_from_url_accepts_valid_tabs() -> None:
+    for tab in ("charts", "active", "history", "judge"):
+        result_tab, _, _, _ = sync_filters_from_url(f"?tab={tab}")
+        assert result_tab == tab
+
+
+def test_sync_filters_from_url_falls_back_to_charts_for_invalid_tab() -> None:
+    result_tab, _, _, _ = sync_filters_from_url("?tab=unknown")
+    assert result_tab == "charts"
+
+
+def test_sync_filters_from_url_parses_multiple_query_params() -> None:
+    tab, recipe_id, chart_id, result_id = sync_filters_from_url(
+        "?tab=judge&recipe_id=RCP_1&chart_id=CHART_2&result_id=JR_3"
+    )
+    assert tab == "judge"
+    assert recipe_id == "RCP_1"
+    assert chart_id == "CHART_2"
+    assert result_id == "JR_3"
+
+
+def test_sync_filters_from_url_handles_empty_search() -> None:
+    tab, recipe_id, chart_id, result_id = sync_filters_from_url("")
+    assert tab == "charts"
+    assert recipe_id == ""
+    assert chart_id == ""
+    assert result_id == ""
+
+
+# --- #153 / #161: move_to_active_by_chart_name ---
+
+
+def test_move_to_active_by_chart_name_returns_no_update_for_none() -> None:
+    from dash import no_update
+
+    tab, chart_id, search = move_to_active_by_chart_name(None, "", "")
+    assert tab is no_update
+    assert chart_id is no_update
+    assert search is no_update
+
+
+def test_move_to_active_by_chart_name_switches_tab_and_updates_url() -> None:
+    tab, chart_id, search = move_to_active_by_chart_name("CHART_1", "RCP_1", "")
+    assert tab == "active"
+    assert chart_id == "CHART_1"
+    assert "tab=active" in search
+    assert "chart_id=CHART_1" in search
+
+
+# --- #153 / #161: select_chart_from_table ---
+
+
+def test_select_chart_from_table_returns_no_update_for_none_cell() -> None:
+    from dash import no_update
+
+    result = select_chart_from_table(None, [{"chart_id": "CHART_1"}])
+    assert result is no_update
+
+
+def test_select_chart_from_table_returns_no_update_for_out_of_bounds_row() -> None:
+    from dash import no_update
+
+    result = select_chart_from_table({"row": 5}, [{"chart_id": "CHART_1"}])
+    assert result is no_update
+
+
+def test_select_chart_from_table_returns_chart_id_on_valid_cell() -> None:
+    data = [{"chart_id": "CHART_1"}, {"chart_id": "CHART_2"}]
+    result = select_chart_from_table({"row": 1}, data)
+    assert result == "CHART_2"
+
+
+# --- #153 / #161: sync_active_selected_base_url ---
+
+
+def test_sync_active_selected_base_url_returns_given_url() -> None:
+    result = sync_active_selected_base_url("http://localhost:8000")
+    assert result == "http://localhost:8000"
+
+
+# --- #153 / #161: render_active_drilldown ---
+
+
+def test_render_active_drilldown_returns_empty_figure_for_none_click_data() -> None:
+    figure = render_active_drilldown(None, "http://localhost:8000")
+    assert figure["layout"]["title"] == "Raw Waveform Drilldown"
+
+
+def test_render_active_drilldown_returns_empty_figure_for_empty_points() -> None:
+    figure = render_active_drilldown({"points": []}, "http://localhost:8000")
+    assert figure["layout"]["title"] == "Raw Waveform Drilldown"
+
+
+def test_render_active_drilldown_returns_empty_figure_when_customdata_not_str() -> None:
+    figure = render_active_drilldown({"points": [{"customdata": 123}]}, "http://localhost:8000")
+    assert figure["layout"]["title"] == "Raw Waveform Drilldown"
+
+
+def test_render_active_drilldown_returns_waveform_figure_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "portfolio_fdc.dashboard.app.validate_base_url",
+        lambda url: (url, "localhost"),
+    )
+
+    def _fake_preview(base_url: str, process_id: str, params: Any = None) -> dict[str, Any]:
+        return {"process_id": process_id, "points": [{"x": "t1", "y": 1.0}]}
+
+    monkeypatch.setattr(
+        "portfolio_fdc.dashboard.app.get_process_waveform_preview",
+        _fake_preview,
+    )
+
+    click_data = {"points": [{"customdata": "P1"}]}
+    figure = render_active_drilldown(click_data, "http://localhost:8000")
+    assert figure["layout"]["title"] == "Raw Waveform Preview (P1)"
+
+
+def test_render_active_drilldown_returns_empty_figure_on_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "portfolio_fdc.dashboard.app.validate_base_url",
+        lambda url: (url, "localhost"),
+    )
+
+    def _raise_api_error(*_args: Any, **_kwargs: Any) -> None:
+        raise APIError(message="not found")
+
+    monkeypatch.setattr(
+        "portfolio_fdc.dashboard.app.get_process_waveform_preview",
+        _raise_api_error,
+    )
+
+    click_data = {"points": [{"customdata": "P1"}]}
+    figure = render_active_drilldown(click_data, "http://localhost:8000")
+    assert figure["layout"]["title"] == "Raw Waveform Drilldown"
+    annotations = figure["layout"].get("annotations", [])
+    error_text = " ".join(a.get("text", "") for a in annotations)
+    assert "not found" in error_text

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -269,6 +269,7 @@ def test_move_to_active_by_chart_name_switches_tab_and_updates_url() -> None:
     assert tab == "active"
     assert chart_id == "CHART_1"
     assert "tab=active" in search
+    assert "recipe_id=RCP_1" in search
     assert "chart_id=CHART_1" in search
 
 

--- a/tests/dashboard/test_dashboard_view_models.py
+++ b/tests/dashboard/test_dashboard_view_models.py
@@ -5,6 +5,7 @@ from portfolio_fdc.dashboard.view_models import (
     chart_band_figure,
     chart_points_figure,
     empty_drilldown_figure,
+    format_range,
     sort_judge_rows,
     spc_band_with_points_figure,
     waveform_figure,
@@ -199,3 +200,31 @@ def test_waveform_figure_ignores_invalid_points() -> None:
     )
 
     assert wf["data"][0]["y"] == [1.5]
+
+
+# --- #153: sort_judge_rows 未知のレベル ---
+
+
+def test_sort_judge_rows_places_unknown_level_at_end() -> None:
+    rows = [
+        {"result_id": "JR_1", "level": "UNKNOWN", "judged_at": "2026-04-17T00:00:00.000Z"},
+        {"result_id": "JR_2", "level": "OK", "judged_at": "2026-04-17T00:00:01.000Z"},
+    ]
+
+    sorted_rows = sort_judge_rows(rows)
+
+    # OK は priority=2, UNKNOWN は priority=9 → OK が先
+    assert sorted_rows[0]["result_id"] == "JR_2"
+    assert sorted_rows[1]["result_id"] == "JR_1"
+
+
+# --- #153: format_range falsy だが有効な値 ---
+
+
+def test_format_range_handles_zero_values() -> None:
+    assert format_range(0.0, 0.0) == "0.0 .. 0.0"
+
+
+def test_format_range_returns_dash_for_none() -> None:
+    assert format_range(None, 1.0) == "-"
+    assert format_range(1.0, None) == "-"


### PR DESCRIPTION
## 概要

#153 および #161 で指摘されたテストギャップを解消します。

## 変更内容

### `tests/dashboard/test_dashboard_app.py`

未テストだったコールバック5件のユニットテストを追加（DashboardController は依存性注入経由でモック化）。

- `sync_filters_from_url`: 有効タブ4種・無効タブフォールバック・複数クエリパラメータ・空文字列
- `move_to_active_by_chart_name`: `None` → `no_update`・有効 chart_id → タブ切り替え + URL 更新
- `select_chart_from_table`: `None` セル・範囲外行 → `no_update`・正常系
- `sync_active_selected_base_url`: 基本動作確認
- `render_active_drilldown`: `None` / 空 points / customdata 非str → empty figure、正常系 waveform figure、`APIError` → empty figure with message

### 	`tests/dashboard/test_dashboard_api_client.py`

- `parse_utc_millis`: `None`・空文字列・Z サフィックス変換・ミリ秒なし・無効文字列・非 UTC タイムゾーン変換
- `parse_api_error`: error キー正常系・detail キー・どちらもないフォールバック・非 dict ペイロード
- `_request_envelope`: `RequestException` → APIError 変換

### 	`tests/dashboard/test_dashboard_view_models.py`

- `sort_judge_rows`: 未知レベル → priority=9 で末尾配置
- `format_range`: `0.0, 0.0` → `'0.0 .. 0.0'`（falsy だが有効な値）・None は `'-'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## テストカバレッジ拡充 - コールバック・APIクライアント・ビューモデル

### 追加されたテスト（概要）
- tests/dashboard/test_dashboard_app.py（ダッシュボードのコールバック）
  - sync_filters_from_url：有効なタブ4種、無効タブ→disabled-tabフォールバック、複数クエリ、空文字列ケース
  - move_to_active_by_chart_name：None→dash.no_update、正常時はタブ切替とURL更新（recipe_id/chart_id）
  - select_chart_from_table：セルNone・行範囲外→dash.no_update、正常系でchart_id選択
  - sync_active_selected_base_url：基本動作確認
  - render_active_drilldown：クリックなし/空/非文字customdata→空の図（タイトル確認）、波形正常系、APIError発生時はエラー注釈付きの空図

- tests/dashboard/test_dashboard_api_client.py（APIクライアントユーティリティ）
  - parse_utc_millis：None/空文字、ZサフィックスのUTC化、ミリ秒欠落・非UTCオフセット変換、無効文字列の取り扱い
  - parse_api_error：{"error":...} / {"detail":...} / フォールバック、非dictペイロードの扱い
  - _request_envelope：requests.RequestException → APIError変換（エラーメッセージ含有を確認）

- tests/dashboard/test_dashboard_view_models.py（表示用ユーティリティ）
  - sort_judge_rows：未知のlevelは末尾配置（priority=9）
  - format_range：0.0（有効だが偽値）を維持、None→"-"に変換

### リスク・注意点
- Mock/DIの妥当性：DashboardControllerは依存注入でMockされているため、実実装とのズレがあるとテストが過信を生む可能性あり。
- エラーメッセージ伝播：APIErrorやNetworkエラーのメッセージ内容が期待通りにUIへ反映されるかは統合層での確認が望ましい。
- タイムゾーン処理の網羅性：parse_utc_millisは代表的ケースを網羅するが、全タイムゾーン・境界ケースの網羅は限定的。

### 残るテストギャップ
- UI統合／レンダリング確認：Dashコンポーネントの実際の描画やブラウザでの操作を伴う統合テストは未実施（単体テスト中心）。
- 大規模データ・パフォーマンス：多数行／大量クエリでの動作確認がない。
- 追加エッジケース：より多様なタイムスタンプ形式や異常なAPIペイロード（部分的に壊れた構造など）については追加検討が有用。

### 変更種別
- テスト追加のみ。公開APIや実装の宣言変更はなし。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->