### PR TITLE
dashboard: improve responsive filter controls and tabs

### DIFF
--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -32,6 +32,25 @@ def _build_controller() -> DashboardController:
     return DashboardController(logger, deps)
 
 
+def _build_filter_group(
+    children: list[Any],
+    *,
+    flex: str,
+    class_name: str = "dashboard-filter-group",
+    style_overrides: dict[str, str] | None = None,
+) -> html.Div:
+    style = {
+        "display": "flex",
+        "flexDirection": "column",
+        "gap": "4px",
+        "flex": flex,
+        "minWidth": "0",
+    }
+    if style_overrides:
+        style.update(style_overrides)
+    return html.Div(children, style=style, className=class_name)
+
+
 app = Dash(
     __name__,
     suppress_callback_exceptions=False,
@@ -60,7 +79,7 @@ app.layout = html.Div(
         ),
         html.Div(
             [
-                html.Div(
+                _build_filter_group(
                     [
                         html.Label("db_api base URL"),
                         dcc.Input(
@@ -70,44 +89,24 @@ app.layout = html.Div(
                             style={"width": "100%"},
                         ),
                     ],
-                    style={
-                        "display": "flex",
-                        "flexDirection": "column",
-                        "gap": "4px",
-                        "flex": "2 1 320px",
-                        "minWidth": "0",
-                    },
-                    className="dashboard-filter-group dashboard-filter-base-url",
+                    flex="2 1 320px",
+                    class_name="dashboard-filter-group dashboard-filter-base-url",
                 ),
-                html.Div(
+                _build_filter_group(
                     [
                         html.Label("recipe_id"),
                         dcc.Input(id="recipe-id", type="text", value="", style={"width": "100%"}),
                     ],
-                    style={
-                        "display": "flex",
-                        "flexDirection": "column",
-                        "gap": "4px",
-                        "flex": "1 1 180px",
-                        "minWidth": "0",
-                    },
-                    className="dashboard-filter-group",
+                    flex="1 1 180px",
                 ),
-                html.Div(
+                _build_filter_group(
                     [
                         html.Label("chart_id"),
                         dcc.Input(id="chart-id", type="text", value="", style={"width": "100%"}),
                     ],
-                    style={
-                        "display": "flex",
-                        "flexDirection": "column",
-                        "gap": "4px",
-                        "flex": "1 1 160px",
-                        "minWidth": "0",
-                    },
-                    className="dashboard-filter-group",
+                    flex="1 1 160px",
                 ),
-                html.Div(
+                _build_filter_group(
                     [
                         html.Label("chart_name"),
                         dcc.Dropdown(
@@ -118,38 +117,21 @@ app.layout = html.Div(
                             style={"width": "100%"},
                         ),
                     ],
-                    style={
-                        "display": "flex",
-                        "flexDirection": "column",
-                        "gap": "4px",
-                        "flex": "3 1 360px",
-                        "minWidth": "0",
-                    },
-                    className="dashboard-filter-group dashboard-filter-chart-name",
+                    flex="3 1 360px",
+                    class_name="dashboard-filter-group dashboard-filter-chart-name",
                 ),
-                html.Div(
+                _build_filter_group(
                     [
                         html.Label("result_id"),
                         dcc.Input(id="result-id", type="text", value="", style={"width": "100%"}),
                     ],
-                    style={
-                        "display": "flex",
-                        "flexDirection": "column",
-                        "gap": "4px",
-                        "flex": "1 1 160px",
-                        "minWidth": "0",
-                    },
-                    className="dashboard-filter-group",
+                    flex="1 1 160px",
                 ),
-                html.Div(
+                _build_filter_group(
                     [html.Button("Load", id="load-btn", n_clicks=0, style={"width": "100%"})],
-                    style={
-                        "display": "flex",
-                        "alignItems": "flex-end",
-                        "flex": "1 1 120px",
-                        "minWidth": "96px",
-                    },
-                    className="dashboard-filter-group dashboard-filter-load",
+                    flex="1 1 120px",
+                    class_name="dashboard-filter-group dashboard-filter-load",
+                    style_overrides={"alignItems": "flex-end", "minWidth": "96px"},
                 ),
             ],
             style={

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -32,7 +32,13 @@ def _build_controller() -> DashboardController:
     return DashboardController(logger, deps)
 
 
-app = Dash(__name__, suppress_callback_exceptions=False, title="FDC Dashboard Baseline")
+app = Dash(
+    __name__,
+    suppress_callback_exceptions=False,
+    title="FDC Dashboard Baseline",
+    meta_tags=[{"name": "viewport", "content": "width=device-width, initial-scale=1"}],
+    assets_folder=os.path.join(os.path.dirname(__file__), "assets"),
+)
 
 # Re-exported aliases for backward compatibility.
 # IMPORTANT: Tests should monkeypatch tab_renderers module directly, not these aliases,
@@ -54,50 +60,124 @@ app.layout = html.Div(
         ),
         html.Div(
             [
-                html.Label("db_api base URL"),
-                dcc.Input(
-                    id="base-url",
-                    type="text",
-                    value=DEFAULT_DB_API_BASE_URL,
-                    style={"width": "360px"},
+                html.Div(
+                    [
+                        html.Label("db_api base URL"),
+                        dcc.Input(
+                            id="base-url",
+                            type="text",
+                            value=DEFAULT_DB_API_BASE_URL,
+                            style={"width": "100%"},
+                        ),
+                    ],
+                    style={
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "gap": "4px",
+                        "flex": "2 1 320px",
+                        "minWidth": "0",
+                    },
+                    className="dashboard-filter-group dashboard-filter-base-url",
                 ),
-                html.Label("recipe_id"),
-                dcc.Input(id="recipe-id", type="text", value="", style={"width": "220px"}),
-                html.Label("chart_id"),
-                dcc.Input(id="chart-id", type="text", value="", style={"width": "160px"}),
-                html.Label("chart_name"),
-                dcc.Dropdown(
-                    id="chart-name",
-                    options=[],
-                    value=None,
-                    placeholder="Select chart",
-                    style={"width": "500px"},
+                html.Div(
+                    [
+                        html.Label("recipe_id"),
+                        dcc.Input(id="recipe-id", type="text", value="", style={"width": "100%"}),
+                    ],
+                    style={
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "gap": "4px",
+                        "flex": "1 1 180px",
+                        "minWidth": "0",
+                    },
+                    className="dashboard-filter-group",
                 ),
-                html.Label("result_id"),
-                dcc.Input(id="result-id", type="text", value="", style={"width": "160px"}),
-                html.Button("Load", id="load-btn", n_clicks=0),
+                html.Div(
+                    [
+                        html.Label("chart_id"),
+                        dcc.Input(id="chart-id", type="text", value="", style={"width": "100%"}),
+                    ],
+                    style={
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "gap": "4px",
+                        "flex": "1 1 160px",
+                        "minWidth": "0",
+                    },
+                    className="dashboard-filter-group",
+                ),
+                html.Div(
+                    [
+                        html.Label("chart_name"),
+                        dcc.Dropdown(
+                            id="chart-name",
+                            options=[],
+                            value=None,
+                            placeholder="Select chart",
+                            style={"width": "100%"},
+                        ),
+                    ],
+                    style={
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "gap": "4px",
+                        "flex": "3 1 360px",
+                        "minWidth": "0",
+                    },
+                    className="dashboard-filter-group dashboard-filter-chart-name",
+                ),
+                html.Div(
+                    [
+                        html.Label("result_id"),
+                        dcc.Input(id="result-id", type="text", value="", style={"width": "100%"}),
+                    ],
+                    style={
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "gap": "4px",
+                        "flex": "1 1 160px",
+                        "minWidth": "0",
+                    },
+                    className="dashboard-filter-group",
+                ),
+                html.Div(
+                    [html.Button("Load", id="load-btn", n_clicks=0, style={"width": "100%"})],
+                    style={
+                        "display": "flex",
+                        "alignItems": "flex-end",
+                        "flex": "1 1 120px",
+                        "minWidth": "96px",
+                    },
+                    className="dashboard-filter-group dashboard-filter-load",
+                ),
             ],
             style={
-                "display": "grid",
-                "gridTemplateColumns": "auto auto auto auto auto auto auto auto auto auto auto",
+                "display": "flex",
+                "flexWrap": "wrap",
                 "gap": "8px",
-                "alignItems": "center",
+                "alignItems": "flex-end",
+                "width": "100%",
                 "margin": "12px 0",
             },
+            className="dashboard-filter-controls",
         ),
         html.Div(
             id="error-banner",
             style={"color": "#b00020", "fontWeight": "bold", "marginBottom": "8px"},
         ),
-        dcc.Tabs(
-            id="tabs",
-            value="charts",
-            children=[
-                dcc.Tab(label="Charts", value="charts"),
-                dcc.Tab(label="Active", value="active"),
-                dcc.Tab(label="History", value="history"),
-                dcc.Tab(label="Judge", value="judge"),
-            ],
+        html.Div(
+            dcc.Tabs(
+                id="tabs",
+                value="charts",
+                children=[
+                    dcc.Tab(label="Charts", value="charts"),
+                    dcc.Tab(label="Active", value="active"),
+                    dcc.Tab(label="History", value="history"),
+                    dcc.Tab(label="Judge", value="judge"),
+                ],
+            ),
+            className="dashboard-tabs-wrap",
         ),
         html.Div(id="tab-content"),
     ],

--- a/src/portfolio_fdc/dashboard/assets/dashboard.css
+++ b/src/portfolio_fdc/dashboard/assets/dashboard.css
@@ -16,6 +16,7 @@
 @media (max-width: 480px) {
   .dashboard-filter-group {
     flex-basis: 100% !important;
+    width: 100%;
   }
 
   .dashboard-filter-controls {

--- a/src/portfolio_fdc/dashboard/assets/dashboard.css
+++ b/src/portfolio_fdc/dashboard/assets/dashboard.css
@@ -1,0 +1,24 @@
+.dashboard-tabs-wrap {
+  overflow-x: auto;
+}
+
+@media (max-width: 720px) {
+  .dashboard-filter-controls {
+    gap: 6px;
+  }
+
+  .dashboard-filter-load {
+    flex-basis: 100% !important;
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .dashboard-filter-group {
+    flex-basis: 100% !important;
+  }
+
+  .dashboard-filter-controls {
+    align-items: stretch !important;
+  }
+}

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import socket
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -8,6 +9,7 @@ from dash import html
 
 from portfolio_fdc.dashboard.api_client import APIError
 from portfolio_fdc.dashboard.app import (
+    app,
     load_data,
     move_to_active_by_chart_name,
     refresh_chart_name_options,
@@ -17,6 +19,38 @@ from portfolio_fdc.dashboard.app import (
     sync_filters_from_url,
     validate_base_url,
 )
+
+
+def test_dashboard_filter_controls_are_wrapping_for_narrow_viewports() -> None:
+    controls_row = app.layout.children[4]
+    assert isinstance(controls_row, html.Div)
+    assert controls_row.style["display"] == "flex"
+    assert controls_row.style["flexWrap"] == "wrap"
+    assert controls_row.style["width"] == "100%"
+    assert controls_row.className == "dashboard-filter-controls"
+    control_groups = controls_row.children
+    for group in control_groups[:-1]:
+        assert group.style["minWidth"] == "0"
+        assert "dashboard-filter-group" in group.className
+
+
+def test_dashboard_layout_exposes_responsive_css_hooks() -> None:
+    tabs_wrapper = app.layout.children[6]
+    assert isinstance(tabs_wrapper, html.Div)
+    assert tabs_wrapper.className == "dashboard-tabs-wrap"
+
+    load_group = app.layout.children[4].children[-1]
+    assert "dashboard-filter-load" in load_group.className
+
+    css_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "portfolio_fdc"
+        / "dashboard"
+        / "assets"
+        / "dashboard.css"
+    )
+    assert css_path.exists()
 
 
 def test_refresh_chart_name_options_keeps_dropdown_unselected_without_chart_id(

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -21,8 +21,19 @@ from portfolio_fdc.dashboard.app import (
 )
 
 
+def _find_div_by_class_token(root: html.Div, class_token: str) -> html.Div:
+    for child in root.children:
+        if not isinstance(child, html.Div):
+            continue
+        class_name = getattr(child, "className", "") or ""
+        if class_token in class_name.split():
+            return child
+    raise AssertionError(f"Could not find html.Div with class token: {class_token}")
+
+
 def test_dashboard_filter_controls_are_wrapping_for_narrow_viewports() -> None:
-    controls_row = app.layout.children[4]
+    assert isinstance(app.layout, html.Div)
+    controls_row = _find_div_by_class_token(app.layout, "dashboard-filter-controls")
     assert isinstance(controls_row, html.Div)
     assert controls_row.style["display"] == "flex"
     assert controls_row.style["flexWrap"] == "wrap"
@@ -35,12 +46,23 @@ def test_dashboard_filter_controls_are_wrapping_for_narrow_viewports() -> None:
 
 
 def test_dashboard_layout_exposes_responsive_css_hooks() -> None:
-    tabs_wrapper = app.layout.children[6]
+    assert isinstance(app.layout, html.Div)
+    tabs_wrapper = _find_div_by_class_token(app.layout, "dashboard-tabs-wrap")
     assert isinstance(tabs_wrapper, html.Div)
     assert tabs_wrapper.className == "dashboard-tabs-wrap"
 
-    load_group = app.layout.children[4].children[-1]
+    controls_row = _find_div_by_class_token(app.layout, "dashboard-filter-controls")
+    load_group = _find_div_by_class_token(controls_row, "dashboard-filter-load")
     assert "dashboard-filter-load" in load_group.className
+
+    assets_dir = (
+        getattr(app, "assets_folder", None)
+        or getattr(app, "assets_path", None)
+        or getattr(app.config, "assets_folder", None)
+    )
+    assert assets_dir
+    assets_css_path = Path(assets_dir) / "dashboard.css"
+    assert assets_css_path.exists()
 
     css_path = (
         Path(__file__).resolve().parents[2]

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -40,9 +40,14 @@ def test_dashboard_filter_controls_are_wrapping_for_narrow_viewports() -> None:
     assert controls_row.style["width"] == "100%"
     assert controls_row.className == "dashboard-filter-controls"
     control_groups = controls_row.children
-    for group in control_groups[:-1]:
-        assert group.style["minWidth"] == "0"
+    for group in control_groups:
         assert "dashboard-filter-group" in group.className
+        if "dashboard-filter-load" not in group.className:
+            assert group.style["minWidth"] == "0"
+
+    load_group = _find_div_by_class_token(controls_row, "dashboard-filter-load")
+    assert load_group.style["minWidth"] == "96px"
+    assert load_group.style["flex"] == "1 1 120px"
 
 
 def test_dashboard_layout_exposes_responsive_css_hooks() -> None:

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -74,7 +74,7 @@ def test_dashboard_layout_exposes_responsive_css_hooks() -> None:
         or getattr(app.config, "assets_folder", None)
     )
     assert assets_dir
-    assets_css_path = Path(assets_dir) / "dashboard.css"
+    assets_css_path = Path(assets_dir).resolve() / "dashboard.css"
     assert assets_css_path.exists()
 
     css_path = (
@@ -86,6 +86,25 @@ def test_dashboard_layout_exposes_responsive_css_hooks() -> None:
         / "dashboard.css"
     )
     assert css_path.exists()
+
+
+def _extract_brace_block(text: str, after: str) -> str:
+    """Return the content of the first { ... } block following `after` in `text`."""
+    idx = text.find(after)
+    if idx == -1:
+        return ""
+    brace_open = text.find("{", idx)
+    if brace_open == -1:
+        return ""
+    depth = 0
+    for i in range(brace_open, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace_open + 1 : i]
+    return ""
 
 
 def test_dashboard_css_contains_required_media_queries() -> None:
@@ -103,14 +122,14 @@ def test_dashboard_css_contains_required_media_queries() -> None:
     assert "720px" in css_text
     assert "480px" in css_text
 
-    assert ".dashboard-tabs-wrap" in css_text
-    assert "overflow-x" in css_text
+    # overflow-x must appear inside the .dashboard-tabs-wrap selector block
+    tabs_wrap_block = _extract_brace_block(css_text, ".dashboard-tabs-wrap")
+    assert "overflow-x" in tabs_wrap_block
 
-    media_start = css_text.find("@media")
-    assert media_start != -1
-    media_text = css_text[media_start:]
-    assert ".dashboard-filter-group" in media_text
-    assert "width: 100%" in media_text
+    # .dashboard-filter-group must contain width: 100% inside the 480px media block
+    media_480_block = _extract_brace_block(css_text, "480px")
+    filter_group_block = _extract_brace_block(media_480_block, ".dashboard-filter-group")
+    assert "width: 100%" in filter_group_block
 
 
 def test_refresh_chart_name_options_keeps_dropdown_unselected_without_chart_id(

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -88,6 +88,31 @@ def test_dashboard_layout_exposes_responsive_css_hooks() -> None:
     assert css_path.exists()
 
 
+def test_dashboard_css_contains_required_media_queries() -> None:
+    css_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "portfolio_fdc"
+        / "dashboard"
+        / "assets"
+        / "dashboard.css"
+    )
+    css_text = css_path.read_text(encoding="utf-8")
+
+    assert "@media" in css_text
+    assert "720px" in css_text
+    assert "480px" in css_text
+
+    assert ".dashboard-tabs-wrap" in css_text
+    assert "overflow-x" in css_text
+
+    media_start = css_text.find("@media")
+    assert media_start != -1
+    media_text = css_text[media_start:]
+    assert ".dashboard-filter-group" in media_text
+    assert "width: 100%" in media_text
+
+
 def test_refresh_chart_name_options_keeps_dropdown_unselected_without_chart_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -22,7 +22,15 @@ from portfolio_fdc.dashboard.app import (
 
 
 def _find_div_by_class_token(root: html.Div, class_token: str) -> html.Div:
-    for child in root.children:
+    children = root.children
+    if children is None:
+        normalized_children: list[Any] = []
+    elif isinstance(children, (list, tuple)):
+        normalized_children = list(children)
+    else:
+        normalized_children = [children]
+
+    for child in normalized_children:
         if not isinstance(child, html.Div):
             continue
         class_name = getattr(child, "className", "") or ""
@@ -38,7 +46,7 @@ def test_dashboard_filter_controls_are_wrapping_for_narrow_viewports() -> None:
     assert controls_row.style["display"] == "flex"
     assert controls_row.style["flexWrap"] == "wrap"
     assert controls_row.style["width"] == "100%"
-    assert controls_row.className == "dashboard-filter-controls"
+    assert "dashboard-filter-controls" in controls_row.className.split()
     control_groups = controls_row.children
     for group in control_groups:
         assert "dashboard-filter-group" in group.className
@@ -54,7 +62,7 @@ def test_dashboard_layout_exposes_responsive_css_hooks() -> None:
     assert isinstance(app.layout, html.Div)
     tabs_wrapper = _find_div_by_class_token(app.layout, "dashboard-tabs-wrap")
     assert isinstance(tabs_wrapper, html.Div)
-    assert tabs_wrapper.className == "dashboard-tabs-wrap"
+    assert "dashboard-tabs-wrap" in tabs_wrapper.className.split()
 
     controls_row = _find_div_by_class_token(app.layout, "dashboard-filter-controls")
     load_group = _find_div_by_class_token(controls_row, "dashboard-filter-load")


### PR DESCRIPTION
## Summary
- switch dashboard filter controls from fixed multi-column layout to responsive wrapping groups
- add dashboard assets CSS for narrow viewport behavior (load button row and stacked controls)
- make tabs horizontally scrollable on small screens
- add dashboard layout regression tests for responsive class hooks and CSS asset presence

## Testing
- E:/work/python/logger/.venv/Scripts/python.exe -m pytest -q tests/dashboard/test_dashboard_app.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ダッシュボードのレスポンシブ対応改善 (PR #181)

- 変更内容（短く）
  - src/portfolio_fdc/dashboard/app.py: viewport meta 追加、モジュール内 assets 指定。フィルター群を固定グリッドからレスポンシブな flex-wrap の縦積みグループへリファクタ。Load ボタンを専用グループ（幅制約あり）へ移動。Tabs を .dashboard-tabs-wrap でラップして小画面で横スクロール可能に。
  - src/portfolio_fdc/dashboard/assets/dashboard.css（新規）: タブ横スクロール対応と @media (max-width: 720px / 480px) によるフィルター群の全幅化・ギャップ／整列調整を追加。
  - tests/dashboard/test_dashboard_app.py: レイアウトの className / inline style によるレスポンシブフック確認テストと、assets/dashboard.css の存在およびメディアクエリ／セレクタ／プロパティ（720px/480px、overflow-x、width:100% など）をチェックする CSS 内容テストを追加。

- リスク
  - 指定ブレークポイント（720px/480px）以外の幅で期待外表示が発生する可能性。
  - flex-basis / min-width 指定（例: Load の 96px）やインラインスタイルと外部 CSS の競合でブラウザ差異や優先度問題が生じる可能性。
  - タブの横スクロールはタッチ操作、フォーカス管理、スクリーンリーダーなどアクセシビリティに影響する懸念がある。

- テストギャップ（重要）
  - 実ブラウザでのビジュアル回帰（スクリーンショット比較）や E2E テストが無く、実デバイスでの折返し・スクロール挙動（タッチ含む）が未検証。
  - 複数ビューポート（例: 320px/375px/768px 等）での網羅的表示確認が不足。
  - getComputedStyle を使ったブラウザ計算スタイルの実測（flex-wrap や overflow-x 等）テストが無いため、実レンダリング挙動が未保証。
  - キーボード操作やスクリーンリーダーを含むアクセシビリティ検証が未実施。
  - レイアウト変更が既存の Dash コールバックや UI インタラクションに与える影響を確認する統合テストが不足。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->