### PR TITLE
fix: remove Dash DataTable deprecation warnings in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 # UTC ISO 8601 before they reach these comparisons; SQLite < 3.38 may parse
 # those strings incorrectly and silently produce wrong filter results.
 dependencies = [
-  "dash>=2.18",
+  "dash[ag-grid]>=2.18",
   "fastapi>=0.115",
   "numpy>=2.4.2",
   "pandas>=3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.11"
 # UTC ISO 8601 before they reach these comparisons; SQLite < 3.38 may parse
 # those strings incorrectly and silently produce wrong filter results.
 dependencies = [
-  "dash[ag-grid]>=2.18",
+  "dash>=2.18",
+  "dash-ag-grid>=35.2",
   "fastapi>=0.115",
   "numpy>=2.4.2",
   "pandas>=3.0.1",

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -194,14 +194,12 @@ def move_to_active_by_chart_name(
 @app.callback(
     Output("chart-name", "value", allow_duplicate=True),
     Input("charts-table", "cellClicked"),
-    State("charts-table", "rowData"),
     prevent_initial_call=True,
 )
 def select_chart_from_table(
-    active_cell: dict[str, Any] | None,
-    data: list[dict[str, Any]] | None,
+    cell_clicked: dict[str, Any] | None,
 ) -> str | Any:
-    return _build_controller().select_chart_from_table(active_cell, data)
+    return _build_controller().select_chart_from_table(cell_clicked)
 
 
 @app.callback(

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -193,8 +193,8 @@ def move_to_active_by_chart_name(
 
 @app.callback(
     Output("chart-name", "value", allow_duplicate=True),
-    Input("charts-table", "active_cell"),
-    State("charts-table", "data"),
+    Input("charts-table", "cellClicked"),
+    State("charts-table", "rowData"),
     prevent_initial_call=True,
 )
 def select_chart_from_table(

--- a/src/portfolio_fdc/dashboard/controller.py
+++ b/src/portfolio_fdc/dashboard/controller.py
@@ -74,10 +74,9 @@ class DashboardController:
 
     def select_chart_from_table(
         self,
-        active_cell: dict[str, Any] | None,
-        data: list[dict[str, Any]] | None,
+        cell_clicked: dict[str, Any] | None,
     ) -> str | Any:
-        return self._navigation.select_chart_from_table(active_cell, data)
+        return self._navigation.select_chart_from_table(cell_clicked)
 
     def sync_active_selected_base_url(self, base_url: str) -> str:
         return self._navigation.sync_active_selected_base_url(base_url)

--- a/src/portfolio_fdc/dashboard/services/navigation.py
+++ b/src/portfolio_fdc/dashboard/services/navigation.py
@@ -40,6 +40,8 @@ class NavigationService:
             return no_update
 
         row_idx = active_cell.get("row")
+        if not isinstance(row_idx, int):
+            row_idx = active_cell.get("rowIndex")
         if not isinstance(row_idx, int) or row_idx < 0 or row_idx >= len(data):
             return no_update
 

--- a/src/portfolio_fdc/dashboard/services/navigation.py
+++ b/src/portfolio_fdc/dashboard/services/navigation.py
@@ -33,19 +33,16 @@ class NavigationService:
 
     def select_chart_from_table(
         self,
-        active_cell: dict[str, Any] | None,
-        data: list[dict[str, Any]] | None,
+        cell_clicked: dict[str, Any] | None,
     ) -> str | Any:
-        if not active_cell or not data:
+        if not cell_clicked:
             return no_update
 
-        row_idx = active_cell.get("row")
-        if not isinstance(row_idx, int):
-            row_idx = active_cell.get("rowIndex")
-        if not isinstance(row_idx, int) or row_idx < 0 or row_idx >= len(data):
+        row_data = cell_clicked.get("data")
+        if not isinstance(row_data, dict):
             return no_update
 
-        selected = data[row_idx].get("chart_id")
+        selected = row_data.get("chart_id")
         if not selected:
             return no_update
         return str(selected)

--- a/src/portfolio_fdc/dashboard/tab_renderers.py
+++ b/src/portfolio_fdc/dashboard/tab_renderers.py
@@ -78,22 +78,28 @@ def render_charts_tab(base_url: str, recipe_id: str) -> html.Div:
                 rowData=table_rows,
                 columnDefs=(
                     [
-                        {"headerName": "chart_id", "field": "chart_id"},
-                        {"headerName": "is_active", "field": "is_active"},
-                        {"headerName": "chart_name", "field": "chart_name"},
-                        {"headerName": "recipe_id", "field": "recipe_id"},
-                        {"headerName": "parameter", "field": "parameter"},
-                        {"headerName": "step_no", "field": "step_no"},
-                        {"headerName": "feature_type", "field": "feature_type"},
-                        {"headerName": "warning", "field": "warning"},
-                        {"headerName": "critical", "field": "critical"},
-                        {"headerName": "updated_at", "field": "updated_at"},
                         {
-                            "headerName": "open",
-                            "field": "open",
+                            **col,
                             "cellRenderer": "markdown",
                             "cellRendererParams": {"linkTarget": "_self"},
-                        },
+                        }
+                        if col["field"] == "open"
+                        else col
+                        for col in _ag_grid_columns(
+                            [
+                                "chart_id",
+                                "is_active",
+                                "chart_name",
+                                "recipe_id",
+                                "parameter",
+                                "step_no",
+                                "feature_type",
+                                "warning",
+                                "critical",
+                                "updated_at",
+                                "open",
+                            ]
+                        )
                     ]
                     if table_rows
                     else []

--- a/src/portfolio_fdc/dashboard/tab_renderers.py
+++ b/src/portfolio_fdc/dashboard/tab_renderers.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlencode
 
-from dash import dash_table, dcc, html
+import dash_ag_grid as dag
+from dash import dcc, html
 
 from .api_client import (
     get_active_charts,
@@ -23,8 +24,9 @@ from .view_models import (
     spc_band_with_points_figure,
 )
 
-typed_dash_table = cast(Any, dash_table)
-DataTable: Any = typed_dash_table.DataTable
+
+def _ag_grid_columns(keys: list[str]) -> list[dict[str, Any]]:
+    return [{"headerName": key, "field": key} for key in keys]
 
 
 def render_charts_tab(base_url: str, recipe_id: str) -> html.Div:
@@ -71,29 +73,34 @@ def render_charts_tab(base_url: str, recipe_id: str) -> html.Div:
     return html.Div(
         [
             html.H4(f"Charts: {len(table_rows)} rows"),
-            DataTable(
+            dag.AgGrid(
                 id="charts-table",
-                data=table_rows,
-                columns=(
+                rowData=table_rows,
+                columnDefs=(
                     [
-                        {"name": "chart_id", "id": "chart_id"},
-                        {"name": "is_active", "id": "is_active"},
-                        {"name": "chart_name", "id": "chart_name"},
-                        {"name": "recipe_id", "id": "recipe_id"},
-                        {"name": "parameter", "id": "parameter"},
-                        {"name": "step_no", "id": "step_no"},
-                        {"name": "feature_type", "id": "feature_type"},
-                        {"name": "warning", "id": "warning"},
-                        {"name": "critical", "id": "critical"},
-                        {"name": "updated_at", "id": "updated_at"},
-                        {"name": "open", "id": "open", "presentation": "markdown"},
+                        {"headerName": "chart_id", "field": "chart_id"},
+                        {"headerName": "is_active", "field": "is_active"},
+                        {"headerName": "chart_name", "field": "chart_name"},
+                        {"headerName": "recipe_id", "field": "recipe_id"},
+                        {"headerName": "parameter", "field": "parameter"},
+                        {"headerName": "step_no", "field": "step_no"},
+                        {"headerName": "feature_type", "field": "feature_type"},
+                        {"headerName": "warning", "field": "warning"},
+                        {"headerName": "critical", "field": "critical"},
+                        {"headerName": "updated_at", "field": "updated_at"},
+                        {
+                            "headerName": "open",
+                            "field": "open",
+                            "cellRenderer": "markdown",
+                            "cellRendererParams": {"linkTarget": "_self"},
+                        },
                     ]
                     if table_rows
                     else []
                 ),
-                page_size=12,
-                markdown_options={"link_target": "_self"},
-                style_table={"overflowX": "auto"},
+                defaultColDef={"resizable": True, "sortable": True, "filter": True},
+                dashGridOptions={"pagination": True, "paginationPageSize": 12},
+                style={"width": "100%", "overflowX": "auto"},
             ),
         ]
     )
@@ -157,11 +164,12 @@ def render_active_tab(base_url: str, recipe_id: str, chart_id: str) -> html.Div:
                     "Click a point in the top graph to show raw waveform"
                 ),
             ),
-            DataTable(
-                data=rows,
-                columns=[{"name": col, "id": col} for col in rows[0].keys()] if rows else [],
-                page_size=10,
-                style_table={"overflowX": "auto"},
+            dag.AgGrid(
+                rowData=rows,
+                columnDefs=_ag_grid_columns(list(rows[0].keys())) if rows else [],
+                defaultColDef={"resizable": True, "sortable": True, "filter": True},
+                dashGridOptions={"pagination": True, "paginationPageSize": 10},
+                style={"width": "100%", "overflowX": "auto"},
             ),
         ]
     )
@@ -190,13 +198,12 @@ def render_history_tab(base_url: str, chart_id: str) -> html.Div:
     return html.Div(
         [
             html.H4(f"History: {len(table_rows)} rows"),
-            DataTable(
-                data=table_rows,
-                columns=[{"name": col, "id": col} for col in table_rows[0].keys()]
-                if table_rows
-                else [],
-                page_size=12,
-                style_table={"overflowX": "auto"},
+            dag.AgGrid(
+                rowData=table_rows,
+                columnDefs=_ag_grid_columns(list(table_rows[0].keys())) if table_rows else [],
+                defaultColDef={"resizable": True, "sortable": True, "filter": True},
+                dashGridOptions={"pagination": True, "paginationPageSize": 12},
+                style={"width": "100%", "overflowX": "auto"},
             ),
         ]
     )
@@ -316,27 +323,28 @@ def render_judge_tab(base_url: str, recipe_id: str, chart_id: str, result_id: st
                     html.Ul(drilldown_links),
                 ]
             ),
-            DataTable(
-                data=table_rows,
-                columns=(
-                    [{"name": col, "id": col} for col in table_rows[0].keys()] if table_rows else []
-                ),
-                page_size=12,
-                style_data_conditional=[
-                    {
-                        "if": {"filter_query": '{level} = "NG"'},
-                        "backgroundColor": "rgba(176,0,32,0.08)",
-                    },
-                    {
-                        "if": {"filter_query": '{level} = "WARN"'},
-                        "backgroundColor": "rgba(245,124,0,0.08)",
-                    },
-                    {
-                        "if": {"filter_query": '{level} = "OK"'},
-                        "backgroundColor": "rgba(46,125,50,0.08)",
-                    },
-                ],
-                style_table={"overflowX": "auto"},
+            dag.AgGrid(
+                rowData=table_rows,
+                columnDefs=_ag_grid_columns(list(table_rows[0].keys())) if table_rows else [],
+                defaultColDef={"resizable": True, "sortable": True, "filter": True},
+                dashGridOptions={"pagination": True, "paginationPageSize": 12},
+                getRowStyle={
+                    "styleConditions": [
+                        {
+                            "condition": "params.data.level === 'NG'",
+                            "style": {"backgroundColor": "rgba(176,0,32,0.08)"},
+                        },
+                        {
+                            "condition": "params.data.level === 'WARN'",
+                            "style": {"backgroundColor": "rgba(245,124,0,0.08)"},
+                        },
+                        {
+                            "condition": "params.data.level === 'OK'",
+                            "style": {"backgroundColor": "rgba(46,125,50,0.08)"},
+                        },
+                    ]
+                },
+                style={"width": "100%", "overflowX": "auto"},
             ),
             html.H4("Judge Result Detail"),
             detail_block,

--- a/tests/dashboard/test_controller.py
+++ b/tests/dashboard/test_controller.py
@@ -187,30 +187,29 @@ class TestMoveToActiveByChartName:
 class TestSelectChartFromTable:
     """Tests for select_chart_from_table delegation."""
 
-    def test_delegates_with_active_cell_and_data(self, controller: DashboardController) -> None:
-        """select_chart_from_table should delegate arguments to NavigationService."""
-        active_cell = {"row": 0, "column": 0}
-        data = [{"chart_id": "CHART_1"}]
+    def test_delegates_with_cell_clicked(self, controller: DashboardController) -> None:
+        """select_chart_from_table should delegate cell_clicked to NavigationService."""
+        cell_clicked = {"rowIndex": 0, "data": {"chart_id": "CHART_1"}}
 
         with patch.object(
             controller._navigation,
             "select_chart_from_table",
             return_value="CHART_1",
         ) as mock_select:
-            controller.select_chart_from_table(active_cell, data)
+            controller.select_chart_from_table(cell_clicked)
 
-            mock_select.assert_called_once_with(active_cell, data)
+            mock_select.assert_called_once_with(cell_clicked)
 
-    def test_handles_none_arguments(self, controller: DashboardController) -> None:
-        """select_chart_from_table should handle None arguments."""
+    def test_handles_none_cell_clicked(self, controller: DashboardController) -> None:
+        """select_chart_from_table should handle None cell_clicked."""
         with patch.object(
             controller._navigation,
             "select_chart_from_table",
             return_value=None,
         ) as mock_select:
-            result = controller.select_chart_from_table(None, None)
+            result = controller.select_chart_from_table(None)
 
-            mock_select.assert_called_once_with(None, None)
+            mock_select.assert_called_once_with(None)
             assert result is None
 
 

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -305,20 +305,19 @@ def test_move_to_active_by_chart_name_switches_tab_and_updates_url() -> None:
 def test_select_chart_from_table_returns_no_update_for_none_cell() -> None:
     from dash import no_update
 
-    result = select_chart_from_table(None, [{"chart_id": "CHART_1"}])
+    result = select_chart_from_table(None)
     assert result is no_update
 
 
-def test_select_chart_from_table_returns_no_update_for_out_of_bounds_row() -> None:
+def test_select_chart_from_table_returns_no_update_when_data_key_missing() -> None:
     from dash import no_update
 
-    result = select_chart_from_table({"row": 5}, [{"chart_id": "CHART_1"}])
+    result = select_chart_from_table({"rowIndex": 0})
     assert result is no_update
 
 
 def test_select_chart_from_table_returns_chart_id_on_valid_cell() -> None:
-    data = [{"chart_id": "CHART_1"}, {"chart_id": "CHART_2"}]
-    result = select_chart_from_table({"row": 1}, data)
+    result = select_chart_from_table({"rowIndex": 1, "data": {"chart_id": "CHART_2"}})
     assert result == "CHART_2"
 
 

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -3,12 +3,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.portfolio_fdc.dashboard.api_client import APIError
-from src.portfolio_fdc.dashboard.services.active_drilldown import ActiveDrilldownService
-from src.portfolio_fdc.dashboard.services.chart_name_options import ChartNameOptionService
-from src.portfolio_fdc.dashboard.services.navigation import NavigationService
-from src.portfolio_fdc.dashboard.services.tab_load import TabLoadService
-from src.portfolio_fdc.dashboard.services.url_filters import UrlFilterService
+from portfolio_fdc.dashboard.api_client import APIError
+from portfolio_fdc.dashboard.services.active_drilldown import ActiveDrilldownService
+from portfolio_fdc.dashboard.services.chart_name_options import ChartNameOptionService
+from portfolio_fdc.dashboard.services.navigation import NavigationService
+from portfolio_fdc.dashboard.services.tab_load import TabLoadService
+from portfolio_fdc.dashboard.services.url_filters import UrlFilterService
 
 
 @pytest.fixture
@@ -489,42 +489,33 @@ def test_navigation_service_select_chart_from_table_none_cases():
     service = NavigationService()
     from dash import no_update
 
-    # active_cell=None
-    assert service.select_chart_from_table(None, [{"chart_id": "c1"}]) is no_update
-    # data=None
-    assert service.select_chart_from_table({"row": 0}, None) is no_update
+    # cell_clicked=None
+    assert service.select_chart_from_table(None) is no_update
+    # data key missing
+    assert service.select_chart_from_table({}) is no_update
+    # data not a dict
+    assert service.select_chart_from_table({"data": None}) is no_update
 
 
-def test_navigation_service_select_chart_from_table_row_idx_cases():
+def test_navigation_service_select_chart_from_table_chart_id_missing():
     service = NavigationService()
     from dash import no_update
 
-    data = [{"chart_id": "c1"}, {"chart_id": "c2"}]
-    # row_idx out of range
-    assert service.select_chart_from_table({"row": 2}, data) is no_update
-    # row_idx negative
-    assert service.select_chart_from_table({"row": -1}, data) is no_update
-    # row_idx not int
-    assert service.select_chart_from_table({"row": "0"}, data) is no_update
-
-
-def test_navigation_service_select_chart_from_table_chart_id_empty():
-    service = NavigationService()
-    from dash import no_update
-
-    data = [{"chart_id": ""}]
-    assert service.select_chart_from_table({"row": 0}, data) is no_update
+    # chart_id absent from row data
+    assert service.select_chart_from_table({"data": {}}) is no_update
+    # chart_id empty string
+    assert service.select_chart_from_table({"data": {"chart_id": ""}}) is no_update
 
 
 def test_navigation_service_select_chart_from_table_normal():
     service = NavigationService()
-    data = [{"chart_id": "c1"}, {"chart_id": "c2"}]
-    assert service.select_chart_from_table({"row": 1}, data) == "c2"
+    result = service.select_chart_from_table({"data": {"chart_id": "c2"}})
+    assert result == "c2"
 
 
 def test_navigation_service_sync_active_selected_base_url():
     service = NavigationService()
-    from src.portfolio_fdc.dashboard.base_url import DEFAULT_DB_API_BASE_URL
+    from portfolio_fdc.dashboard.base_url import DEFAULT_DB_API_BASE_URL
 
     # 空文字列→デフォルト
     assert service.sync_active_selected_base_url("") == DEFAULT_DB_API_BASE_URL


### PR DESCRIPTION
## Summary
- replace deprecated dash_table.DataTable usage with dash_ag_grid.AgGrid in dashboard tab renderers
- update charts table callback wiring from DataTable props to AgGrid props (ctive_cell/data -> cellClicked/rowData)
- keep row selection compatibility by accepting both ow and owIndex
- update dependency to dash[ag-grid]

## Validation
- E:/work/python/logger/.venv/Scripts/python.exe -m pytest tests/dashboard/test_tab_renderers.py
- E:/work/python/logger/.venv/Scripts/python.exe -m pytest -q

## Expected Effect
- pytest warning summary no longer shows Dash DataTable deprecation warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更概要

- Dashの廃止予定コンポーネント dash_table.DataTable を dash_ag_grid.AgGrid に置換
- pyproject.toml に dash-ag-grid（dash[ag-grid]相当、>=35.2）を追加
- チャートテーブルのコールバックを DataTable の props (active_cell, data) から AgGrid のイベント/props (cellClicked / rowData) に差し替え
- row 選択処理は後方互換性を維持するため row と rowIndex の両方を受け入れるロジックを保持／追加
- 関連するコントローラ・サービス・テストを新しい単一 payload (cell_clicked) 形に合わせて修正

## 実装上のリスク

- cellClicked ペイロードの形状依存：コードは cellClicked["data"] を期待するが、実運用での AgGrid ペイロード形式（row vs rowIndex、ネスト構造等）のバリエーション確認が不十分
- 後方互換フォールバックの網羅性：row / rowIndex 両対応ロジックはあるが、実際の AgGrid が常に期待するフィールドを送る保証はテストで完全に担保されていない
- セルレンダリング差分：charts タブの「開く」列を markdown レンダラに置き換えたが、レンダラ挙動（リンクターゲットやセキュリティ属性等）は実動作で未検証
- 行スタイル適用ロジック：judge 結果タブの色付けを getRowStyle に移行したが、条件マッチや空データ時の挙動が未確認
- 依存更新影響：dash[ag-grid] 追加に伴うパッケージ互換性や環境差異の影響（CI・ローカル環境）を完全には検証していない

## テスト不足 / ギャップ

- AgGrid 固有の E2E／統合テストが不足（特に cellClicked イベントを発火する E2E）
- cellRenderer="markdown" によるリンクレンダリングの視覚的／機能的検証がない
- getRowStyle による行着色の単体／統合テストがない（空テーブル含む）
- ページネーション／ページサイズ（paginationPageSize）や列リサイズ等の UI 設定の挙動テストがない
- CI 上での依存解決（dash-ag-grid の実環境互換）チェックが明示されていない

## 既に検証された項目

- ローカルでの pytest（部分テストおよびフルスイート実行）を実行済み（tests/dashboard 関連を含む）
- コントローラ／サービスの単体テストを新しい cell_clicked 形式へ更新し合格
- Pytest 上の Dash DataTable 廃止警告が出ないこと（期待）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->