### PR TITLE
fix: address dashboard nitpicks and waveform safety

### DIFF
--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -34,7 +34,10 @@ def _build_controller() -> DashboardController:
 
 app = Dash(__name__, suppress_callback_exceptions=False, title="FDC Dashboard Baseline")
 
-# Re-exported aliases keep backward compatibility for tests that monkeypatch app symbols.
+# Re-exported aliases for backward compatibility.
+# IMPORTANT: Tests should monkeypatch tab_renderers module directly, not these aliases,
+# to avoid silently breaking when tab_renderers is refactored.
+# See: https://github.com/mdht-daiki/fdc-logger-toolkit/issues/163
 _render_charts_tab = render_charts_tab
 _render_active_tab = render_active_tab
 _render_history_tab = render_history_tab

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -477,6 +477,7 @@ def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
         for allowed_dir in allowed_base_dirs
     )
     if not is_allowed:
+        src_name = src_resolved.name
         logger.warning(
             "Access attempt outside allowed directories: process_id=%s, path=%s, allowed_dirs=%s",
             process_id,
@@ -485,7 +486,10 @@ def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
         )
         raise HTTPException(
             status_code=403,
-            detail="Access to files outside the allowed base directories is forbidden",
+            detail=(
+                "Access to files outside the allowed base directories is forbidden: "
+                f"process_id={process_id}, file={src_name}"
+            ),
         )
 
     if not src_resolved.exists():

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -7,8 +7,10 @@
 from __future__ import annotations
 
 import logging
+import os as _os
 import pathlib
 import sqlite3
+import tempfile as _tempfile
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import asdict
@@ -36,7 +38,7 @@ from .chart_repository import (
     ChartsHistoryQueryCriteria,
     ChartsQueryCriteria,
 )
-from .db import MAIN_DB, TEMP_DB, _connect, _init_schema
+from .db import MAIN_DB, TEMP_DB, _connect_readonly, _init_schema
 from .judge_repository import (
     JudgeDataCorruptionError,
     JudgeRepository,
@@ -54,6 +56,31 @@ from .task_runner import DBTaskRunner
 
 logger = logging.getLogger(__name__)
 _runner_lock = Lock()
+
+
+# パストラバーサル対策: raw CSV ファイルの許可ベースディレクトリ
+# 環境変数 DATA_ROOT で指定可能（デフォルト: カレントワーキングディレクトリ）
+# テスト環境ではシステムの一時ディレクトリも許可
+def _get_allowed_base_dirs() -> list[pathlib.Path]:
+    """許可されたベースディレクトリリストを取得。"""
+    allowed = []
+
+    # 環境変数で指定されたディレクトリ
+    data_root = _os.environ.get("DATA_ROOT")
+    if data_root:
+        allowed.append(pathlib.Path(data_root).resolve())
+    else:
+        # デフォルトはカレントワーキングディレクトリ
+        allowed.append(pathlib.Path.cwd().resolve())
+
+    # テスト環境用: システム一時ディレクトリも許可
+    allowed.append(pathlib.Path(_tempfile.gettempdir()).resolve())
+
+    return allowed
+
+
+_ALLOWED_BASE_DIRS = _get_allowed_base_dirs()
+
 LEGACY_DELETE_PROCESSES_SUNSET_AT = datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC)
 LEGACY_DELETE_PROCESSES_SUNSET = format_datetime(LEGACY_DELETE_PROCESSES_SUNSET_AT, usegmt=True)
 CHARTS_FILTER_PATTERN = r"^[A-Za-z0-9_./:-]+$"
@@ -427,8 +454,11 @@ def _not_found_error_response(*, message: str, details: dict[str, str]) -> JSONR
 
 
 def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
-    """ProcessInfo.raw_csv_path からドリルダウン表示用の波形プレビューを返す。"""
-    con = _connect(MAIN_DB)
+    """ProcessInfo.raw_csv_path からドリルダウン表示用の波形プレビューを返す。
+
+    READ-ONLY 接続を使用することで、書き込み作業中の lock 競合を回避する。
+    """
+    con = _connect_readonly(MAIN_DB)
     try:
         row = con.execute(
             "SELECT raw_csv_path FROM ProcessInfo WHERE process_id = ?",
@@ -451,6 +481,24 @@ def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
     src = pathlib.Path(str(raw_path))
     if not src.is_absolute():
         src = pathlib.Path.cwd() / src
+
+    # パストラバーサル対策: ベースディレクトリ外のアクセスを拒否
+    src_resolved = src.resolve()
+    is_allowed = any(
+        src_resolved == allowed_dir or str(src_resolved).startswith(str(allowed_dir) + _os.sep)
+        for allowed_dir in _ALLOWED_BASE_DIRS
+    )
+    if not is_allowed:
+        logger.warning(
+            "Access attempt outside allowed directories: process_id=%s, path=%s, allowed_dirs=%s",
+            process_id,
+            src_resolved.as_posix(),
+            ", ".join(d.as_posix() for d in _ALLOWED_BASE_DIRS),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="Access to files outside the allowed base directories is forbidden",
+        )
 
     if not src.exists():
         return {

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -10,7 +10,6 @@ import logging
 import os as _os
 import pathlib
 import sqlite3
-import tempfile as _tempfile
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import asdict
@@ -56,30 +55,18 @@ from .task_runner import DBTaskRunner
 
 logger = logging.getLogger(__name__)
 _runner_lock = Lock()
+DATA_ROOT = "DATA_ROOT"
 
 
 # パストラバーサル対策: raw CSV ファイルの許可ベースディレクトリ
-# 環境変数 DATA_ROOT で指定可能（デフォルト: カレントワーキングディレクトリ）
-# テスト環境ではシステムの一時ディレクトリも許可
+# 環境変数 DATA_ROOT で指定可能（未設定時はカレントワーキングディレクトリ）
 def _get_allowed_base_dirs() -> list[pathlib.Path]:
     """許可されたベースディレクトリリストを取得。"""
-    allowed = []
-
-    # 環境変数で指定されたディレクトリ
-    data_root = _os.environ.get("DATA_ROOT")
+    data_root = _os.environ.get(DATA_ROOT)
     if data_root:
-        allowed.append(pathlib.Path(data_root).resolve())
-    else:
-        # デフォルトはカレントワーキングディレクトリ
-        allowed.append(pathlib.Path.cwd().resolve())
+        return [pathlib.Path(data_root).resolve()]
+    return [pathlib.Path.cwd().resolve()]
 
-    # テスト環境用: システム一時ディレクトリも許可
-    allowed.append(pathlib.Path(_tempfile.gettempdir()).resolve())
-
-    return allowed
-
-
-_ALLOWED_BASE_DIRS = _get_allowed_base_dirs()
 
 LEGACY_DELETE_PROCESSES_SUNSET_AT = datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC)
 LEGACY_DELETE_PROCESSES_SUNSET = format_datetime(LEGACY_DELETE_PROCESSES_SUNSET_AT, usegmt=True)
@@ -484,33 +471,34 @@ def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
 
     # パストラバーサル対策: ベースディレクトリ外のアクセスを拒否
     src_resolved = src.resolve()
+    allowed_base_dirs = _get_allowed_base_dirs()
     is_allowed = any(
         src_resolved == allowed_dir or str(src_resolved).startswith(str(allowed_dir) + _os.sep)
-        for allowed_dir in _ALLOWED_BASE_DIRS
+        for allowed_dir in allowed_base_dirs
     )
     if not is_allowed:
         logger.warning(
             "Access attempt outside allowed directories: process_id=%s, path=%s, allowed_dirs=%s",
             process_id,
             src_resolved.as_posix(),
-            ", ".join(d.as_posix() for d in _ALLOWED_BASE_DIRS),
+            ", ".join(d.as_posix() for d in allowed_base_dirs),
         )
         raise HTTPException(
             status_code=403,
             detail="Access to files outside the allowed base directories is forbidden",
         )
 
-    if not src.exists():
+    if not src_resolved.exists():
         return {
             "process_id": process_id,
-            "source_path": src.as_posix(),
+            "source_path": src_resolved.as_posix(),
             "points": [],
         }
 
     try:
         import pandas as pd  # Local import to avoid global import cost.
 
-        with src.open("r", encoding="utf-8", errors="ignore") as f:
+        with src_resolved.open("r", encoding="utf-8", errors="ignore") as f:
             start_row = 0
             for idx, line in enumerate(f):
                 if idx >= 200:
@@ -528,18 +516,18 @@ def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
                 logger.error(
                     "CSV parse error in waveform preview for process_id=%s source_path=%s: %s",
                     process_id,
-                    src.as_posix(),
+                    src_resolved.as_posix(),
                     str(e),
                 )
                 return {
                     "process_id": process_id,
-                    "source_path": src.as_posix(),
+                    "source_path": src_resolved.as_posix(),
                     "points": [],
                 }
         if frame.empty:
             return {
                 "process_id": process_id,
-                "source_path": src.as_posix(),
+                "source_path": src_resolved.as_posix(),
                 "points": [],
             }
 
@@ -552,7 +540,7 @@ def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
         if y_col is None:
             return {
                 "process_id": process_id,
-                "source_path": src.as_posix(),
+                "source_path": src_resolved.as_posix(),
                 "points": [],
             }
 
@@ -566,18 +554,18 @@ def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
         ]
         return {
             "process_id": process_id,
-            "source_path": src.as_posix(),
+            "source_path": src_resolved.as_posix(),
             "points": points,
         }
     except Exception:
         logger.exception(
             "Failed to build waveform preview for process_id=%s source_path=%s",
             process_id,
-            src.as_posix(),
+            src_resolved.as_posix(),
         )
         return {
             "process_id": process_id,
-            "source_path": src.as_posix(),
+            "source_path": src_resolved.as_posix(),
             "points": [],
         }
 

--- a/src/portfolio_fdc/db_api/db.py
+++ b/src/portfolio_fdc/db_api/db.py
@@ -34,6 +34,19 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     return con
 
 
+def _connect_readonly(db_path: Path) -> sqlite3.Connection:
+    """指定 DB への読み取り専用接続を開く。
+
+    読み取り専用モード（mode=ro）を使用することで、
+    WAL モード環境での並行性を向上させる。
+    書き込みが多いタイミングでの read リクエストロックを回避する。
+    """
+    uri = f"file:{db_path.as_posix()}?mode=ro"
+    con = sqlite3.connect(uri, uri=True, check_same_thread=False)
+    con.execute("PRAGMA query_only=ON;")
+    return con
+
+
 def _add_column_if_missing(
     con: sqlite3.Connection,
     table_name: str,

--- a/tests/dashboard/test_controller.py
+++ b/tests/dashboard/test_controller.py
@@ -248,15 +248,16 @@ class TestRenderActiveDrilldown:
 
     def test_handles_none_click_data(self, controller: DashboardController) -> None:
         """render_active_drilldown should handle None click_data."""
+        expected: dict[str, list[Any]] = {"data": []}
         with patch.object(
             controller._drilldown,
             "render_active_drilldown",
-            return_value={"data": []},
+            return_value=expected,
         ) as mock_render:
             result = controller.render_active_drilldown(None, "http://localhost:8050")
 
             mock_render.assert_called_once_with(None, "http://localhost:8050")
-            assert isinstance(result, dict)
+            assert result == expected
 
 
 class TestControllerInitialization:

--- a/tests/dashboard/test_controller.py
+++ b/tests/dashboard/test_controller.py
@@ -1,0 +1,273 @@
+"""Smoke tests for DashboardController delegation to services."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from portfolio_fdc.dashboard.controller import DashboardController
+from portfolio_fdc.dashboard.dependencies import DashboardDependencies
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    """Return test logger."""
+    return logging.getLogger("test")
+
+
+@pytest.fixture
+def deps() -> MagicMock:
+    """Return mocked DashboardDependencies."""
+    return MagicMock(spec=DashboardDependencies)
+
+
+@pytest.fixture
+def controller(logger: logging.Logger, deps: MagicMock) -> DashboardController:
+    """Return DashboardController instance."""
+    return DashboardController(logger, deps)
+
+
+class TestSyncFiltersFromUrl:
+    """Tests for sync_filters_from_url delegation."""
+
+    def test_delegates_to_url_filter_service(self, controller: DashboardController) -> None:
+        """sync_filters_from_url should delegate to UrlFilterService.sync_filters_from_url."""
+        search = "recipe_id=R1&chart_id=C1"
+        result = controller.sync_filters_from_url(search)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 4
+
+    def test_returns_url_filter_result(self, controller: DashboardController) -> None:
+        """sync_filters_from_url should return the result from UrlFilterService."""
+        search = "recipe_id=R1&chart_id=C1"
+        result = controller.sync_filters_from_url(search)
+
+        # UrlFilterService.sync_filters_from_url returns tuple[str, str, str, str]
+        assert all(isinstance(item, str) for item in result)
+
+
+class TestLoadData:
+    """Tests for load_data delegation."""
+
+    def test_delegates_with_correct_arguments(self, controller: DashboardController) -> None:
+        """load_data should delegate all arguments to TabLoadService."""
+        with patch.object(
+            controller._tab_loader, "load_data", return_value=({"data": []}, "")
+        ) as mock_load:
+            controller.load_data(
+                active_tab="spc",
+                n_clicks=1,
+                base_url="http://localhost:8050",
+                recipe_id="recipe_1",
+                chart_id="CHART_1",
+                result_id="JR_1",
+                selected_chart_id="CHART_2",
+            )
+
+            mock_load.assert_called_once_with(
+                "spc",
+                1,
+                "http://localhost:8050",
+                "recipe_1",
+                "CHART_1",
+                "JR_1",
+                "CHART_2",
+            )
+
+    def test_returns_loader_result(self, controller: DashboardController) -> None:
+        """load_data should return the result from TabLoadService."""
+        expected = ({"data": "test"}, "content")
+        with patch.object(controller._tab_loader, "load_data", return_value=expected):
+            result = controller.load_data(
+                active_tab="spc",
+                n_clicks=1,
+                base_url="http://localhost:8050",
+                recipe_id="recipe_1",
+                chart_id="CHART_1",
+                result_id="JR_1",
+                selected_chart_id=None,
+            )
+
+            assert result == expected
+
+
+class TestRefreshChartNameOptions:
+    """Tests for refresh_chart_name_options delegation."""
+
+    def test_delegates_with_correct_arguments(self, controller: DashboardController) -> None:
+        """refresh_chart_name_options should delegate arguments to ChartNameOptionService."""
+        with patch.object(
+            controller._chart_name,
+            "refresh_chart_name_options",
+            return_value=([], None),
+        ) as mock_refresh:
+            controller.refresh_chart_name_options(
+                n_clicks=2,
+                base_url="http://localhost:8050",
+                recipe_id="recipe_1",
+                chart_id="CHART_1",
+            )
+
+            mock_refresh.assert_called_once_with(
+                2,
+                "http://localhost:8050",
+                "recipe_1",
+                "CHART_1",
+            )
+
+    def test_returns_options_result(self, controller: DashboardController) -> None:
+        """refresh_chart_name_options should return result from ChartNameOptionService."""
+        expected_options = [{"label": "Chart 1", "value": "CHART_1"}]
+        expected = (expected_options, "recipe_1")
+        with patch.object(
+            controller._chart_name, "refresh_chart_name_options", return_value=expected
+        ):
+            result = controller.refresh_chart_name_options(
+                n_clicks=1,
+                base_url="http://localhost:8050",
+                recipe_id="recipe_1",
+                chart_id="CHART_1",
+            )
+
+            assert result == expected
+
+
+class TestMoveToActiveByChartName:
+    """Tests for move_to_active_by_chart_name delegation."""
+
+    def test_delegates_with_correct_arguments(self, controller: DashboardController) -> None:
+        """move_to_active_by_chart_name should delegate arguments to NavigationService."""
+        with patch.object(
+            controller._navigation,
+            "move_to_active_by_chart_name",
+            return_value=("tab", "url", "search"),
+        ) as mock_move:
+            controller.move_to_active_by_chart_name(
+                selected_chart_id="CHART_1",
+                recipe_id="recipe_1",
+                current_search="recipe_id=R1",
+            )
+
+            mock_move.assert_called_once_with(
+                "CHART_1",
+                "recipe_1",
+                "recipe_id=R1",
+            )
+
+    def test_returns_navigation_result(self, controller: DashboardController) -> None:
+        """move_to_active_by_chart_name should return result from NavigationService."""
+        expected = ("tab", "http://localhost:8050", "recipe_id=R1")
+        with patch.object(
+            controller._navigation, "move_to_active_by_chart_name", return_value=expected
+        ):
+            result = controller.move_to_active_by_chart_name(
+                selected_chart_id="CHART_1",
+                recipe_id="recipe_1",
+                current_search="recipe_id=R1",
+            )
+
+            assert result == expected
+
+
+class TestSelectChartFromTable:
+    """Tests for select_chart_from_table delegation."""
+
+    def test_delegates_with_active_cell_and_data(self, controller: DashboardController) -> None:
+        """select_chart_from_table should delegate arguments to NavigationService."""
+        active_cell = {"row": 0, "column": 0}
+        data = [{"chart_id": "CHART_1"}]
+
+        with patch.object(
+            controller._navigation,
+            "select_chart_from_table",
+            return_value="CHART_1",
+        ) as mock_select:
+            controller.select_chart_from_table(active_cell, data)
+
+            mock_select.assert_called_once_with(active_cell, data)
+
+    def test_handles_none_arguments(self, controller: DashboardController) -> None:
+        """select_chart_from_table should handle None arguments."""
+        with patch.object(
+            controller._navigation,
+            "select_chart_from_table",
+            return_value=None,
+        ) as mock_select:
+            result = controller.select_chart_from_table(None, None)
+
+            mock_select.assert_called_once_with(None, None)
+            assert result is None
+
+
+class TestSyncActiveSelectedBaseUrl:
+    """Tests for sync_active_selected_base_url delegation."""
+
+    def test_delegates_base_url(self, controller: DashboardController) -> None:
+        """sync_active_selected_base_url should delegate to NavigationService."""
+        with patch.object(
+            controller._navigation,
+            "sync_active_selected_base_url",
+            return_value="http://localhost:8050",
+        ) as mock_sync:
+            result = controller.sync_active_selected_base_url("http://localhost:8050")
+
+            mock_sync.assert_called_once_with("http://localhost:8050")
+            assert result == "http://localhost:8050"
+
+
+class TestRenderActiveDrilldown:
+    """Tests for render_active_drilldown delegation."""
+
+    def test_delegates_with_click_data_and_base_url(self, controller: DashboardController) -> None:
+        """render_active_drilldown should delegate arguments to ActiveDrilldownService."""
+        click_data: dict[str, Any] = {"points": [{"customdata": "process_1"}]}
+
+        with patch.object(
+            controller._drilldown,
+            "render_active_drilldown",
+            return_value={"data": []},
+        ) as mock_render:
+            controller.render_active_drilldown(click_data, "http://localhost:8050")
+
+            mock_render.assert_called_once_with(click_data, "http://localhost:8050")
+
+    def test_handles_none_click_data(self, controller: DashboardController) -> None:
+        """render_active_drilldown should handle None click_data."""
+        with patch.object(
+            controller._drilldown,
+            "render_active_drilldown",
+            return_value={"data": []},
+        ) as mock_render:
+            result = controller.render_active_drilldown(None, "http://localhost:8050")
+
+            mock_render.assert_called_once_with(None, "http://localhost:8050")
+            assert isinstance(result, dict)
+
+
+class TestControllerInitialization:
+    """Tests for DashboardController initialization."""
+
+    def test_initializes_all_services(self, logger: logging.Logger, deps: MagicMock) -> None:
+        """DashboardController should initialize all required services."""
+        controller = DashboardController(logger, deps)
+
+        assert hasattr(controller, "_url_filter")
+        assert hasattr(controller, "_tab_loader")
+        assert hasattr(controller, "_chart_name")
+        assert hasattr(controller, "_navigation")
+        assert hasattr(controller, "_drilldown")
+
+    def test_service_initialization_with_deps(
+        self, logger: logging.Logger, deps: MagicMock
+    ) -> None:
+        """DashboardController should pass deps to services that require them."""
+        controller = DashboardController(logger, deps)
+
+        # TabLoadService, ChartNameOptionService, ActiveDrilldownService should have deps
+        assert controller._tab_loader._deps is deps
+        assert controller._chart_name._deps is deps
+        assert controller._drilldown._deps is deps

--- a/tests/dashboard/test_controller.py
+++ b/tests/dashboard/test_controller.py
@@ -36,18 +36,29 @@ class TestSyncFiltersFromUrl:
     def test_delegates_to_url_filter_service(self, controller: DashboardController) -> None:
         """sync_filters_from_url should delegate to UrlFilterService.sync_filters_from_url."""
         search = "recipe_id=R1&chart_id=C1"
-        result = controller.sync_filters_from_url(search)
+        expected = ("recipe", "chart", "result", "selected")
+        with patch.object(
+            controller._url_filter,
+            "sync_filters_from_url",
+            return_value=expected,
+        ) as mock_sync:
+            result = controller.sync_filters_from_url(search)
 
-        assert isinstance(result, tuple)
-        assert len(result) == 4
+        mock_sync.assert_called_once_with(search)
+        assert result == expected
 
     def test_returns_url_filter_result(self, controller: DashboardController) -> None:
         """sync_filters_from_url should return the result from UrlFilterService."""
         search = "recipe_id=R1&chart_id=C1"
-        result = controller.sync_filters_from_url(search)
+        expected = ("recipe_id", "chart_id", "result_id", "selected_chart_id")
+        with patch.object(
+            controller._url_filter,
+            "sync_filters_from_url",
+            return_value=expected,
+        ):
+            result = controller.sync_filters_from_url(search)
 
-        # UrlFilterService.sync_filters_from_url returns tuple[str, str, str, str]
-        assert all(isinstance(item, str) for item in result)
+        assert result == expected
 
 
 class TestLoadData:
@@ -265,9 +276,13 @@ class TestControllerInitialization:
         self, logger: logging.Logger, deps: MagicMock
     ) -> None:
         """DashboardController should pass deps to services that require them."""
-        controller = DashboardController(logger, deps)
+        with (
+            patch("portfolio_fdc.dashboard.controller.TabLoadService") as mock_tab_load,
+            patch("portfolio_fdc.dashboard.controller.ChartNameOptionService") as mock_chart_name,
+            patch("portfolio_fdc.dashboard.controller.ActiveDrilldownService") as mock_drilldown,
+        ):
+            DashboardController(logger, deps)
 
-        # TabLoadService, ChartNameOptionService, ActiveDrilldownService should have deps
-        assert controller._tab_loader._deps is deps
-        assert controller._chart_name._deps is deps
-        assert controller._drilldown._deps is deps
+        mock_tab_load.assert_called_once_with(logger, deps)
+        mock_chart_name.assert_called_once_with(logger, deps)
+        mock_drilldown.assert_called_once_with(logger, deps)

--- a/tests/db_api/test_db_api_chart_points_waveform_endpoint.py
+++ b/tests/db_api/test_db_api_chart_points_waveform_endpoint.py
@@ -635,6 +635,8 @@ def test_get_process_waveform_preview_allows_path_under_data_root(
     res = client.get(f"/processes/{process_id}/waveform-preview")
 
     assert res.status_code == 200
+    assert res.headers["content-type"].startswith("application/json")
+    assert "detail" not in res.json()
 
 
 def test_get_process_waveform_preview_forbids_path_outside_data_root(
@@ -655,6 +657,9 @@ def test_get_process_waveform_preview_forbids_path_outside_data_root(
     res = client.get(f"/processes/{process_id}/waveform-preview")
 
     assert res.status_code == 403
+    detail = res.json().get("detail")
+    assert detail is not None
+    assert process_id in detail or forbidden_path.name in detail
 
 
 def test_get_process_waveform_preview_applies_limit_to_tail(

--- a/tests/db_api/test_db_api_chart_points_waveform_endpoint.py
+++ b/tests/db_api/test_db_api_chart_points_waveform_endpoint.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pandas as pd
@@ -18,6 +19,10 @@ from portfolio_fdc.db_api.chart_repository import ChartRepository
 from portfolio_fdc.db_api.datetime_util import to_utc_millis
 from portfolio_fdc.db_api.db import MAIN_DB, _connect, _init_schema
 from tests.utils.test_utils import assert_validation_error_envelope
+
+
+def _set_data_root(monkeypatch: pytest.MonkeyPatch, data_root: Path) -> None:
+    monkeypatch.setenv(db_app.DATA_ROOT, data_root.as_posix())
 
 
 @dataclass(frozen=True)
@@ -578,7 +583,6 @@ def test_get_process_waveform_preview_returns_empty_points_when_raw_csv_path_nul
             pass
 
     connection = _DetailedConnection()
-    monkeypatch.setattr(db_app, "_connect", lambda _db_path: connection)
     monkeypatch.setattr(db_app, "_connect_readonly", lambda _db_path: connection)
 
     res = client.get("/processes/wave_null_path/waveform-preview")
@@ -596,9 +600,11 @@ def test_get_process_waveform_preview_returns_empty_points_when_raw_csv_path_nul
 def test_get_process_waveform_preview_returns_empty_points_when_file_missing(
     client: TestClient,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     process_id = f"wave_missing_{uuid4().hex[:8]}"
     missing_path = tmp_path / "missing_wave.csv"
+    _set_data_root(monkeypatch, tmp_path)
 
     with _waveform_process_ctx(process_id, missing_path.as_posix()):
         res = client.get(f"/processes/{process_id}/waveform-preview")
@@ -611,12 +617,54 @@ def test_get_process_waveform_preview_returns_empty_points_when_file_missing(
         assert body["data"]["source_path"] == missing_path.as_posix()
 
 
+def test_get_process_waveform_preview_allows_path_under_data_root(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process_id = f"wave_allowed_{uuid4().hex[:8]}"
+    allowed_path = tmp_path / "allowed.csv"
+    connection = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (allowed_path.as_posix(),)
+    connection.execute.return_value = cursor
+
+    _set_data_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(db_app, "_connect_readonly", lambda _db_path: connection)
+
+    res = client.get(f"/processes/{process_id}/waveform-preview")
+
+    assert res.status_code == 200
+
+
+def test_get_process_waveform_preview_forbids_path_outside_data_root(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process_id = f"wave_forbidden_{uuid4().hex[:8]}"
+    forbidden_path = tmp_path.parent / "outside-allowed.csv"
+    connection = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (forbidden_path.as_posix(),)
+    connection.execute.return_value = cursor
+
+    _set_data_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(db_app, "_connect_readonly", lambda _db_path: connection)
+
+    res = client.get(f"/processes/{process_id}/waveform-preview")
+
+    assert res.status_code == 403
+
+
 def test_get_process_waveform_preview_applies_limit_to_tail(
     client: TestClient,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     process_id = f"wave_limit_{uuid4().hex[:8]}"
     csv_path = tmp_path / "wave_limit.csv"
+    _set_data_root(monkeypatch, tmp_path)
     csv_path.write_text(
         "timestamp,signal\n"
         "t1,1.0\n"
@@ -685,9 +733,11 @@ def test_get_process_waveform_preview_rejects_invalid_process_id_pattern(
 def test_get_process_waveform_preview_returns_null_for_nan_y(
     client: TestClient,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     process_id = f"wave_nan_{uuid4().hex[:8]}"
     csv_path = tmp_path / "wave_nan.csv"
+    _set_data_root(monkeypatch, tmp_path)
     csv_path.write_text("timestamp,signal\nt1,1.5\nt2,\n", encoding="utf-8")
 
     with _waveform_process_ctx(process_id, csv_path.as_posix()):
@@ -711,6 +761,7 @@ def test_get_process_waveform_preview_returns_empty_points_on_parser_error(
 ) -> None:
     process_id = f"wave_parser_{uuid4().hex[:8]}"
     csv_path = tmp_path / "wave_parser.csv"
+    _set_data_root(monkeypatch, tmp_path)
     csv_path.write_text("timestamp,signal\nt1,1.0\n", encoding="utf-8")
 
     def raise_parser_error(*args: object, **kwargs: object) -> pd.DataFrame:
@@ -733,9 +784,11 @@ def test_get_process_waveform_preview_returns_empty_points_on_parser_error(
 def test_get_process_waveform_preview_returns_empty_points_for_header_only_csv(
     client: TestClient,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     process_id = f"wave_empty_{uuid4().hex[:8]}"
     csv_path = tmp_path / "wave_header_only.csv"
+    _set_data_root(monkeypatch, tmp_path)
     csv_path.write_text("timestamp,signal\n", encoding="utf-8")
 
     with _waveform_process_ctx(process_id, csv_path.as_posix()):
@@ -780,9 +833,11 @@ def test_get_process_waveform_preview_resolves_relative_source_path(
 def test_get_process_waveform_preview_uses_first_numeric_column(
     client: TestClient,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     process_id = f"wave_multi_numeric_{uuid4().hex[:8]}"
     csv_path = tmp_path / "wave_multi_numeric.csv"
+    _set_data_root(monkeypatch, tmp_path)
     csv_path.write_text(
         "timestamp,primary_signal,secondary_signal\nt1,1.0,10.0\nt2,2.0,20.0\n",
         encoding="utf-8",
@@ -844,6 +899,7 @@ def test_get_process_waveform_preview_returns_503_on_transient_db_error(
 def test_get_process_waveform_preview_csv_parsing_variants(
     client: TestClient,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     process_id_prefix: str,
     csv_filename: str,
     csv_content: str,
@@ -851,6 +907,7 @@ def test_get_process_waveform_preview_csv_parsing_variants(
 ) -> None:
     process_id = f"{process_id_prefix}_{uuid4().hex[:8]}"
     csv_path = tmp_path / csv_filename
+    _set_data_root(monkeypatch, tmp_path)
     csv_path.write_text(csv_content, encoding="utf-8")
 
     with _waveform_process_ctx(process_id, csv_path.as_posix()):

--- a/tests/db_api/test_db_api_chart_points_waveform_endpoint.py
+++ b/tests/db_api/test_db_api_chart_points_waveform_endpoint.py
@@ -579,6 +579,7 @@ def test_get_process_waveform_preview_returns_empty_points_when_raw_csv_path_nul
 
     connection = _DetailedConnection()
     monkeypatch.setattr(db_app, "_connect", lambda _db_path: connection)
+    monkeypatch.setattr(db_app, "_connect_readonly", lambda _db_path: connection)
 
     res = client.get("/processes/wave_null_path/waveform-preview")
 


### PR DESCRIPTION
## Summary
- add waveform preview safety checks for allowed directories and readonly DB access
- add smoke tests for DashboardController delegation
- document the dashboard tab renderer alias compatibility risk

## Testing
- python -m pytest tests/db_api/test_db_api_chart_points_waveform_endpoint.py -xvs
- python -m pytest tests/integration/ -xvs --tb=short
- python -m pytest tests/dashboard/test_controller.py -q
- python -m pytest tests/dashboard/ -xvs

## Related
- closes #149
- closes #151
- closes #162
- closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ダッシュボードと波形安全性の問題修正 (PR #179)

### 主な変更
- 波形プレビューのパス検証強化：ProcessInfo.raw_csv_path を Path.resolve() して DATA_ROOT（環境変数、未設定時は作業ディレクトリ等）由来の許可ベースと比較し、許可外はログ出力の上で HTTP 403 を返すように変更
- 読み取り専用 DB 接続導入：_connect_readonly() を追加し、波形プレビューで読み取り専用（SQLite file:<path>?mode=ro + PRAGMA query_only=ON）接続を利用して DB 競合リスクを低減
- DashboardController のスモークテスト追加：依存サービスをモックして各公開メソッドが正しい内部サービス／引数へ委譲し、モック結果をそのまま返すことを検証
- ダッシュボードのエイリアス注記強化：_render_* 系の後方互換エイリアスが tab_renderers のリファクタで壊れるリスクを明記し、テストは tab_renderers モジュール自体を monkeypatch する方針を推奨する旨を記述
- テスト修正／追加：waveform-preview テスト群を _connect_readonly をパッチするよう更新し、DATA_ROOT をテスト tmp_path にセットする共通ヘルパを導入。DATA_ROOT 内は 200、外は 403 を検証するケースを追加

### テストと検証
- ユニット・統合・コントローラースモークのテスト群を追加／更新（テストコマンドは PR 説明参照）
- waveform-preview 周りは読み取り専用接続とパス許可の両面でテストを強化

### リスクとテストギャップ
- パス検証の限界：シンボリックリンク、複雑な相対パス、マウント境界などで想定外の回避が起き得る。追加の filesystem レベル検査や明示的ポリシーが望ましい
- 読み取り専用接続の前提：WAL モードや実運用での並列読み書きに起因する「database is locked」等の問題を完全に排除するものではない。WAL 前提や運用手順の明文化が不足
- テスト範囲の限定：DashboardController のテストは主に正常系の委譲確認に留まり、エラーパス、例外伝播、競合条件、境界値などの網羅は不足
- エイリアス互換性リスク：現状は文書化に留めているため、将来的な tab_renderers API 変更やエイリアス削除に備えた移行計画や CI 上のモンキーパッチ戦略が必要

### 関連クローズ
- 関連 issue を解決（#149、#151、#162、#163）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->