### PR TITLE
docs(governance): record Discussion #183 audit_events/notification_outbox decisions

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -38,30 +38,30 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_target
 
 #### 論点2: event_type 一覧（Phase 1 確定）
 
-| event_type | 発生タイミング | before/after |
-|---|---|---|
-| `change_requested` | change_request 作成時 | after のみ（申請内容） |
-| `change_request_approved` | approve 完了時 | なし |
-| `change_request_rejected` | reject 時 | なし |
-| `change_request_applied` | apply 成功時 | 閾値の before/after（フル snapshot） |
-| `change_request_apply_failed` | apply 失敗時 | after に error_code/message |
-| `emergency_changed` | 緊急変更完了時 | 閾値の before/after（フル snapshot） |
-| `emergency_ratified` | 追認完了時 | なし |
-| `notification_queued` | outbox INSERT 時 | なし |
-| `notification_sent` | 送信成功時 | なし |
-| `notification_retry_succeeded` | retry 成功時 | なし |
-| `notification_retry_failed` | retry 上限到達時 | なし |
+| event_type                     | 発生タイミング        | before/after                         |
+| ------------------------------ | --------------------- | ------------------------------------ |
+| `change_requested`             | change_request 作成時 | after のみ（申請内容）               |
+| `change_request_approved`      | approve 完了時        | なし                                 |
+| `change_request_rejected`      | reject 時             | なし                                 |
+| `change_request_applied`       | apply 成功時          | 閾値の before/after（フル snapshot） |
+| `change_request_apply_failed`  | apply 失敗時          | after に error_code/message          |
+| `emergency_changed`            | 緊急変更完了時        | 閾値の before/after（フル snapshot） |
+| `emergency_ratified`           | 追認完了時            | なし                                 |
+| `notification_queued`          | outbox INSERT 時      | なし                                 |
+| `notification_sent`            | 送信成功時            | なし                                 |
+| `notification_retry_succeeded` | retry 成功時          | なし                                 |
+| `notification_retry_failed`    | retry 上限到達時      | なし                                 |
 
 Phase 2 以降候補: `notification_dead_lettered`
 
 #### 論点3: before/after の差分形式
 
-| event_type | before_json | after_json |
-|---|---|---|
+| event_type               | before_json                 | after_json                  |
+| ------------------------ | --------------------------- | --------------------------- |
 | `change_request_applied` | 変更前全フィールド snapshot | 変更後全フィールド snapshot |
-| `emergency_changed` | 変更前全フィールド snapshot | 変更後全フィールド snapshot |
-| `change_requested` | null | 申請内容（delta のみで可） |
-| それ以外 | null | null |
+| `emergency_changed`      | 変更前全フィールド snapshot | 変更後全フィールド snapshot |
+| `change_requested`       | null                        | 申請内容（delta のみで可）  |
+| それ以外                 | null                        | null                        |
 
 - changed fields のみでは before が何だったか復元できないため、apply と緊急変更は必ず全フィールド snapshot
 - no-op 更新（値に差分なし）の場合: audit event も ChartsHistory も残さない（`#109` 決定済み）
@@ -79,7 +79,7 @@ Phase 2 以降候補: `notification_dead_lettered`
 CREATE TABLE IF NOT EXISTS GovernanceNotificationOutbox (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     event_id        INTEGER NOT NULL,    -- GovernanceAuditEvents.id（emergency_changed イベントが起点）
-    status          TEXT    NOT NULL DEFAULT 'pending',
+  status          TEXT    NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','sent','failed')),
     retry_count     INTEGER NOT NULL DEFAULT 0,
     next_retry_at   TEXT,               -- NULL = 即時試行可
     last_attempt_at TEXT,
@@ -92,6 +92,7 @@ CREATE INDEX IF NOT EXISTS idx_notification_outbox_status
 ```
 
 FK の方向:
+
 - `outbox.event_id → GovernanceAuditEvents.id`（起点 audit event への参照）
 - retry 系 audit event（`notification_queued` / `notification_retry_failed` 等）は `target_type='notification', target_id=outbox.id` で論理参照。循環 FK を避ける
 
@@ -99,7 +100,7 @@ FK の方向:
 
 `sending` を省略した真の3状態を採用する。
 
-```
+```text
 pending → sent（ターミナル）
         ↘ failed
 failed → sent（retry 成功、ターミナル）
@@ -112,14 +113,14 @@ failed → sent（retry 成功、ターミナル）
 
 #### 論点7: retry の契約
 
-| 項目 | 方針 |
-|---|---|
-| retry 対象 | `status = 'failed'` のみ |
-| retry_count 上限 | 3 回（`#102` write 系 attempts 上限に統一） |
-| next_retry_at 算出 | 指数バックオフ（1分, 5分, 30分）。`datetime_util.to_utc_millis()` で記録 |
-| 上限到達後 | `status = 'failed'` のまま `next_retry_at = NULL` で取得対象から外れる |
-| 最終失敗の監査連携 | 上限到達時に `notification_retry_failed` audit event を INSERT |
-| retry API に `sent` / `pending` を指定した場合 | 400（retry 対象外） |
+| 項目                                           | 方針                                                                     |
+| ---------------------------------------------- | ------------------------------------------------------------------------ |
+| retry 対象                                     | `status = 'failed'` のみ                                                 |
+| retry_count 上限                               | 3 回（`#102` write 系 attempts 上限に統一）                              |
+| next_retry_at 算出                             | 指数バックオフ（1分, 5分, 30分）。`datetime_util.to_utc_millis()` で記録 |
+| 上限到達後                                     | `status = 'failed'` のまま `next_retry_at = NULL` で取得対象から外れる   |
+| 最終失敗の監査連携                             | 上限到達時に `notification_retry_failed` audit event を INSERT           |
+| retry API に `sent` / `pending` を指定した場合 | 400（retry 対象外）                                                      |
 
 retry は `POST /governance/notifications/{event_id}/retry` の明示呼び出し方式（バックグラウンドポーリングは今回対象外）。
 
@@ -333,12 +334,12 @@ CREATE TABLE IF NOT EXISTS GovernanceRatifications (
 );
 ```
 
-| 列                     | 型                            | 理由                                                                                      |
-| ---------------------- | ----------------------------- | ----------------------------------------------------------------------------------------- |
-| `ec_id` UNIQUE         | FK→GovernanceEmergencyChanges | 1緊急変更 = 1追認。重複追認は UNIQUE 制約でブロック → HTTP 409                            |
-| `ratified_by_role`     | TEXT NOT NULL                 | 追認者ロール（監査要件上必須）                                                            |
-| `ratified_at`          | TEXT NOT NULL                 | UTC ISO 8601 ミリ秒固定（to_utc_millis 利用）                                             |
-| `ratification_comment` | TEXT NULL                     | 追認理由・補足。NULL 可（role 記録があれば最低限の監査は成立）                            |
+| 列                     | 型                            | 理由                                                                                     |
+| ---------------------- | ----------------------------- | ---------------------------------------------------------------------------------------- |
+| `ec_id` UNIQUE         | FK→GovernanceEmergencyChanges | 1緊急変更 = 1追認。重複追認は UNIQUE 制約でブロック → HTTP 409                           |
+| `ratified_by_role`     | TEXT NOT NULL                 | 追認者ロール（監査要件上必須）                                                           |
+| `ratified_at`          | TEXT NOT NULL                 | UTC ISO 8601 ミリ秒固定（to_utc_millis 利用）                                            |
+| `ratification_comment` | TEXT NULL                     | 追認理由・補足。NULL 可（role 記録があれば最低限の監査は成立）                           |
 | `related_pr`           | TEXT NULL                     | 計画段階で紐付ける予定 PR/Issue。確定実績は emergency_changes.related_issue_or_pr に記録 |
 
 ### Why
@@ -398,13 +399,13 @@ stateDiagram-v2
 
 `POST /apply` handler は、まず `expected_version` 一致を確認し、通過後に status を分岐する。status 分岐では `applied` / `apply_failed` を先に 409 とし、それ以外の `approved` 以外（`pending` / `rejected`）を 400 とする。
 
-| 操作          | 条件                                      | HTTP |
-| ------------- | ----------------------------------------- | ---- |
-| POST /approve | status が `pending` 以外                  | 409  |
-| POST /apply   | expected_version 不一致（楽観ロック失敗） | 409  |
-| POST /apply   | 既に `applied` / `apply_failed`           | 409  |
+| 操作          | 条件                                                | HTTP |
+| ------------- | --------------------------------------------------- | ---- |
+| POST /approve | status が `pending` 以外                            | 409  |
+| POST /apply   | expected_version 不一致（楽観ロック失敗）           | 409  |
+| POST /apply   | 既に `applied` / `apply_failed`                     | 409  |
 | POST /apply   | status が `approved` 以外（`pending` / `rejected`） | 400  |
-| POST /ratify  | ec_id の ratification レコードが既存      | 409  |
+| POST /ratify  | ec_id の ratification レコードが既存                | 409  |
 
 ### Why
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -78,7 +78,7 @@ Phase 2 以降候補: `notification_dead_lettered`
 ```sql
 CREATE TABLE IF NOT EXISTS GovernanceNotificationOutbox (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    event_id        INTEGER NOT NULL,    -- GovernanceAuditEvents.id（emergency_changed イベントが起点）
+    event_id        INTEGER NOT NULL UNIQUE,    -- GovernanceAuditEvents.id（emergency_changed イベントが起点）
   status          TEXT    NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','sent','failed')),
     retry_count     INTEGER NOT NULL DEFAULT 0,
     next_retry_at   TEXT,               -- NULL = 即時試行可
@@ -94,6 +94,7 @@ CREATE INDEX IF NOT EXISTS idx_notification_outbox_status
 FK の方向:
 
 - `outbox.event_id → GovernanceAuditEvents.id`（起点 audit event への参照）
+- `event_id UNIQUE` により 1 起点イベント = 1 outbox レコードを強制し、`POST /governance/notifications/{event_id}/retry` の対象を一意にする
 - retry 系 audit event（`notification_queued` / `notification_retry_failed` 等）は `target_type='notification', target_id=outbox.id` で論理参照。循環 FK を避ける
 
 #### 論点6: notification status モデル

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,6 +1,148 @@
 # Decision Log
 
-## 2026-05-03: #140 governance schema 基盤 - version 正本、chart_name追加、API配置方針の確定
+## 2026-05-04: `#140` governance schema 基盤 - 論点1〜8 GovernanceAuditEvents / GovernanceNotificationOutbox 確定
+
+日付基準: JST
+
+### Context
+
+Discussion #183 で audit events と notification outbox の最小契約を確定する必要があった。
+前 PR（chore/governance-schema-documentation）で論点1〜9（GovernanceChangeRequests 〜 保管期間）は確定済みであり、
+本エントリはその後続として audit / outbox 層を固定する。
+
+### Decision
+
+#### 論点1: GovernanceAuditEvents 最小列定義
+
+```sql
+CREATE TABLE IF NOT EXISTS GovernanceAuditEvents (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type     TEXT    NOT NULL,
+    actor          TEXT    NOT NULL,
+    actor_role     TEXT    NOT NULL,
+    target_type    TEXT    NOT NULL,   -- 'change_request' | 'emergency_change' | 'notification'
+    target_id      INTEGER NOT NULL,   -- 対応テーブルの id
+    occurred_at    TEXT    NOT NULL,
+    before_json    TEXT,               -- 変更前 snapshot（変更系のみ）
+    after_json     TEXT,               -- 変更後 snapshot（変更系のみ）
+    correlation_id TEXT               -- 同一フロー内イベントを束ねる任意ID（NULL可）
+);
+CREATE INDEX IF NOT EXISTS idx_audit_events_type_time
+    ON GovernanceAuditEvents(event_type, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_audit_events_target
+    ON GovernanceAuditEvents(target_type, target_id);
+```
+
+- `source` 列は `event_type` から自明なため不要
+- `correlation_id` は NULL 許可。将来のトレース用に列として確保
+
+#### 論点2: event_type 一覧（Phase 1 確定）
+
+| event_type | 発生タイミング | before/after |
+|---|---|---|
+| `change_requested` | change_request 作成時 | after のみ（申請内容） |
+| `change_request_approved` | approve 完了時 | なし |
+| `change_request_rejected` | reject 時 | なし |
+| `change_request_applied` | apply 成功時 | 閾値の before/after（フル snapshot） |
+| `change_request_apply_failed` | apply 失敗時 | after に error_code/message |
+| `emergency_changed` | 緊急変更完了時 | 閾値の before/after（フル snapshot） |
+| `emergency_ratified` | 追認完了時 | なし |
+| `notification_queued` | outbox INSERT 時 | なし |
+| `notification_sent` | 送信成功時 | なし |
+| `notification_retry_succeeded` | retry 成功時 | なし |
+| `notification_retry_failed` | retry 上限到達時 | なし |
+
+Phase 2 以降候補: `notification_dead_lettered`
+
+#### 論点3: before/after の差分形式
+
+| event_type | before_json | after_json |
+|---|---|---|
+| `change_request_applied` | 変更前全フィールド snapshot | 変更後全フィールド snapshot |
+| `emergency_changed` | 変更前全フィールド snapshot | 変更後全フィールド snapshot |
+| `change_requested` | null | 申請内容（delta のみで可） |
+| それ以外 | null | null |
+
+- changed fields のみでは before が何だったか復元できないため、apply と緊急変更は必ず全フィールド snapshot
+- no-op 更新（値に差分なし）の場合: audit event も ChartsHistory も残さない（`#109` 決定済み）
+
+#### 論点4: audit writer の責務境界
+
+- **service 層からの明示呼び出し**に統一
+- repository 内部に audit writer を埋め込まない（repository は単一テーブルの CRUD 責務に限定）
+- `AuditEventWriter.write(con, event_type, actor, actor_role, target_type, target_id, occurred_at, before_json=None, after_json=None, correlation_id=None)` の 1 メソッドのみ
+- `occurred_at` の正規化（`datetime_util.to_utc_millis()`）は呼び出し側（service 層）の責務。writer 内では正規化しない
+
+#### 論点5: GovernanceNotificationOutbox 最小列定義
+
+```sql
+CREATE TABLE IF NOT EXISTS GovernanceNotificationOutbox (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id        INTEGER NOT NULL,    -- GovernanceAuditEvents.id（emergency_changed イベントが起点）
+    status          TEXT    NOT NULL DEFAULT 'pending',
+    retry_count     INTEGER NOT NULL DEFAULT 0,
+    next_retry_at   TEXT,               -- NULL = 即時試行可
+    last_attempt_at TEXT,
+    last_error      TEXT,
+    delivered_at    TEXT,               -- 成功時のみ設定
+    FOREIGN KEY (event_id) REFERENCES GovernanceAuditEvents (id)
+);
+CREATE INDEX IF NOT EXISTS idx_notification_outbox_status
+    ON GovernanceNotificationOutbox(status, next_retry_at);
+```
+
+FK の方向:
+- `outbox.event_id → GovernanceAuditEvents.id`（起点 audit event への参照）
+- retry 系 audit event（`notification_queued` / `notification_retry_failed` 等）は `target_type='notification', target_id=outbox.id` で論理参照。循環 FK を避ける
+
+#### 論点6: notification status モデル
+
+`sending` を省略した真の3状態を採用する。
+
+```
+pending → sent（ターミナル）
+        ↘ failed
+failed → sent（retry 成功、ターミナル）
+       → failed（retry 上限到達、ターミナル）
+```
+
+- SQLite ローカル・単一 FastAPI プロセス・明示 retry 呼び出し方式のため並行送信シナリオがない
+- `sending` を持つと「クラッシュで永続 sending」スタック問題が生じ回収ロジックが必要になる
+- 二重送信防止は `UPDATE SET status='sent' WHERE status IN ('pending','failed') AND retry_count < 3` をトランザクション内で実行することで担保
+
+#### 論点7: retry の契約
+
+| 項目 | 方針 |
+|---|---|
+| retry 対象 | `status = 'failed'` のみ |
+| retry_count 上限 | 3 回（`#102` write 系 attempts 上限に統一） |
+| next_retry_at 算出 | 指数バックオフ（1分, 5分, 30分）。`datetime_util.to_utc_millis()` で記録 |
+| 上限到達後 | `status = 'failed'` のまま `next_retry_at = NULL` で取得対象から外れる |
+| 最終失敗の監査連携 | 上限到達時に `notification_retry_failed` audit event を INSERT |
+| retry API に `sent` / `pending` を指定した場合 | 400（retry 対象外） |
+
+retry は `POST /governance/notifications/{event_id}/retry` の明示呼び出し方式（バックグラウンドポーリングは今回対象外）。
+
+#### 論点8: apply 時にも outbox を使うか
+
+Phase 1 は**緊急変更通知のみ** outbox 対象とする。
+通常 apply（承認フロー経由）は UI または ops が確認しているため追加通知は不要。
+将来的に通常 apply 通知が必要になった場合は `target_type` を使って自然に拡張できる設計になっている。
+
+### Why
+
+- `source` 列省略: `event_type` から一意に判断できるため過剰
+- `sending` 状態省略: ローカル SQLite 単一プロセスでは並行送信が起きないため、スタック状態を作るリスクの方が大きい
+- FK 方向（outbox → audit）: audit event を起点とする参照方向が自然。循環参照を避け、retry 系イベントは論理参照で対応
+- audit writer を service 層に置く: repository が別テーブルを書く責務を持つと境界が曖昧になる。service 層の 1 TX ブロック内で writer を呼ぶことで同一 transaction を保証できる
+
+### Consequence
+
+- `GovernanceAuditEvents` と `GovernanceNotificationOutbox` の CREATE TABLE を `db_api/db.py` の初期化処理に追加
+- `AuditEventWriter` クラスを `db_api/` 配下に新規作成（実装 PR 別途）
+- `#144`（GET audit-events / POST notifications retry）の endpoint 契約はこのスキーマを前提に定義
+
+## 2026-05-03: `#140` governance schema 基盤 - version 正本、chart_name追加、API配置方針の確定
 
 日付基準: JST
 


### PR DESCRIPTION
## 概要

Discussion #183 の全論点（論点1-8）の決定内容を `docs/decision-log.md` に記録する。

refs #140

## 変更内容

### docs/decision-log.md
- 論点1: GovernanceAuditEvents 最小列定義（source 不要、correlation_id NULL 可）
- 論点2: event_type 一覧 11 種確定（change_request_rejected を Phase 1 に含む）
- 論点3: before/after の差分形式（apply/緊急変更はフル snapshot、no-op は残さない）
- 論点4: audit writer は service 層から明示呼び出し、正規化は呼び出し側責務
- 論点5: GovernanceNotificationOutbox 最小列定義、FK 方向（outbox→audit 起点参照）
- 論点6: notification status は真の3状態（pending/sent/failed）、sending 省略
- 論点7: retry 上限3回・指数バックオフ（1/5/30分）・上限到達時に notification_retry_failed audit event
- 論点8: Phase 1 は緊急変更通知のみ outbox 対象

## 未対応（別 PR 予定）

- [ ] GovernanceAuditEvents / GovernanceNotificationOutbox の CREATE TABLE を db_api/db.py に追加（実装 PR）
- [ ] AuditEventWriter クラスの実装（実装 PR）
- [ ] #144 GET audit-events / POST notifications retry endpoint 実装

## レビュー観点

- decision-log エントリの決定内容と Discussion #183 の合意内容の整合
- event_type 一覧の網羅性（Phase 1 スコープ内）
- FK 方向と循環参照回避方針の妥当性


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 概要

Discussion #183 の決定（論点1–8）を docs/decision-log.md に記録。GovernanceAuditEvents / GovernanceNotificationOutbox の最小契約を確定し、Phase 1 を緊急変更通知のみに限定。CREATE TABLE 追加・AuditEventWriter 実装・#144 のエンドポイントは別PRで対応。outbox の event_id を一意化してリトライ決定性を確保する変更を追加。

## 記載内容（要点）

- 論点1: GovernanceAuditEvents の最小列定義（source は不要、correlation_id は NULL 可）。  
- 論点2: event_type を11種で確定（change_request_rejected を Phase 1 に含む）。  
- 論点3: before/after は差分形式。apply/緊急変更はフル snapshot、no-op の場合はイベントを残さない。  
- 論点4: Audit writer は service 層から明示呼び出し。occurred_at の正規化は呼び出し側の責務。  
- 論点5: GovernanceNotificationOutbox の最小列定義と FK 方針（outbox → audit を起点に参照し、循環参照回避）。UNIQUE な event_id を outbox に課すことでリトライ時の決定性を確保。  
- 論点6: notification status は真の3状態（pending / sent / failed）、sending 状態は省略。二重送信防止の更新ロジックを明記（pending/failed の条件付き更新）。  
- 論点7: retry は上限3回・指数バックオフ（1 / 5 / 30 分）。上限到達時に notification_retry_failed audit event を出す。retry は failed のみに適用。  
- 論点8: Phase 1 は緊急変更通知のみ outbox 対象。

未対応（別PR予定）
- GovernanceAuditEvents / GovernanceNotificationOutbox の CREATE TABLE を db_api/db.py に追加  
- AuditEventWriter クラスの実装  
- #144 の GET audit-events / POST notifications retry エンドポイント実装

## レビュー観点（要求確認）

- decision-log と Discussion #183 の文言・意図の整合性  
- Phase 1 スコープ内での event_type 網羅性（11種が妥当か）  
- FK 方向と循環参照回避方針の妥当性と実装上の影響

## テストギャップ・リスク

- occurred_at の正規化を呼び出し側に委ねるため、service 層で統一的な実装・テストが不足すると時刻整合性が崩れるリスク。  
- notification retry の二重送信防止（UPDATE WHERE status IN ('pending','failed') 等）のトランザクション的正確性が未検証。並行実行時の競合リスク。  
- no-op 判定（差分なしでイベントを残さない）の判定一貫性が apply/緊急変更フローで保証されるか未検証。  
- FK 方針が論理参照と物理 FK を混在させる場合、実装時に逆向きFKや循環依存が混入するリスク。  
- Phase 1 制限（緊急変更のみ）を将来拡張する際のマイグレーション・テスト不足。  
- 指数バックオフ（1 / 5 / 30 分）がデータベースや運用環境のタイミングやロック戦略と相互作用する可能性の検証不足。  
- notification_retry_failed 発火の境界（retry_count >= 3）とその発行トランザクション境界が未定義。  
- outbox.event_id の UNIQUE 制約に伴う既存データ/インサートロジックの整合性・エラー処理（重複時の取り扱い）を検証する必要。

## 推奨フォローアップ（短め）

- AuditEventWriter の実装仕様を早急に作成（occurred_at 正規化方法・単体/統合テスト含む）。  
- retry/二重送信防止の統合テスト（並列実行・DB特性別）を追加。  
- CREATE TABLE とマイグレーションを別PRで実装し、FK・インデックス・UNIQUE 制約の影響を明示的に検証する。  
- outbox.event_id の生成/重複ハンドリング方針とそれを検証するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->