### PR TITLE
refactor(dashboard): callback配線の安定化と統合テスト追加 (#154)

### DIFF
--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -32,7 +32,7 @@ def _build_controller() -> DashboardController:
     return DashboardController(logger, deps)
 
 
-app = Dash(__name__, suppress_callback_exceptions=True, title="FDC Dashboard Baseline")
+app = Dash(__name__, suppress_callback_exceptions=False, title="FDC Dashboard Baseline")
 
 # Re-exported aliases keep backward compatibility for tests that monkeypatch app symbols.
 _render_charts_tab = render_charts_tab
@@ -123,6 +123,7 @@ def sync_filters_from_url(search: str) -> tuple[str, str, str, str]:
     State("recipe-id", "value"),
     State("chart-id", "value"),
     State("result-id", "value"),
+    State("chart-name", "value"),
 )
 def load_data(
     active_tab: str,
@@ -131,6 +132,7 @@ def load_data(
     recipe_id: str,
     chart_id: str,
     result_id: str,
+    selected_chart_id: str | None,
 ) -> tuple[Any, str]:
     return _build_controller().load_data(
         active_tab,
@@ -139,6 +141,7 @@ def load_data(
         recipe_id,
         chart_id,
         result_id,
+        selected_chart_id,
     )
 
 

--- a/src/portfolio_fdc/dashboard/controller.py
+++ b/src/portfolio_fdc/dashboard/controller.py
@@ -34,6 +34,7 @@ class DashboardController:
         recipe_id: str,
         chart_id: str,
         result_id: str,
+        selected_chart_id: str | None,
     ) -> tuple[Any, str]:
         return self._tab_loader.load_data(
             active_tab,
@@ -42,6 +43,7 @@ class DashboardController:
             recipe_id,
             chart_id,
             result_id,
+            selected_chart_id,
         )
 
     def refresh_chart_name_options(

--- a/src/portfolio_fdc/dashboard/services/tab_load.py
+++ b/src/portfolio_fdc/dashboard/services/tab_load.py
@@ -22,9 +22,12 @@ class TabLoadService:
         recipe_id: str,
         chart_id: str,
         result_id: str,
+        selected_chart_id: str | None,
     ) -> tuple[Any, str]:
         if not n_clicks:
             return html.Div("Press Load to fetch data"), ""
+
+        effective_chart_id = chart_id or (selected_chart_id or "")
 
         try:
             result = self._deps.validate_base_url(base_url)
@@ -35,10 +38,17 @@ class TabLoadService:
             if active_tab == "charts":
                 return self._deps.render_charts_tab(safe_base_url, recipe_id), ""
             if active_tab == "active":
-                return self._deps.render_active_tab(safe_base_url, recipe_id, chart_id), ""
+                return self._deps.render_active_tab(
+                    safe_base_url, recipe_id, effective_chart_id
+                ), ""
             if active_tab == "history":
-                return self._deps.render_history_tab(safe_base_url, chart_id), ""
-            return self._deps.render_judge_tab(safe_base_url, recipe_id, chart_id, result_id), ""
+                return self._deps.render_history_tab(safe_base_url, effective_chart_id), ""
+            return self._deps.render_judge_tab(
+                safe_base_url,
+                recipe_id,
+                effective_chart_id,
+                result_id,
+            ), ""
         except APIError as exc:
             code = f" [{exc.code}]" if exc.code else ""
             return html.Div(""), f"{exc.message}{code}"

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -78,7 +78,7 @@ def test_refresh_chart_name_options_does_not_fetch_before_load_click(
 
 
 def test_load_data_shows_prompt_before_first_load_click() -> None:
-    content, error = load_data("active", 0, "http://localhost:8000", "", "", "")
+    content, error = load_data("active", 0, "http://localhost:8000", "", "", "", None)
 
     assert isinstance(content, html.Div)
     assert content.children == "Press Load to fetch data"
@@ -96,7 +96,7 @@ def test_load_data_renders_active_tab_after_load_click(
         _fake_render_active_tab,
     )
 
-    content, error = load_data("active", 1, "http://localhost:8000", "", "", "")
+    content, error = load_data("active", 1, "http://localhost:8000", "", "", "", None)
 
     assert isinstance(content, html.Div)
     assert content.children == "ACTIVE_RENDERED"
@@ -108,10 +108,36 @@ def test_validate_base_url_accepts_localhost() -> None:
 
 
 def test_load_data_rejects_invalid_base_url() -> None:
-    content, error = load_data("active", 1, "file:///etc/passwd", "", "", "")
+    content, error = load_data("active", 1, "file:///etc/passwd", "", "", "", None)
 
     assert isinstance(content, html.Div)
     assert error == "Invalid db_api base URL [INVALID_BASE_URL]"
+
+
+def test_load_data_uses_chart_name_selection_as_fallback_for_chart_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_render_active_tab(base_url: str, recipe_id: str, chart_id: str) -> html.Div:
+        return html.Div(f"ACTIVE:{chart_id}")
+
+    monkeypatch.setattr(
+        "portfolio_fdc.dashboard.app._render_active_tab",
+        _fake_render_active_tab,
+    )
+
+    content, error = load_data(
+        "active",
+        1,
+        "http://localhost:8000",
+        "",
+        "",
+        "",
+        "CHART_2",
+    )
+
+    assert isinstance(content, html.Div)
+    assert content.children == "ACTIVE:CHART_2"
+    assert error == ""
 
 
 def test_refresh_chart_name_options_rejects_invalid_base_url(

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -203,7 +203,7 @@ def test_navigation_service_current_search_equal():
 def test_tab_load_service_load_data(logger, deps):
     service = TabLoadService(logger, deps)
     # n_clicks=0 early return
-    result, msg = service.load_data("charts", 0, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 0, "base_url", "r1", "c1", "res1", None)
     from dash import html
 
     assert isinstance(result, html.Div)
@@ -212,7 +212,7 @@ def test_tab_load_service_load_data(logger, deps):
 
     deps.validate_base_url.return_value = "safe_url"
     deps.render_charts_tab.return_value = ("charts", "")
-    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1", None)
     assert result == ("charts", "")
     assert msg == ""
 
@@ -309,19 +309,19 @@ def test_tab_load_service_tab_branches(logger, deps):
     deps.render_history_tab.return_value = ("history", "")
     deps.render_judge_tab.return_value = ("judge", "")
     # charts
-    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1", None)
     assert result == ("charts", "")
     assert msg == ""
     # active
-    result, msg = service.load_data("active", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("active", 1, "base_url", "r1", "c1", "res1", None)
     assert result == ("active", "")
     assert msg == ""
     # history
-    result, msg = service.load_data("history", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("history", 1, "base_url", "r1", "c1", "res1", None)
     assert result == ("history", "")
     assert msg == ""
     # judge
-    result, msg = service.load_data("judge", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("judge", 1, "base_url", "r1", "c1", "res1", None)
     assert result == ("judge", "")
     assert msg == ""
 
@@ -332,12 +332,12 @@ def test_tab_load_service_apierror_code_and_no_code(logger, deps):
     # codeあり
     api_error = APIError("msg", code="E001")
     deps.render_charts_tab.side_effect = api_error
-    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1", None)
     assert msg == "msg [E001]"
     # codeなし
     api_error2 = APIError("msg2")
     deps.render_charts_tab.side_effect = api_error2
-    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1", None)
     assert msg == "msg2"
 
 
@@ -346,7 +346,7 @@ def test_tab_load_service_unexpected_exception(logger, deps, caplog):
     deps.validate_base_url.return_value = "safe_url"
     deps.render_charts_tab.side_effect = Exception("unexpected")
     with caplog.at_level(logging.ERROR, logger="test"):
-        result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+        result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1", None)
     assert "Unexpected error while loading dashboard data" in msg
     assert any(
         r.levelname == "ERROR" and "Unexpected error in load_data callback" in r.getMessage()
@@ -357,10 +357,10 @@ def test_tab_load_service_unexpected_exception(logger, deps, caplog):
 def test_tab_load_service_validate_base_url_apierror(logger, deps):
     service = TabLoadService(logger, deps)
     deps.validate_base_url.side_effect = APIError("msg", code="E001")
-    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1", None)
     assert msg == "msg [E001]"
     deps.validate_base_url.side_effect = APIError("msg2")
-    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1", None)
     assert msg == "msg2"
 
 
@@ -369,7 +369,7 @@ def test_tab_load_service_unknown_tab_fallback(logger, deps):
     deps.validate_base_url.return_value = "safe_url"
     deps.render_judge_tab.return_value = ("judge", "")
     # 未知タブはjudge_tabにフォールバック
-    result, msg = service.load_data("unknown", 1, "base_url", "r1", "c1", "res1")
+    result, msg = service.load_data("unknown", 1, "base_url", "r1", "c1", "res1", None)
     assert result == ("judge", "")
     assert msg == ""
 
@@ -401,48 +401,62 @@ def test_chart_name_option_service_recipe_id_omitted(logger, deps):
 
 
 def test_chart_name_option_service_selected_none_when_not_found(logger, deps):
-    def test_chart_name_option_service_validate_base_url_tuple(logger, deps):
-        service = ChartNameOptionService(logger, deps)
-        # validate_base_urlがtupleを返す場合の分岐網羅
-        deps.validate_base_url.return_value = ("safe_url", "dummy")
-        deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
-        options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
-        assert isinstance(options, list)
-        assert len(options) == 1
-        assert options[0]["value"] == "c1"
-        assert "name1" in options[0]["label"]
-        assert selected == "c1"
-
-    def test_tab_load_service_validate_base_url_tuple(logger, deps):
-        service = TabLoadService(logger, deps)
-        deps.validate_base_url.return_value = ("safe_url", "dummy")
-        deps.render_charts_tab.return_value = ("charts", "")
-        deps.render_active_tab.return_value = ("active", "")
-        deps.render_history_tab.return_value = ("history", "")
-        deps.render_judge_tab.return_value = ("judge", "")
-        # charts
-        result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1")
-        assert result == ("charts", "")
-        assert msg == ""
-        # active
-        result, msg = service.load_data("active", 1, "base_url", "r1", "c1", "res1")
-        assert result == ("active", "")
-        assert msg == ""
-        # history
-        result, msg = service.load_data("history", 1, "base_url", "r1", "c1", "res1")
-        assert result == ("history", "")
-        assert msg == ""
-        # judge
-        result, msg = service.load_data("judge", 1, "base_url", "r1", "c1", "res1")
-        assert result == ("judge", "")
-        assert msg == ""
-
     service = ChartNameOptionService(logger, deps)
     deps.validate_base_url.return_value = "safe_url"
     deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
     options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "not_found")
     assert options
     assert selected is None
+
+
+def test_chart_name_option_service_validate_base_url_tuple(logger, deps):
+    service = ChartNameOptionService(logger, deps)
+    # validate_base_urlがtupleを返す場合の分岐網羅
+    deps.validate_base_url.return_value = ("safe_url", "dummy")
+    deps.get_charts.return_value = [{"chart_id": "c1", "chart_name": "name1"}]
+    options, selected = service.refresh_chart_name_options(1, "base_url", "r1", "c1")
+    assert isinstance(options, list)
+    assert len(options) == 1
+    assert options[0]["value"] == "c1"
+    assert "name1" in options[0]["label"]
+    assert selected == "c1"
+
+
+def test_tab_load_service_validate_base_url_tuple(logger, deps):
+    service = TabLoadService(logger, deps)
+    deps.validate_base_url.return_value = ("safe_url", "dummy")
+    deps.render_charts_tab.return_value = ("charts", "")
+    deps.render_active_tab.return_value = ("active", "")
+    deps.render_history_tab.return_value = ("history", "")
+    deps.render_judge_tab.return_value = ("judge", "")
+    # charts
+    result, msg = service.load_data("charts", 1, "base_url", "r1", "c1", "res1", None)
+    assert result == ("charts", "")
+    assert msg == ""
+    # active
+    result, msg = service.load_data("active", 1, "base_url", "r1", "c1", "res1", None)
+    assert result == ("active", "")
+    assert msg == ""
+    # history
+    result, msg = service.load_data("history", 1, "base_url", "r1", "c1", "res1", None)
+    assert result == ("history", "")
+    assert msg == ""
+    # judge
+    result, msg = service.load_data("judge", 1, "base_url", "r1", "c1", "res1", None)
+    assert result == ("judge", "")
+    assert msg == ""
+
+
+def test_tab_load_service_uses_selected_chart_id_fallback(logger, deps):
+    service = TabLoadService(logger, deps)
+    deps.validate_base_url.return_value = "safe_url"
+    deps.render_active_tab.return_value = ("active", "")
+
+    result, msg = service.load_data("active", 1, "base_url", "r1", "", "res1", "c2")
+
+    assert result == ("active", "")
+    assert msg == ""
+    deps.render_active_tab.assert_called_once_with("safe_url", "r1", "c2")
 
 
 def test_active_drilldown_service_validate_base_url_tuple(logger, deps):

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -139,16 +139,6 @@ def test_chart_name_option_service_get_charts_unexpected_exception(logger, deps,
 
 
 def test_navigation_service_move_to_active_by_chart_name():
-    def test_navigation_service_move_to_active_by_chart_name_recipe_id_omitted():
-        service = NavigationService()
-        tab, chart_id, search = service.move_to_active_by_chart_name("c1", "", "")
-        import urllib.parse
-
-        parsed = urllib.parse.parse_qs(search.lstrip("?"))
-        assert "recipe_id" not in parsed
-        assert parsed["tab"] == ["active"]
-        assert parsed["chart_id"] == ["c1"]
-
     import urllib.parse
 
     service = NavigationService()
@@ -161,6 +151,20 @@ def test_navigation_service_move_to_active_by_chart_name():
     assert parsed["tab"] == ["active"]
     assert parsed["chart_id"] == ["c1"]
     assert parsed["recipe_id"] == ["r1"]
+
+
+def test_navigation_service_move_to_active_by_chart_name_recipe_id_omitted():
+    import urllib.parse
+
+    service = NavigationService()
+    tab, chart_id, search = service.move_to_active_by_chart_name("c1", "", "")
+
+    assert tab == "active"
+    assert chart_id == "c1"
+    parsed = urllib.parse.parse_qs(search.lstrip("?"))
+    assert "recipe_id" not in parsed
+    assert parsed["tab"] == ["active"]
+    assert parsed["chart_id"] == ["c1"]
 
 
 def test_navigation_service_selected_chart_id_none():
@@ -268,16 +272,6 @@ def test_url_filter_service_sync_filters_from_url_none():
 
 
 def test_url_filter_service_sync_filters_from_url_partial_keys():
-    def test_url_filter_service_tab_judge():
-        service = UrlFilterService()
-        tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
-            "?tab=judge&recipe_id=r1&chart_id=c1&result_id=res1"
-        )
-        assert tab == "judge"
-        assert recipe_id == "r1"
-        assert chart_id == "c1"
-        assert result_id == "res1"
-
     service = UrlFilterService()
     # recipe_idのみ
     tab, recipe_id, chart_id, result_id = service.sync_filters_from_url("?recipe_id=r1")
@@ -299,6 +293,17 @@ def test_url_filter_service_sync_filters_from_url_partial_keys():
     assert recipe_id == ""
     assert chart_id == ""
     assert result_id == ""
+
+
+def test_url_filter_service_tab_judge():
+    service = UrlFilterService()
+    tab, recipe_id, chart_id, result_id = service.sync_filters_from_url(
+        "?tab=judge&recipe_id=r1&chart_id=c1&result_id=res1"
+    )
+    assert tab == "judge"
+    assert recipe_id == "r1"
+    assert chart_id == "c1"
+    assert result_id == "res1"
 
 
 def test_tab_load_service_tab_branches(logger, deps):

--- a/tests/integration/test_dashboard_callbacks_integration.py
+++ b/tests/integration/test_dashboard_callbacks_integration.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from portfolio_fdc.dashboard.app import app
+
+
+def _collect_component_ids(node: Any) -> set[str]:
+    ids: set[str] = set()
+    if isinstance(node, dict):
+        if "props" in node and isinstance(node["props"], dict):
+            node_id = node["props"].get("id")
+            if isinstance(node_id, str):
+                ids.add(node_id)
+            children = node["props"].get("children")
+            if children is not None:
+                ids.update(_collect_component_ids(children))
+        for value in node.values():
+            ids.update(_collect_component_ids(value))
+    elif isinstance(node, list):
+        for item in node:
+            ids.update(_collect_component_ids(item))
+    return ids
+
+
+@pytest.mark.integration
+def test_dashboard_layout_exposes_static_store_and_root_components() -> None:
+    client = app.server.test_client()
+
+    response = client.get("/_dash-layout")
+
+    assert response.status_code == 200
+    layout = response.get_json()
+    component_ids = _collect_component_ids(layout)
+    assert "active-selected-base-url" in component_ids
+    assert "tabs" in component_ids
+    assert "tab-content" in component_ids
+
+
+@pytest.mark.integration
+def test_load_data_callback_depends_on_chart_name_state() -> None:
+    client = app.server.test_client()
+
+    response = client.get("/_dash-dependencies")
+
+    assert response.status_code == 200
+    dependencies = response.get_json()
+    assert isinstance(dependencies, list)
+
+    load_callback = next(
+        dep
+        for dep in dependencies
+        if isinstance(dep, dict)
+        and isinstance(dep.get("output"), str)
+        and "tab-content.children" in dep["output"]
+        and "error-banner.children" in dep["output"]
+    )
+
+    states = load_callback.get("state", [])
+    assert any(
+        isinstance(state, dict)
+        and state.get("id") == "chart-name"
+        and state.get("property") == "value"
+        for state in states
+    )

--- a/tests/integration/test_dashboard_callbacks_integration.py
+++ b/tests/integration/test_dashboard_callbacks_integration.py
@@ -50,13 +50,21 @@ def test_load_data_callback_depends_on_chart_name_state() -> None:
     assert isinstance(dependencies, list)
 
     load_callback = next(
-        dep
-        for dep in dependencies
-        if isinstance(dep, dict)
-        and isinstance(dep.get("output"), str)
-        and "tab-content.children" in dep["output"]
-        and "error-banner.children" in dep["output"]
+        (
+            dep
+            for dep in dependencies
+            if isinstance(dep, dict)
+            and isinstance(dep.get("output"), str)
+            and "tab-content.children" in dep["output"]
+            and "error-banner.children" in dep["output"]
+        ),
+        None,
     )
+    if load_callback is None:
+        pytest.fail(
+            "expected dependency with 'tab-content.children' and 'error-banner.children' not found"
+        )
+    assert load_callback is not None
 
     states = load_callback.get("state", [])
     assert any(


### PR DESCRIPTION
概要
- Issue #154 のうち、コールバック配線の不安定要因を低減する変更と、結合レベルの検証テストを追加しました。
- suppress_callback_exceptions を false に戻し、load_data が chart-name 選択値を State として参照できるようにしました。
- Dash の公開エンドポイントを使った統合テストを追加し、レイアウトと依存関係の配線を検証しています。

背景
- load_data と refresh_chart_name_options が同じ Load トリガを持つため、実行順によって chart_id 未確定状態が発生しうる懸念がありました。
- また、動的 Store 前提の suppress_callback_exceptions=true は typo 検出力を下げるため、静的宣言化後に false へ戻せるか確認が必要でした。

変更内容
- src/portfolio_fdc/dashboard/app.py
  - suppress_callback_exceptions を false に変更
  - load_data コールバックに chart-name.value の State を追加
- src/portfolio_fdc/dashboard/controller.py
  - load_data シグネチャに selected_chart_id を追加してサービスへ委譲
- src/portfolio_fdc/dashboard/services/tab_load.py
  - effective_chart_id = chart_id or selected_chart_id のフォールバックを導入
  - active/history/judge の描画時に effective_chart_id を利用
- tests/dashboard/test_dashboard_app.py
  - load_data 新シグネチャに追従
  - chart-name 選択値フォールバックの回帰テストを追加
- tests/dashboard/test_services.py
  - TabLoadService の新シグネチャに追従
  - selected_chart_id フォールバックのユニットテストを追加
- tests/integration/test_dashboard_callbacks_integration.py
  - /_dash-layout で静的 Store とルート要素を検証
  - /_dash-dependencies で load_data が chart-name.value を State に持つことを検証

テスト
- E:/work/python/logger/.venv/Scripts/python.exe -m pytest tests/dashboard -q
- E:/work/python/logger/.venv/Scripts/python.exe -m pytest tests/integration/test_dashboard_callbacks_integration.py -q
- E:/work/python/logger/.venv/Scripts/python.exe -m pytest tests/dashboard tests/integration/test_dashboard_callbacks_integration.py -q
- いずれも pass（DeprecationWarning のみ）

影響範囲
- dashboard モジュール内のコールバック配線とテストのみ
- ingest/judge/db_api への依存方向変更なし
- API 契約変更なし

ロールバック計画
- 問題があれば以下を段階的に戻せます
- 1. load_data への chart-name State 追加とサービス側フォールバック
- 2. suppress_callback_exceptions の false 変更
- 3. 追加テストファイル

関連
- closes #154
- related #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更概要

**コールバック配線の安定化と統合テスト追加**

### 主な変更
- app の初期化で `suppress_callback_exceptions` を `False` に戻し、コールバック例外を明示的に検出可能に
- `load_data` コールバックに `chart-name.value` を State として追加し、選択中のチャートIDを受け取るように変更
- `DashboardController.load_data` と `TabLoadService.load_data` に `selected_chart_id` パラメータを追加
- `TabLoadService` 内で `effective_chart_id = chart_id or selected_chart_id` のフォールバックを導入し、`active`/`history`/`judge` タブ描画で利用

### テスト
- 単体テストを修正：`load_data`／`TabLoadService.load_data` の新シグネチャに追従し、selected_chart_id フォールバックの単体検証を追加
- 統合テスト追加：Dash の公開エンドポイント `/_dash-layout` と `/_dash-dependencies` を用い、静的コンポーネント（root 要素・静的 Store 等）と `load_data` の依存（`chart-name.value` が State として含まれること）を検証
- 指定の pytest 実行で全テスト通過（DeprecationWarning のみ）

### 影響範囲
- dashboard モジュール内のコールバック配線とテストに限定。外部モジュール（ingest/judge/db_api 等）への API 契約変更はない

### 懸念事項（リスク）
- suppress_callback_exceptions=False により、未登録や動的に不安定なコールバックが実行時にエラーを投げてアプリが影響を受けるリスク（過渡期の動的 Store 扱いに注意）
- フォールバック `chart_id or selected_chart_id` の両方が空の場合の動作が明示されておらず、描画側（render 関数）に依存している点
- コールバック間の競合（URL 同期→オプション更新→チャート切替の循環発火）や順序依存の完全除去は未完（対策の一部を実施しているが、並行操作時の振る舞いは依然注意が必要）

### テストギャップ
- タブ高速切替や API 呼び出し中の同時操作など、競合条件やタイミング依存の統合テストは未カバー
- 例外表示（error-banner）への統合的な動作検証：例外を捕捉して UI に表示することの確認テストは追加されていない
- 動的 Store を静的化する移行が完全でない場合の実行時安定性に関する長時間・高負荷下の検証が不足

### ロールバック手順
1. load_data からの `chart-name` State 追加とサービス側フォールバックを元に戻す  
2. `suppress_callback_exceptions` の元の値に戻す  
3. 追加したテストファイルを削除または元に戻す

関連: closes #154、related #153
<!-- end of auto-generated comment: release notes by coderabbit.ai -->