### PR TITLE
feat(#188): governance schema init, repository, AuditEventWriter

### DIFF
--- a/src/portfolio_fdc/db_api/audit_event_writer.py
+++ b/src/portfolio_fdc/db_api/audit_event_writer.py
@@ -1,0 +1,48 @@
+"""GovernanceAuditEvents への書き込みを担う AuditEventWriter。"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+class AuditEventWriter:
+    """GovernanceAuditEvents テーブルへの監査イベント書き込みを担う。
+
+    occurred_at の正規化は呼び出し側（service 層）の責務。
+    writer 内では正規化を行わない。
+    """
+
+    def write(
+        self,
+        con: sqlite3.Connection,
+        event_type: str,
+        actor: str,
+        actor_role: str,
+        target_type: str,
+        target_id: int,
+        occurred_at: str,
+        before_json: str | None = None,
+        after_json: str | None = None,
+        correlation_id: str | None = None,
+    ) -> int:
+        """監査イベントを INSERT し、生成された id を返す。"""
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceAuditEvents
+                (event_type, actor, actor_role, target_type, target_id,
+                 occurred_at, before_json, after_json, correlation_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_type,
+                actor,
+                actor_role,
+                target_type,
+                target_id,
+                occurred_at,
+                before_json,
+                after_json,
+                correlation_id,
+            ),
+        )
+        return cur.lastrowid  # type: ignore[return-value]

--- a/src/portfolio_fdc/db_api/db.py
+++ b/src/portfolio_fdc/db_api/db.py
@@ -343,6 +343,144 @@ def _init_schema(db_path: Path) -> None:
             """
         )
 
+        # --- ChartsV2 migration: version and chart_name columns ---------------
+        _add_column_if_missing(con, "ChartsV2", "version INTEGER NOT NULL DEFAULT 1")
+        _add_column_if_missing(con, "ChartsV2", "chart_name TEXT")
+
+        # --- Governance tables ------------------------------------------------
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS GovernanceChangeRequests (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                chart_id         INTEGER NOT NULL,
+                status           TEXT    NOT NULL DEFAULT 'pending'
+                                         CHECK (status IN (
+                                             'pending','approved','applied',
+                                             'apply_failed','rejected'
+                                         )),
+                proposed_by      TEXT    NOT NULL,
+                proposed_at      TEXT    NOT NULL,
+                change_payload   TEXT    NOT NULL,
+                expected_version INTEGER NOT NULL,
+                idempotency_key  TEXT    NOT NULL,
+                FOREIGN KEY (chart_id) REFERENCES ChartsV2 (id)
+            );
+            """
+        )
+        con.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_change_requests_idempotency
+            ON GovernanceChangeRequests (idempotency_key);
+            """
+        )
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS GovernanceApprovals (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                request_id       INTEGER NOT NULL UNIQUE,
+                approved_by      TEXT    NOT NULL,
+                approved_by_role TEXT    NOT NULL,
+                approved_at      TEXT    NOT NULL,
+                comment          TEXT,
+                FOREIGN KEY (request_id) REFERENCES GovernanceChangeRequests (id)
+            );
+            """
+        )
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS GovernanceApplyResults (
+                id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                request_id        INTEGER NOT NULL UNIQUE,
+                applied_at        TEXT    NOT NULL,
+                success           INTEGER NOT NULL CHECK (success IN (0, 1)),
+                resulting_version INTEGER,
+                error_code        TEXT,
+                error_message     TEXT,
+                FOREIGN KEY (request_id) REFERENCES GovernanceChangeRequests (id)
+            );
+            """
+        )
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS GovernanceEmergencyChanges (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                chart_id            INTEGER NOT NULL,
+                changed_by          TEXT    NOT NULL,
+                changed_by_role     TEXT    NOT NULL,
+                changed_at          TEXT    NOT NULL,
+                reason              TEXT    NOT NULL,
+                before_json         TEXT    NOT NULL,
+                after_json          TEXT    NOT NULL,
+                resulting_version   INTEGER NOT NULL,
+                related_issue_or_pr TEXT,
+                FOREIGN KEY (chart_id) REFERENCES ChartsV2 (id)
+            );
+            """
+        )
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS GovernanceRatifications (
+                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+                ec_id                INTEGER NOT NULL UNIQUE,
+                ratified_by_role     TEXT    NOT NULL,
+                ratified_at          TEXT    NOT NULL,
+                ratification_comment TEXT,
+                related_pr           TEXT,
+                FOREIGN KEY (ec_id) REFERENCES GovernanceEmergencyChanges (id)
+            );
+            """
+        )
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS GovernanceAuditEvents (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type     TEXT    NOT NULL,
+                actor          TEXT    NOT NULL,
+                actor_role     TEXT    NOT NULL,
+                target_type    TEXT    NOT NULL,
+                target_id      INTEGER NOT NULL,
+                occurred_at    TEXT    NOT NULL,
+                before_json    TEXT,
+                after_json     TEXT,
+                correlation_id TEXT
+            );
+            """
+        )
+        con.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_audit_events_type_time
+            ON GovernanceAuditEvents (event_type, occurred_at);
+            """
+        )
+        con.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_audit_events_target
+            ON GovernanceAuditEvents (target_type, target_id);
+            """
+        )
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS GovernanceNotificationOutbox (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id        INTEGER NOT NULL UNIQUE,
+                status          TEXT    NOT NULL DEFAULT 'pending'
+                                        CHECK (status IN ('pending','sent','failed')),
+                retry_count     INTEGER NOT NULL DEFAULT 0,
+                next_retry_at   TEXT,
+                last_attempt_at TEXT,
+                last_error      TEXT,
+                delivered_at    TEXT,
+                FOREIGN KEY (event_id) REFERENCES GovernanceAuditEvents (id)
+            );
+            """
+        )
+        con.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_notification_outbox_status
+            ON GovernanceNotificationOutbox (status, next_retry_at);
+            """
+        )
+
         row = con.execute(
             "SELECT chart_set_id FROM ChartSet ORDER BY chart_set_id ASC LIMIT 1"
         ).fetchone()

--- a/src/portfolio_fdc/db_api/governance_repository.py
+++ b/src/portfolio_fdc/db_api/governance_repository.py
@@ -1,0 +1,334 @@
+"""Governance テーブル群の repository 層。"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+class GovernanceNotFoundError(LookupError):
+    """要求されたレコードが存在しない場合に送出する。"""
+
+
+# ---------------------------------------------------------------------------
+# GovernanceChangeRequests
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChangeRequestRow:
+    """GovernanceChangeRequests の 1 行を表す DTO。"""
+
+    id: int
+    chart_id: int
+    status: str
+    proposed_by: str
+    proposed_at: str
+    change_payload: str
+    expected_version: int
+    idempotency_key: str
+
+
+class GovernanceChangeRequestRepository:
+    """GovernanceChangeRequests テーブルへの CRUD 操作を提供する。"""
+
+    def create(
+        self,
+        con: sqlite3.Connection,
+        chart_id: int,
+        proposed_by: str,
+        proposed_at: str,
+        change_payload: str,
+        expected_version: int,
+        idempotency_key: str,
+    ) -> int:
+        """申請を INSERT し、生成された id を返す。"""
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceChangeRequests
+                (chart_id, proposed_by, proposed_at, change_payload,
+                 expected_version, idempotency_key)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (chart_id, proposed_by, proposed_at, change_payload, expected_version, idempotency_key),
+        )
+        return cur.lastrowid  # type: ignore[return-value]
+
+    def find_by_id(self, con: sqlite3.Connection, record_id: int) -> ChangeRequestRow:
+        """指定 id の申請を返す。存在しない場合は GovernanceNotFoundError を送出する。"""
+        row = con.execute(
+            """
+            SELECT id, chart_id, status, proposed_by, proposed_at,
+                   change_payload, expected_version, idempotency_key
+            FROM GovernanceChangeRequests
+            WHERE id = ?
+            """,
+            (record_id,),
+        ).fetchone()
+        if row is None:
+            raise GovernanceNotFoundError(f"GovernanceChangeRequests id={record_id} not found")
+        return ChangeRequestRow(*row)
+
+    def update_status(
+        self,
+        con: sqlite3.Connection,
+        record_id: int,
+        new_status: str,
+    ) -> None:
+        """status 列のみを更新する。対象行が存在しない場合は GovernanceNotFoundError を送出する。"""
+        cur = con.execute(
+            "UPDATE GovernanceChangeRequests SET status = ? WHERE id = ?",
+            (new_status, record_id),
+        )
+        if cur.rowcount == 0:
+            raise GovernanceNotFoundError(f"GovernanceChangeRequests id={record_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# GovernanceApprovals
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ApprovalRow:
+    """GovernanceApprovals の 1 行を表す DTO。"""
+
+    id: int
+    request_id: int
+    approved_by: str
+    approved_by_role: str
+    approved_at: str
+    comment: str | None
+
+
+class GovernanceApprovalsRepository:
+    """GovernanceApprovals テーブルへの操作を提供する。"""
+
+    def create(
+        self,
+        con: sqlite3.Connection,
+        request_id: int,
+        approved_by: str,
+        approved_by_role: str,
+        approved_at: str,
+        comment: str | None = None,
+    ) -> int:
+        """承認レコードを INSERT し、生成された id を返す。"""
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceApprovals
+                (request_id, approved_by, approved_by_role, approved_at, comment)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (request_id, approved_by, approved_by_role, approved_at, comment),
+        )
+        return cur.lastrowid  # type: ignore[return-value]
+
+    def find_by_request_id(self, con: sqlite3.Connection, request_id: int) -> ApprovalRow:
+        """request_id で承認レコードを返す。存在しない場合は GovernanceNotFoundError を送出する。"""
+        row = con.execute(
+            """
+            SELECT id, request_id, approved_by, approved_by_role, approved_at, comment
+            FROM GovernanceApprovals
+            WHERE request_id = ?
+            """,
+            (request_id,),
+        ).fetchone()
+        if row is None:
+            raise GovernanceNotFoundError(f"GovernanceApprovals request_id={request_id} not found")
+        return ApprovalRow(*row)
+
+
+# ---------------------------------------------------------------------------
+# GovernanceApplyResults
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ApplyResultRow:
+    """GovernanceApplyResults の 1 行を表す DTO。"""
+
+    id: int
+    request_id: int
+    applied_at: str
+    success: int
+    resulting_version: int | None
+    error_code: str | None
+    error_message: str | None
+
+
+class GovernanceApplyResultsRepository:
+    """GovernanceApplyResults テーブルへの操作を提供する。"""
+
+    def create(
+        self,
+        con: sqlite3.Connection,
+        request_id: int,
+        applied_at: str,
+        success: int,
+        resulting_version: int | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> int:
+        """適用結果を INSERT し、生成された id を返す。"""
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceApplyResults
+                (request_id, applied_at, success, resulting_version,
+                 error_code, error_message)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (request_id, applied_at, success, resulting_version, error_code, error_message),
+        )
+        return cur.lastrowid  # type: ignore[return-value]
+
+    def find_by_request_id(self, con: sqlite3.Connection, request_id: int) -> ApplyResultRow:
+        """request_id で適用結果を返す。存在しない場合は GovernanceNotFoundError を送出する。"""
+        row = con.execute(
+            """
+            SELECT id, request_id, applied_at, success, resulting_version,
+                   error_code, error_message
+            FROM GovernanceApplyResults
+            WHERE request_id = ?
+            """,
+            (request_id,),
+        ).fetchone()
+        if row is None:
+            raise GovernanceNotFoundError(
+                f"GovernanceApplyResults request_id={request_id} not found"
+            )
+        return ApplyResultRow(*row)
+
+
+# ---------------------------------------------------------------------------
+# GovernanceEmergencyChanges
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmergencyChangeRow:
+    """GovernanceEmergencyChanges の 1 行を表す DTO。"""
+
+    id: int
+    chart_id: int
+    changed_by: str
+    changed_by_role: str
+    changed_at: str
+    reason: str
+    before_json: str
+    after_json: str
+    resulting_version: int
+    related_issue_or_pr: str | None
+
+
+class GovernanceEmergencyChangesRepository:
+    """GovernanceEmergencyChanges テーブルへの操作を提供する。"""
+
+    def create(
+        self,
+        con: sqlite3.Connection,
+        chart_id: int,
+        changed_by: str,
+        changed_by_role: str,
+        changed_at: str,
+        reason: str,
+        before_json: str,
+        after_json: str,
+        resulting_version: int,
+        related_issue_or_pr: str | None = None,
+    ) -> int:
+        """緊急変更レコードを INSERT し、生成された id を返す。"""
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceEmergencyChanges
+                (chart_id, changed_by, changed_by_role, changed_at, reason,
+                 before_json, after_json, resulting_version, related_issue_or_pr)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chart_id,
+                changed_by,
+                changed_by_role,
+                changed_at,
+                reason,
+                before_json,
+                after_json,
+                resulting_version,
+                related_issue_or_pr,
+            ),
+        )
+        return cur.lastrowid  # type: ignore[return-value]
+
+    def find_by_id(self, con: sqlite3.Connection, record_id: int) -> EmergencyChangeRow:
+        """指定 id の緊急変更レコードを返す。
+
+        存在しない場合は GovernanceNotFoundError を送出する。
+        """
+        row = con.execute(
+            """
+            SELECT id, chart_id, changed_by, changed_by_role, changed_at, reason,
+                   before_json, after_json, resulting_version, related_issue_or_pr
+            FROM GovernanceEmergencyChanges
+            WHERE id = ?
+            """,
+            (record_id,),
+        ).fetchone()
+        if row is None:
+            raise GovernanceNotFoundError(f"GovernanceEmergencyChanges id={record_id} not found")
+        return EmergencyChangeRow(*row)
+
+
+# ---------------------------------------------------------------------------
+# GovernanceRatifications
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RatificationRow:
+    """GovernanceRatifications の 1 行を表す DTO。"""
+
+    id: int
+    ec_id: int
+    ratified_by_role: str
+    ratified_at: str
+    ratification_comment: str | None
+    related_pr: str | None
+
+
+class GovernanceRatificationsRepository:
+    """GovernanceRatifications テーブルへの操作を提供する。"""
+
+    def create(
+        self,
+        con: sqlite3.Connection,
+        ec_id: int,
+        ratified_by_role: str,
+        ratified_at: str,
+        ratification_comment: str | None = None,
+        related_pr: str | None = None,
+    ) -> int:
+        """追認レコードを INSERT し、生成された id を返す。"""
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceRatifications
+                (ec_id, ratified_by_role, ratified_at, ratification_comment, related_pr)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (ec_id, ratified_by_role, ratified_at, ratification_comment, related_pr),
+        )
+        return cur.lastrowid  # type: ignore[return-value]
+
+    def find_by_ec_id(self, con: sqlite3.Connection, ec_id: int) -> RatificationRow:
+        """ec_id で追認レコードを返す。存在しない場合は GovernanceNotFoundError を送出する。"""
+        row = con.execute(
+            """
+            SELECT id, ec_id, ratified_by_role, ratified_at,
+                   ratification_comment, related_pr
+            FROM GovernanceRatifications
+            WHERE ec_id = ?
+            """,
+            (ec_id,),
+        ).fetchone()
+        if row is None:
+            raise GovernanceNotFoundError(f"GovernanceRatifications ec_id={ec_id} not found")
+        return RatificationRow(*row)

--- a/tests/db_api/test_governance_repository.py
+++ b/tests/db_api/test_governance_repository.py
@@ -1,0 +1,515 @@
+"""governance_repository と AuditEventWriter のユニットテスト。"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from portfolio_fdc.db_api.audit_event_writer import AuditEventWriter
+from portfolio_fdc.db_api.db import _init_schema
+from portfolio_fdc.db_api.governance_repository import (
+    GovernanceApplyResultsRepository,
+    GovernanceApprovalsRepository,
+    GovernanceChangeRequestRepository,
+    GovernanceEmergencyChangesRepository,
+    GovernanceNotFoundError,
+    GovernanceRatificationsRepository,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "test_governance.db"
+    _init_schema(path)
+    return path
+
+
+@pytest.fixture()
+def con(db_path: Path) -> Generator[sqlite3.Connection, None, None]:
+    c = sqlite3.connect(db_path.as_posix())
+    c.execute("PRAGMA foreign_keys=ON;")
+    # テスト用の ChartsV2 ダミー行を挿入しておく
+    c.execute(
+        """
+        INSERT INTO ChartsV2
+            (chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+             step_no, feature_type, updated_at)
+        VALUES (1, 'T01', 'C01', 'R01', 'param1', 1, 'mean', '2026-01-01T00:00:00.000Z')
+        """
+    )
+    c.commit()
+    yield c
+    c.close()
+
+
+def _chart_id(con: sqlite3.Connection) -> int:
+    return con.execute("SELECT id FROM ChartsV2 LIMIT 1").fetchone()[0]
+
+
+# ---------------------------------------------------------------------------
+# schema 冪等性テスト
+# ---------------------------------------------------------------------------
+
+
+def test_init_schema_is_idempotent(tmp_path: Path) -> None:
+    """_init_schema を2回呼んでもエラーなし。"""
+    path = tmp_path / "idempotent.db"
+    _init_schema(path)
+    _init_schema(path)  # 2回目もエラーなし
+
+
+def test_init_schema_does_not_alter_existing_columns(db_path: Path) -> None:
+    """governance テーブル追加が ChartsV2 の既存列を壊さないこと。"""
+    con = sqlite3.connect(db_path.as_posix())
+    cols = {row[1] for row in con.execute("PRAGMA table_info(ChartsV2)").fetchall()}
+    con.close()
+    # 既存列が揃っていること
+    for col in (
+        "id",
+        "chart_set_id",
+        "tool_id",
+        "chamber_id",
+        "recipe_id",
+        "parameter",
+        "step_no",
+        "feature_type",
+        "updated_at",
+    ):
+        assert col in cols, f"既存列 {col!r} が消えている"
+    # 新規追加列が存在すること
+    assert "version" in cols
+    assert "chart_name" in cols
+
+
+# ---------------------------------------------------------------------------
+# GovernanceChangeRequestRepository
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceChangeRequestRepository:
+    repo = GovernanceChangeRequestRepository()
+
+    def test_create_and_find_by_id(self, con: sqlite3.Connection) -> None:
+        cid = _chart_id(con)
+        new_id = self.repo.create(
+            con,
+            chart_id=cid,
+            proposed_by="alice",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            change_payload='{"ucl": 1.5}',
+            expected_version=1,
+            idempotency_key="key-001",
+        )
+        con.commit()
+
+        row = self.repo.find_by_id(con, new_id)
+        assert row.id == new_id
+        assert row.chart_id == cid
+        assert row.status == "pending"
+        assert row.proposed_by == "alice"
+        assert row.idempotency_key == "key-001"
+
+    def test_update_status(self, con: sqlite3.Connection) -> None:
+        cid = _chart_id(con)
+        new_id = self.repo.create(
+            con,
+            chart_id=cid,
+            proposed_by="bob",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            change_payload="{}",
+            expected_version=1,
+            idempotency_key="key-002",
+        )
+        con.commit()
+
+        self.repo.update_status(con, new_id, "approved")
+        con.commit()
+
+        row = self.repo.find_by_id(con, new_id)
+        assert row.status == "approved"
+
+    def test_find_by_id_not_found(self, con: sqlite3.Connection) -> None:
+        with pytest.raises(GovernanceNotFoundError):
+            self.repo.find_by_id(con, 99999)
+
+    def test_update_status_not_found(self, con: sqlite3.Connection) -> None:
+        with pytest.raises(GovernanceNotFoundError):
+            self.repo.update_status(con, 99999, "approved")
+
+    def test_duplicate_idempotency_key_raises(self, con: sqlite3.Connection) -> None:
+        cid = _chart_id(con)
+        self.repo.create(
+            con,
+            chart_id=cid,
+            proposed_by="alice",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            change_payload="{}",
+            expected_version=1,
+            idempotency_key="dup-key",
+        )
+        con.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            self.repo.create(
+                con,
+                chart_id=cid,
+                proposed_by="alice",
+                proposed_at="2026-05-01T00:01:00.000Z",
+                change_payload="{}",
+                expected_version=1,
+                idempotency_key="dup-key",
+            )
+
+
+# ---------------------------------------------------------------------------
+# GovernanceApprovalsRepository
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceApprovalsRepository:
+    req_repo = GovernanceChangeRequestRepository()
+    repo = GovernanceApprovalsRepository()
+
+    def _make_request(self, con: sqlite3.Connection, key: str = "key-a") -> int:
+        cid = _chart_id(con)
+        rid = self.req_repo.create(
+            con,
+            chart_id=cid,
+            proposed_by="alice",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            change_payload="{}",
+            expected_version=1,
+            idempotency_key=key,
+        )
+        con.commit()
+        return rid
+
+    def test_create_and_find_by_request_id(self, con: sqlite3.Connection) -> None:
+        rid = self._make_request(con)
+        aid = self.repo.create(
+            con,
+            request_id=rid,
+            approved_by="manager",
+            approved_by_role="approver",
+            approved_at="2026-05-02T00:00:00.000Z",
+            comment="LGTM",
+        )
+        con.commit()
+
+        row = self.repo.find_by_request_id(con, rid)
+        assert row.id == aid
+        assert row.request_id == rid
+        assert row.approved_by == "manager"
+        assert row.approved_by_role == "approver"
+        assert row.comment == "LGTM"
+
+    def test_find_not_found(self, con: sqlite3.Connection) -> None:
+        with pytest.raises(GovernanceNotFoundError):
+            self.repo.find_by_request_id(con, 99999)
+
+    def test_duplicate_approval_raises(self, con: sqlite3.Connection) -> None:
+        rid = self._make_request(con, key="key-dup-a")
+        self.repo.create(
+            con,
+            request_id=rid,
+            approved_by="mgr1",
+            approved_by_role="approver",
+            approved_at="2026-05-02T00:00:00.000Z",
+        )
+        con.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            self.repo.create(
+                con,
+                request_id=rid,
+                approved_by="mgr2",
+                approved_by_role="approver",
+                approved_at="2026-05-02T01:00:00.000Z",
+            )
+
+
+# ---------------------------------------------------------------------------
+# GovernanceApplyResultsRepository
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceApplyResultsRepository:
+    req_repo = GovernanceChangeRequestRepository()
+    repo = GovernanceApplyResultsRepository()
+
+    def _make_request(self, con: sqlite3.Connection, key: str = "key-b") -> int:
+        cid = _chart_id(con)
+        rid = self.req_repo.create(
+            con,
+            chart_id=cid,
+            proposed_by="alice",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            change_payload="{}",
+            expected_version=1,
+            idempotency_key=key,
+        )
+        con.commit()
+        return rid
+
+    def test_create_success_and_find(self, con: sqlite3.Connection) -> None:
+        rid = self._make_request(con)
+        result_id = self.repo.create(
+            con,
+            request_id=rid,
+            applied_at="2026-05-03T00:00:00.000Z",
+            success=1,
+            resulting_version=2,
+        )
+        con.commit()
+
+        row = self.repo.find_by_request_id(con, rid)
+        assert row.id == result_id
+        assert row.success == 1
+        assert row.resulting_version == 2
+        assert row.error_code is None
+
+    def test_create_failure_and_find(self, con: sqlite3.Connection) -> None:
+        rid = self._make_request(con, key="key-b2")
+        self.repo.create(
+            con,
+            request_id=rid,
+            applied_at="2026-05-03T00:00:00.000Z",
+            success=0,
+            error_code="STALE_VERSION",
+            error_message="version mismatch",
+        )
+        con.commit()
+
+        row = self.repo.find_by_request_id(con, rid)
+        assert row.success == 0
+        assert row.resulting_version is None
+        assert row.error_code == "STALE_VERSION"
+
+    def test_find_not_found(self, con: sqlite3.Connection) -> None:
+        with pytest.raises(GovernanceNotFoundError):
+            self.repo.find_by_request_id(con, 99999)
+
+    def test_duplicate_result_raises(self, con: sqlite3.Connection) -> None:
+        rid = self._make_request(con, key="key-dup-b")
+        self.repo.create(
+            con,
+            request_id=rid,
+            applied_at="2026-05-03T00:00:00.000Z",
+            success=1,
+        )
+        con.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            self.repo.create(
+                con,
+                request_id=rid,
+                applied_at="2026-05-03T01:00:00.000Z",
+                success=0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# GovernanceEmergencyChangesRepository
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceEmergencyChangesRepository:
+    repo = GovernanceEmergencyChangesRepository()
+
+    def test_create_and_find_by_id(self, con: sqlite3.Connection) -> None:
+        cid = _chart_id(con)
+        ec_id = self.repo.create(
+            con,
+            chart_id=cid,
+            changed_by="ops-user",
+            changed_by_role="operator",
+            changed_at="2026-05-04T00:00:00.000Z",
+            reason="production incident",
+            before_json='{"ucl": 1.0}',
+            after_json='{"ucl": 1.5}',
+            resulting_version=2,
+        )
+        con.commit()
+
+        row = self.repo.find_by_id(con, ec_id)
+        assert row.id == ec_id
+        assert row.chart_id == cid
+        assert row.changed_by == "ops-user"
+        assert row.reason == "production incident"
+        assert row.related_issue_or_pr is None
+
+    def test_find_not_found(self, con: sqlite3.Connection) -> None:
+        with pytest.raises(GovernanceNotFoundError):
+            self.repo.find_by_id(con, 99999)
+
+
+# ---------------------------------------------------------------------------
+# GovernanceRatificationsRepository
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceRatificationsRepository:
+    ec_repo = GovernanceEmergencyChangesRepository()
+    repo = GovernanceRatificationsRepository()
+
+    def _make_ec(self, con: sqlite3.Connection) -> int:
+        cid = _chart_id(con)
+        ec_id = self.ec_repo.create(
+            con,
+            chart_id=cid,
+            changed_by="ops",
+            changed_by_role="operator",
+            changed_at="2026-05-04T00:00:00.000Z",
+            reason="incident",
+            before_json="{}",
+            after_json="{}",
+            resulting_version=2,
+        )
+        con.commit()
+        return ec_id
+
+    def test_create_and_find_by_ec_id(self, con: sqlite3.Connection) -> None:
+        ec_id = self._make_ec(con)
+        rat_id = self.repo.create(
+            con,
+            ec_id=ec_id,
+            ratified_by_role="manager",
+            ratified_at="2026-05-05T00:00:00.000Z",
+            ratification_comment="approved retrospectively",
+        )
+        con.commit()
+
+        row = self.repo.find_by_ec_id(con, ec_id)
+        assert row.id == rat_id
+        assert row.ec_id == ec_id
+        assert row.ratified_by_role == "manager"
+        assert row.ratification_comment == "approved retrospectively"
+
+    def test_find_not_found(self, con: sqlite3.Connection) -> None:
+        with pytest.raises(GovernanceNotFoundError):
+            self.repo.find_by_ec_id(con, 99999)
+
+    def test_duplicate_ratification_raises(self, con: sqlite3.Connection) -> None:
+        ec_id = self._make_ec(con)
+        self.repo.create(
+            con,
+            ec_id=ec_id,
+            ratified_by_role="manager",
+            ratified_at="2026-05-05T00:00:00.000Z",
+        )
+        con.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            self.repo.create(
+                con,
+                ec_id=ec_id,
+                ratified_by_role="manager2",
+                ratified_at="2026-05-05T01:00:00.000Z",
+            )
+
+
+# ---------------------------------------------------------------------------
+# AuditEventWriter
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEventWriter:
+    writer = AuditEventWriter()
+
+    def test_write_records_all_required_columns(self, con: sqlite3.Connection) -> None:
+        """write() 後、全必須列が記録されること。"""
+        event_id = self.writer.write(
+            con,
+            event_type="change_requested",
+            actor="alice",
+            actor_role="requester",
+            target_type="change_request",
+            target_id=1,
+            occurred_at="2026-05-01T00:00:00.000Z",
+        )
+        con.commit()
+
+        row = con.execute(
+            """
+            SELECT event_type, actor, actor_role, target_type, target_id, occurred_at
+            FROM GovernanceAuditEvents WHERE id = ?
+            """,
+            (event_id,),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "change_requested"
+        assert row[1] == "alice"
+        assert row[2] == "requester"
+        assert row[3] == "change_request"
+        assert row[4] == 1
+        assert row[5] == "2026-05-01T00:00:00.000Z"
+
+    def test_write_before_json_none_stores_null(self, con: sqlite3.Connection) -> None:
+        """before_json=None で呼び出した場合、DB の before_json は NULL。"""
+        event_id = self.writer.write(
+            con,
+            event_type="change_request_approved",
+            actor="mgr",
+            actor_role="approver",
+            target_type="change_request",
+            target_id=1,
+            occurred_at="2026-05-02T00:00:00.000Z",
+            before_json=None,
+        )
+        con.commit()
+
+        row = con.execute(
+            "SELECT before_json, after_json FROM GovernanceAuditEvents WHERE id = ?",
+            (event_id,),
+        ).fetchone()
+        assert row[0] is None
+        assert row[1] is None
+
+    def test_write_with_before_after_json(self, con: sqlite3.Connection) -> None:
+        """before_json / after_json が正しく保存されること。"""
+        event_id = self.writer.write(
+            con,
+            event_type="change_request_applied",
+            actor="system",
+            actor_role="service",
+            target_type="chart",
+            target_id=1,
+            occurred_at="2026-05-03T00:00:00.000Z",
+            before_json='{"ucl": 1.0}',
+            after_json='{"ucl": 1.5}',
+        )
+        con.commit()
+
+        row = con.execute(
+            "SELECT before_json, after_json FROM GovernanceAuditEvents WHERE id = ?",
+            (event_id,),
+        ).fetchone()
+        assert row[0] == '{"ucl": 1.0}'
+        assert row[1] == '{"ucl": 1.5}'
+
+    def test_write_does_not_normalize_occurred_at(self, con: sqlite3.Connection) -> None:
+        """writer は occurred_at を変換せず、渡した値をそのまま保存する。"""
+        raw_ts = "2026-05-01T12:34:56.789Z"
+        event_id = self.writer.write(
+            con,
+            event_type="emergency_changed",
+            actor="ops",
+            actor_role="operator",
+            target_type="chart",
+            target_id=1,
+            occurred_at=raw_ts,
+        )
+        con.commit()
+
+        stored = con.execute(
+            "SELECT occurred_at FROM GovernanceAuditEvents WHERE id = ?",
+            (event_id,),
+        ).fetchone()[0]
+        assert stored == raw_ts


### PR DESCRIPTION
Closes #188

## 変更内容

### `src/portfolio_fdc/db_api/db.py`
- `_init_schema()` に governance 7テーブル初期化を追加
  - `GovernanceChangeRequests` (idempotency_key UNIQUE INDEX)
  - `GovernanceApprovals`
  - `GovernanceApplyResults`
  - `GovernanceEmergencyChanges`
  - `GovernanceRatifications`
  - `GovernanceAuditEvents` (event_type+occurred_at, target_type+target_id インデックス)
  - `GovernanceNotificationOutbox` (status インデックス)
- `ChartsV2` に `version INTEGER NOT NULL DEFAULT 1` / `chart_name TEXT` を migration 追加（`_add_column_if_missing` 使用）

### `src/portfolio_fdc/db_api/governance_repository.py`（新規）
- `GovernanceNotFoundError(LookupError)` 共通例外
- `GovernanceChangeRequestRepository` — create / find_by_id / update_status（status のみ更新可）
- `GovernanceApprovalsRepository` — create / find_by_request_id
- `GovernanceApplyResultsRepository` — create / find_by_request_id
- `GovernanceEmergencyChangesRepository` — create / find_by_id
- `GovernanceRatificationsRepository` — create / find_by_ec_id

### `src/portfolio_fdc/db_api/audit_event_writer.py`（新規）
- `AuditEventWriter.write()` — occurred_at の正規化は呼び出し側責務、writer 内では行わない

### `tests/db_api/test_governance_repository.py`（新規）
- schema 冪等性・既存列非破壊確認
- 各リポジトリの CRUD / NotFound / 重複制約テスト（23件）
- AuditEventWriter: 必須列記録 / NULL / before_after JSON / occurred_at 非正規化確認

## テスト結果
- `pytest tests/db_api/test_governance_repository.py` → 23 passed
- `pytest tests/db_api/` → 154 passed（回帰なし）

## 設計根拠
- decision-log.md 論点10〜12（PR #187 でマージ済み）に準拠
- idempotency_key は不変（update 対象は status のみ）
- 既存 ChartsV2 / ChartsHistory へのデータ影響なし（ADD COLUMN DEFAULT で既存行も整合）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容（要点）

**新規追加ファイル:**
- `audit_event_writer.py`: ガバナンス監査イベントを `GovernanceAuditEvents` テーブルに書き込む `AuditEventWriter` クラス
- `governance_repository.py`: 5つのガバナンステーブル向けリポジトリ層（ChangeRequest、Approval、ApplyResult、EmergencyChange、Ratification）
- `test_governance_repository.py`: 23個の包括的なテスト（CRUD、制約検証、監査イベント）

**既存ファイル修正:**
- `db.py`: 
  - 7つのガバナンステーブルをスキーマ初期化に追加（idempotency_key 一意インデックス、監査イベント用インデックス等）
  - `ChartsV2` に `version` (INTEGER NOT NULL DEFAULT 1) と `chart_name` (TEXT) を追加

## リスク

- **日時フォーマット一貫性**: `occurred_at` の正規化が呼び出し元責務であり、異なるフォーマットで混在する可能性がある
- **既存データへの影響**: `ChartsV2` への列追加は `ADD COLUMN DEFAULT` で安全だが、既存クエリが新列を考慮していない場合の互換性
- **トランザクション管理**: リポジトリメソッド内に明示的なトランザクション制御がなく、複数操作の一貫性が呼び出し元に依存
- **並行実行性**: 競合アクセスやレース条件のテストカバレッジが不足

## テストギャップ

- NotificationOutbox リポジトリ実装なし（設計対象外）
- HTTP エンドポイント統合テストなし
- `occurred_at` フォーマット一貫性の回帰テストなし
- 新規インデックスのパフォーマンステストなし
- トランザクションロールバック シナリオのテストなし
- JSON フィールド（before_json/after_json）の大規模データ エッジケーステストなし
- 複数リポジトリ操作の原子性に関するテストなし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->