### PR TITLE
feat(db_api): #141 POST/GET governance change-requests 実装

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -1,67 +1,69 @@
-## 確定チェックリスト（#140 実装前）
+# #141 Definition of Done
 
-### 📋 テーブル設計・スキーマ
+## POST/GET /governance/change-requests 実装
 
-- [x] **change_requests** 列定義（request_id, chart_id, status, proposed_by, proposed_at, ...）
-- [x] **approvals** 列定義（approval_id, request_id, approved_by, approved_at, comment）
-- [x] **apply_results** 列定義（apply_id, request_id, applied_at, success, error_message）
-- [x] **emergency_changes** 列定義（ec_id, chart_id, changed_by, changed_at, reason, is_ratified）
-- [x] **ratifications** 列定義（ratification_id, ec_id, ratified_by, ratified_at, comment）
-- [x] **audit_events** 列定義（event_id, event_type, target_id, changed_by, changed_at, before_json, after_json）
-- [x] **notification_outbox** 列定義（outbox_id, event_id, status, retry_count, next_retry_at, last_error）
-- [x] 各テーブルの主キー型を確定（UUID / ULID / INTEGER autoincrement）
-- [x] 外部キー制約の有無と `ON DELETE` 挙動を確定
+### 🔧 設計確定（実装前に合意）
 
-### 🔄 状態遷移
+- [x] POST リクエストボディの必須/任意フィールドを確定（`chart_id`, `proposed_by`, `change_payload`, `expected_version`, `idempotency_key`）
+- [x] `change_payload` のバリデーション範囲を確定（A: JSON パース可能性のみ）
+- [x] `idempotency_key` 重複時の HTTP ステータスを確定（409 + B: error envelope）
+- [x] POST 時に `chart_id` の存在確認を行うかどうかを確定（B: POST 時は確認しない）
+- [x] POST レスポンス形式を確定（A: ok/data 形式で固定、data は request_id と status を含む）
+- [x] 初期 `status` 値を確定（`"pending"`）
+- [x] GET フィルタ仕様を確定（`status`, `chart_id`, `from_ts` / `to_ts`、期間対象は `proposed_at` 固定、`proposed_by` は Phase 1 で除外）
+- [x] GET の `limit` / `offset` デフォルト値と上限を確定（`limit`: default 100, max 500 / `offset`: default 0, 上限なし）
+- [x] GET の DB 接続方式を確定（read-only 直接接続、`DBTaskRunner` 経由なし）
+- [x] app 実装での依存注入パターンを確定（POST は `RunnerDep` / GET は read-only 直接接続）
+- [x] GET テスト観点を確定（0件時、`status`/`chart_id`/`from_ts`/`to_ts` フィルタ、`limit`/`offset` 境界）
+- [x] POST 時の監査イベント `event_type` 値を確定（`"change_requested"`）
 
-- [x] change_request の status 一覧（例: `draft` → `approved` → `applied` / `rejected`）
-- [x] 二重 approve の扱い（409 か冪等成功か）
-- [x] 未承認 apply の扱い（400 か 409 か）
-- [x] ratify の重複追認の扱い（409 か冪等成功か）
+### 🗂️ Repository 層
 
-### 🔍 監査イベント契約
+- [x] `GovernanceChangeRequestRepository.list()` メソッドを追加（status / chart_id / from_ts / to_ts / limit / offset でフィルタ）
+- [x] `list()` で 0件時に空リストを返す（例外なし）
 
-- [x] `event_type` 一覧を固定（`change_requested`, `approved`, `applied`, `emergency_changed`, `ratified`, `notified`, `retry_succeeded`, `retry_failed` など）
-- [x] `before_json` / `after_json` の差分形式（changed fields のみ or フル snapshot）
-- [x] audit writer の配置責務（共通 service か repository 内か）
+### 📐 Pydantic スキーマ（`schemas.py`）
 
-### ⏱️ Timestamp 正規化
+- [x] `ChangeRequestIn` — POST リクエストボディモデル追加
+- [x] `ChangeRequestsQuery` — GET クエリパラメータモデル追加（フィルタ + limit/offset）
+- [x] timestamp フィールドは `datetime` 型で受け取り、UTC ISO 8601 ミリ秒に正規化
 
-- [x] 正規化処理の責務先を確定（repository 共通 util か service 層か）
-- [x] マイクロ秒以下の切り捨てを共通関数で一元化することを明文化
+### 🌐 エンドポイント実装（`app.py`）
 
-### 🔧 Migration / 初期化
+- [x] `POST /governance/change-requests` 実装
+  - [x] 正常時: `request_id` と初期 `status` を `{ok: true, data: {...}}` で返す
+  - [x] `idempotency_key` 重複時: 409 を返す
+  - [x] バリデーション不正時: 422 を返す（Pydantic / FastAPI 既存ハンドラで処理）
+  - [x] 申請作成直後に `AuditEventWriter` で監査イベントを記録する
+  - [x] write は `DBTaskRunner` 経由で実行する
+- [x] `GET /governance/change-requests` 実装
+  - [x] status / chart_id / from_ts / to_ts / limit / offset フィルタを受け付ける
+  - [x] 0件時は `{ok: true, data: []}` を返す
+  - [x] read-only のため `DBTaskRunner` 経由なしで直接接続する
 
-- [x] 冪等初期化（`CREATE TABLE IF NOT EXISTS` or migration ツール）の方針確定
-- [x] 既存 DB への適用順（既存テーブルへの影響なし宣言）
-- [x] forward-only 前提の明文化
+### ✅ テスト（`tests/db_api/` に追加）
 
-### 📬 Notification Outbox Retry モデル
+#### POST テスト
 
-- [x] 初期 `status` 値（例: `pending` / `failed` / `sent`）
-- [x] `retry_count` 上限値
-- [x] `next_retry_at` の算出方式（固定間隔 or 指数バックオフ）
-- [x] 最終失敗時の監査イベント連携（`retry_failed` として audit_events に残すか）
+- [x] POST 正常系: 200, レスポンスに `request_id`（int）と `status: "pending"` が含まれる
+- [x] POST envelope 契約: `ok: true`, `data` キーが存在する
+- [x] POST 422: 必須フィールド欠落でバリデーションエラー
+- [x] POST 422: `chart_id` が整数でない場合
+- [x] POST 409: 同一 `idempotency_key` で2回 POST すると 409 が返る
+- [x] POST 監査イベント: POST 成功後に `GovernanceAuditEvents` に 1件追加される
+- [x] POST 監査イベント: `event_type` が `"change_requested"` である
 
-### 🗂️ Repository インターフェース
+#### GET テスト
 
-- [x] 各テーブルの最小 CRUD スコープ（create/read のみか update/delete も含むか）
-- [x] トランザクション境界（apply = ChartsHistory書き込み + audit_event が 1 atomic か）
-
-### ✅ テスト受け入れ条件の具体化
-
-- [ ] schema 初期化の冪等性テスト（2回実行してもエラーなし）
-- [ ] repository 正常 CRUD テスト（最小1件ずつ）
-- [ ] repository 異常系テスト（存在しない ID、制約違反）
-- [ ] audit event の自動必須項目テスト（changed_by / changed_at / before / after が全て記録されること）
-- [x] timestamp 正規化テスト（ミリ秒固定、マイクロ秒切り捨て）
+- [x] GET 正常系: 0件のとき `{ok: true, data: []}` を返す
+- [x] GET envelope 契約: `ok: true`, `data` がリスト型である
+- [x] GET フィルタ `status`: 該当するレコードのみ返る
+- [x] GET フィルタ `chart_id`: 該当するレコードのみ返る
+- [x] GET フィルタ `from_ts` / `to_ts`: 期間外レコードが除外される
+- [x] GET `limit` 境界: `limit=1` のとき最大1件のみ返る
+- [x] GET `offset` 境界: `offset` で先頭 n 件をスキップできる
 
 ### 📄 ドキュメント更新（同一 PR で必須）
 
-- [x] db-api-endpoints.md の governance endpoint tracking 更新
-- [x] decision-log.md にスキーマ/状態遷移確定を記録
-- [x] 必要なら architecture.md の db_api 責務記述を補完
-
----
-
-使い方: チェックが全部入った状態を Issue #140 の DoD に追加し、未確定の行は実装 PR を開く前に Discussion か Issue コメントで方針を決める、という流れが最もシンプルです。
+- [x] `docs/db-api-endpoints.md`: `POST /governance/change-requests` と `GET /governance/change-requests` のステータスを `planned` → `implemented` に変更
+- [x] `docs/chart-governance-playbook.md`: 通常変更フロー（POST/GET の動作仕様）を追記

--- a/docs/chart-governance-playbook.md
+++ b/docs/chart-governance-playbook.md
@@ -34,6 +34,15 @@ Chart 閾値変更を「レビュー必須」で安全に運用する。
 
 ## Branch Strategy
 
+- 方針整理: `chore/chart-governance-*`
+- 閾値変更: `chart/threshold-<ticket>-<short-desc>`
+- API/実装変更: `feature/chart-<short-desc>`
+
+例:
+
+- `chart/threshold-42-recipe-a-step2`
+- `feature/chartset-import-export`
+
 ## Normal Change Request Flow (Phase 1)
 
 通常変更フロー（change-request）は以下の API 契約で運用する。
@@ -56,15 +65,6 @@ Chart 閾値変更を「レビュー必須」で安全に運用する。
 
 - POST は write のため `DBTaskRunner` 経由で実行する
 - GET は read-only のため direct read-only 接続（`_connect_readonly`）で実行する
-
-- 方針整理: `chore/chart-governance-*`
-- 閾値変更: `chart/threshold-<ticket>-<short-desc>`
-- API/実装変更: `feature/chart-<short-desc>`
-
-例:
-
-- `chart/threshold-42-recipe-a-step2`
-- `feature/chartset-import-export`
 
 ## GitHub Discussions Usage
 

--- a/docs/chart-governance-playbook.md
+++ b/docs/chart-governance-playbook.md
@@ -34,6 +34,29 @@ Chart 閾値変更を「レビュー必須」で安全に運用する。
 
 ## Branch Strategy
 
+## Normal Change Request Flow (Phase 1)
+
+通常変更フロー（change-request）は以下の API 契約で運用する。
+
+1. 申請作成: `POST /governance/change-requests`
+
+- 必須フィールド: `chart_id`, `proposed_by`, `change_payload`, `expected_version`, `idempotency_key`
+- `change_payload` は JSON パース可能性のみを検証する
+- 正常レスポンス: `{ok: true, data: {request_id, status}}`（初期 `status` は `pending`）
+- 同一 `idempotency_key` は 409（`DUPLICATE_IDEMPOTENCY_KEY`）を返す
+- 申請作成時に `GovernanceAuditEvents` へ `event_type=change_requested` を 1 件記録する
+
+2. 申請検索: `GET /governance/change-requests`
+
+- フィルタ: `status`, `chart_id`, `from_ts`, `to_ts`（期間対象は `proposed_at`）
+- ページネーション: `limit`（default 100, max 500）, `offset`（default 0）
+- 0 件時レスポンス: `{ok: true, data: []}`
+
+3. 接続責務の分離
+
+- POST は write のため `DBTaskRunner` 経由で実行する
+- GET は read-only のため direct read-only 接続（`_connect_readonly`）で実行する
+
 - 方針整理: `chore/chart-governance-*`
 - 閾値変更: `chart/threshold-<ticket>-<short-desc>`
 - API/実装変更: `feature/chart-<short-desc>`

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -27,12 +27,12 @@
 | `GET`    | `/charts/history`                                   | dashboard read | implemented | dashboard/ops   | source: `db_api/app.py` | chart 変更履歴                               |
 | `GET`    | `/judge/results`                                    | dashboard read | implemented | dashboard       | Issue #132              | 判定結果一覧                                 |
 | `GET`    | `/judge/results/{result_id}`                        | dashboard read | implemented | dashboard       | Issue #133              | 判定詳細（トレース情報含む）                 |
-| `POST`   | `/governance/change-requests`                       | governance     | planned     | dashboard/ops   | Issue #102              | 通常変更の申請作成                           |
+| `POST`   | `/governance/change-requests`                       | governance     | implemented | dashboard/ops   | source: `db_api/app.py` | 通常変更の申請作成                           |
 | `POST`   | `/governance/change-requests/{request_id}/approve`  | governance     | planned     | ops             | Issue #102              | 変更申請の承認                               |
 | `POST`   | `/governance/change-requests/{request_id}/apply`    | governance     | planned     | ops             | Issue #102              | 承認済み申請の反映                           |
 | `POST`   | `/governance/emergency-changes`                     | governance     | planned     | dashboard/ops   | Issue #102              | 緊急変更の即時反映                           |
 | `POST`   | `/governance/emergency-changes/{request_id}/ratify` | governance     | planned     | ops             | Issue #102              | 緊急変更の事後追認                           |
-| `GET`    | `/governance/change-requests`                       | governance     | planned     | ops/audit       | Issue #102              | 変更申請の検索                               |
+| `GET`    | `/governance/change-requests`                       | governance     | implemented | ops/audit       | source: `db_api/app.py` | 変更申請の検索                               |
 | `GET`    | `/governance/audit-events`                          | governance     | planned     | ops/audit       | Issue #102              | 監査イベントの検索                           |
 | `POST`   | `/governance/notifications/{event_id}/retry`        | governance     | planned     | ops             | Issue #102              | 通知失敗時の再送                             |
 
@@ -49,7 +49,7 @@
 
 ## Read-only Endpoint Access Pattern
 
-- `GET /charts*` 系は read-only のため `_connect(MAIN_DB)` で直接接続し、`DBTaskRunner` 経由は不要
+- `GET /charts*` と `GET /governance/change-requests` は read-only のため `_connect_readonly(MAIN_DB)` で直接接続し、`DBTaskRunner` 経由は不要
 - `DBTaskRunner` は write タスク直列化・排他制御専用で、read では並行接続をサポート
 
 ## Consumer Permission Scope

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,5 +1,268 @@
 # Decision Log
 
+## 2026-05-07: `#141` POST /governance/change-requests - リクエストボディ項目を確定
+
+日付基準: JST
+
+### Context
+
+`#141` の POST 実装で、`ChangeRequestIn` の入力契約を固定しないと
+API 実装・422 テスト・クライアント実装の整合が崩れる懸念があった。
+
+### Decision
+
+1. POST の受け付け項目を以下で固定する
+   - `chart_id`（int, 必須）
+   - `proposed_by`（string, 必須）
+   - `change_payload`（string, 必須）
+   - `expected_version`（int, 必須）
+   - `idempotency_key`（string, 必須）
+2. `change_payload` は JSON パース可能性のみを検証する
+3. `chart_id` の存在確認は POST 時に行わず、apply フェーズ責務とする
+
+### Why
+
+1. Child 2 の責務を「申請受理」に限定し、契約を最小化するため
+2. 詳細妥当性検証を apply フェーズへ分離し、段階実装の境界を明確化するため
+3. 必須項目を固定することで 422 契約を機械的に検証しやすくするため
+
+### Consequence
+
+1. `ChangeRequestIn` は上記 5 項目の必須入力として実装する
+2. 不足項目・型不正は 422（validation error envelope）で返す
+3. `change_payload` 非 JSON は 422 で返し、内容妥当性は apply フェーズで扱う
+
+## 2026-05-07: `#141` GovernanceChangeRequestRepository.list() - SQL 契約を確定
+
+日付基準: JST
+
+### Context
+
+`#141` の GET 実装前提として、repository 層の `list()` における
+フィルタ対象・並び順・ページネーション・0 件時挙動を固定する必要があった。
+この契約を固定しないと、`app.py` 実装と GET テスト期待値の整合が崩れる懸念があった。
+
+### Decision
+
+1. `list()` の受け付け条件は `status`, `chart_id`, `from_ts`, `to_ts`, `limit`, `offset` とする
+2. `from_ts` / `to_ts` は `proposed_at` カラムに適用する
+3. 並び順は `proposed_at DESC, id DESC` で固定する
+4. 0 件時は例外ではなく空リストを返す
+
+### Why
+
+1. GET 契約（Discussion #192 と 2026-05-07 の GET 方針決定）に一致させるため
+2. 同一 `proposed_at` の場合に `id` で決定的順序を確保するため
+3. API 層で `{ok: true, data: []}` を安定して返せるようにするため
+
+### Consequence
+
+1. `GovernanceChangeRequestRepository.list()` は動的 WHERE + 固定 ORDER BY + LIMIT/OFFSET を実装する
+2. repository テストは 0 件、フィルタ、`limit`/`offset` 境界を必須で検証する
+3. GET endpoint 実装時はこの `list()` 契約をそのまま利用する
+
+## 2026-05-07: `#141` GET /governance/change-requests - 接続方式・依存注入・テスト観点を確定
+
+日付基準: JST
+
+### Context
+
+`#141` の GET 実装に向けて、以下 3 点を実装前に固定する必要があった。
+
+1. DB 接続方式（read-only 直結 or `DBTaskRunner` 経由）
+2. app 実装での依存注入パターン
+3. 最小必須の GET テスト観点
+
+既存の read endpoint（`/charts*`, `/judge/results*`）は read path と write path を分離しており、
+write の直列化責務は `DBTaskRunner`、read は直接 read-only 接続という運用で統一されている。
+
+### Decision
+
+1. `GET /governance/change-requests` は read-only 直接接続を採用し、`DBTaskRunner` は経由しない
+2. 依存注入パターンは以下で固定する
+   - POST: `RunnerDep`（`DBTaskRunner` 経由で write 実行）
+   - GET: `RunnerDep` を使わず read-only 直接接続
+3. GET テストの最小必須観点を以下で固定する
+   - 0 件時レスポンス（`{ok: true, data: []}`）
+   - フィルタ（`status`, `chart_id`, `from_ts`/`to_ts`）
+   - ページネーション境界（`limit`, `offset`）
+
+### Why
+
+1. write 直列化と read 応答性の責務を分離し、既存 db_api パターンと整合を保つため
+2. GET を runner 非依存にすることで read path の実装を簡潔に保てるため
+3. テスト観点を先に固定することで repository / endpoint の受け入れ条件を揃えられるため
+
+### Consequence
+
+1. `app.py` では POST のみ `RunnerDep` を受け取り、GET は read-only 接続で `list()` を呼び出す
+2. `GovernanceChangeRequestRepository.list()` は 0 件時に空配列を返す実装を前提とする
+3. `tests/db_api/` に GET の 0 件・フィルタ・`limit`/`offset` 境界テストを追加する
+
+## 2026-05-07: `#141` POST /governance/change-requests - 正常レスポンス契約を ok/data 形式で確定
+
+日付基準: JST
+
+### Context
+
+`#141` の POST 実装で、正常系レスポンスの envelope と最小フィールドが未確定だった。
+API テストと画面側の受け取り仕様が揺れないよう、実装前に固定が必要だった。
+
+### Decision
+
+1. 正常系レスポンスは ok/data 形式とする
+   ```json
+   {
+     "ok": true,
+     "data": {
+       "request_id": <int>,
+       "status": "pending"
+     }
+   }
+   ```
+2. data の最小必須フィールドは request_id と status に絞る
+3. 初期 status 値は "pending" で固定する
+
+### Why
+
+1. 既存 endpoint の成功レスポンス慣習と整合しやすい
+2. クライアント契約が単純で拡張時に後方互換を保ちやすい
+3. 最小フィールドに絞ることで実装複雑性を抑える
+
+### Consequence
+
+1. ChangeRequestIn スキーマの POST 返却型を ok/data 形式で実装する
+2. 初期 status は DB デフォルト pending を使用
+3. POST テストは `response["ok"] == true` と `response["data"]["request_id"]` の検証を最小必須とする
+
+## 2026-05-07: `#141` POST /governance/change-requests - 監査イベント名を `change_requested` で確定
+
+日付基準: JST
+
+### Context
+
+`#141` の POST 実装で、申請作成時に記録する監査イベントの命名が
+`change_requested` と `change_request_created` で揺れていた。
+命名を固定しないと、テスト・実装・運用検索クエリの不整合が発生するため、Discussion 1 で確定が必要だった。
+
+### Decision
+
+1. POST 申請作成時の `event_type` は `change_requested` を正式名とする
+2. `change_request_created` は採用しない
+
+### Why
+
+1. 既存 decision-log のイベント語彙と整合し、移行コストが低い
+2. 「申請された」という業務イベントを簡潔に表現できる
+3. approve/apply 系イベント名との対応関係が分かりやすい
+
+### Consequence
+
+1. `POST /governance/change-requests` の監査イベント検証は `event_type == change_requested` を期待値とする
+2. checklist とテスト観点の event_type 表記を `change_requested` に統一する
+3. 実装時に `change_request_created` を新規導入しない
+
+## 2026-05-06: `#141` GET /governance/change-requests - Discussion #192 フィルタ仕様とページネーション確定
+
+日付基準: JST
+
+### Context
+
+`#141` の GET 実装で、検索フィルタ範囲とページネーション既定値を先に固定しないと、
+repository 実装・Pydantic スキーマ・契約テストの前提が揃わない状態だった。
+
+### Decision
+
+1. Phase 1 のフィルタ対象は `status`, `chart_id`, `from_ts`, `to_ts` の 4 種とする
+2. `from_ts` / `to_ts` の対象カラムは `proposed_at` 固定とする
+3. `proposed_by` フィルタは Phase 1 では採用しない（必要時に Phase 2 以降で追加検討）
+4. ページネーションは以下で固定する
+
+- `limit`: default 100, max 500
+- `offset`: default 0, 上限なし
+
+### Why
+
+1. Child 2 の責務を「申請一覧の最小検索」に絞り、実装複雑性を抑えるため
+2. `proposed_at` 固定にすることで、動的カラム指定を避けて SQL の安全性と可読性を保つため
+3. `proposed_by` は後方互換を壊さず追加できるため、先に最小契約を確定するため
+
+### Consequence
+
+1. `ChangeRequestsQuery` は上記 4 フィルタ + `limit` / `offset` を受け付ける
+2. `GovernanceChangeRequestRepository.list()` は `proposed_at` に対して期間条件を適用する
+3. GET 契約テストは、4 フィルタと `limit=1` / `offset` 境界を最小必須ケースとする
+
+## 2026-05-06: `#141` POST /governance/change-requests - idempotency_key 重複時レスポンスを B で確定
+
+日付基準: JST
+
+### Context
+
+`#141` の POST 実装において、同一 `idempotency_key` の再送時に 409 を返す方針は既に合意済みだったが、
+409 時のレスポンス形式（A/B/C）が未確定だった。
+
+### Decision
+
+**方針:** B を採用する。
+
+- 重複時は HTTP 409 を返す
+- レスポンス形式は error envelope とする
+- `error.code` は `DUPLICATE_IDEMPOTENCY_KEY` を使用する
+- `details` に `idempotency_key` を含める
+- `request_id` は返さない
+
+### Why
+
+1. 404 で採用済みの error envelope 方針と整合を取りやすい
+2. クライアントが `error.code` による機械判定をしやすい
+3. Child 2 の最小実装として、追加クエリなしで確定できる
+
+### Consequence
+
+1. `POST /governance/change-requests` の duplicate キーは 409 + envelope で統一する
+2. API テストに `error.code == DUPLICATE_IDEMPOTENCY_KEY` と `details.idempotency_key` の検証を追加する
+3. `request_id` 返却要件は採用しない（必要なら Phase 2 で再検討）
+
+## 2026-05-06: `#141` POST /governance/change-requests - Discussion #190 論点1-2 確定
+
+日付基準: JST
+
+### Context
+
+`#141`（POST/GET change-requests 実装）で、POST 実装前提となる以下 2 論点の合意が必要だった。
+
+1. `change_payload` のバリデーション範囲
+2. `chart_id` の存在確認タイミング
+
+### Decision
+
+#### 論点1: change_payload のバリデーション範囲
+
+**方針:** A を採用する。
+
+- POST では `change_payload` の JSON パース可能性のみを検証する。
+- payload 内容（しきい値項目の妥当性、適用可能性）の詳細検証は apply フェーズで行う。
+
+#### 論点2: chart_id の存在確認タイミング
+
+**方針:** B を採用する。
+
+- POST 時には `chart_id` の存在確認を行わない。
+- 申請登録は `GovernanceChangeRequests` への INSERT を優先し、存在確認は apply フェーズで扱う。
+
+### Why
+
+1. Child 2 の責務を「申請受理」に絞り、実装と運用を簡潔に保つため
+2. payload 詳細検証や chart 実在性検証は apply の責務とした方が責務分離が明確なため
+3. 段階実装（#141 -> #142）で仕様を分離した方がテストとロールバックの境界が明確になるため
+
+### Consequence
+
+1. `POST /governance/change-requests` は JSON 形式不正のみ 422 対象とする
+2. `POST /governance/change-requests` は `chart_id` 非存在を POST 時点で 404 判定しない
+3. apply 時の検証エラー系（chart 不在、payload 内容不正）を `#142` の受け入れ条件で明文化する
+
 ## 2026-05-05: `#140` governance schema 基盤 - 論点12 既存 DB への適用順・既存テーブル影響なし宣言
 
 日付基準: JST

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -82,6 +82,10 @@ JUDGE_LEVEL_PATTERN = r"^(OK|WARN|NG)$"
 RESULT_ID_PATTERN = r"^JR_[0-9]+$"
 
 
+class ReferencedChartNotFoundError(LookupError):
+    """変更申請で参照した chart_id が存在しない場合に送出する。"""
+
+
 def _legacy_delete_headers(process_id: str | None) -> dict[str, str]:
     """旧 DELETE `/processes` の移行ヘッダを生成する。"""
     if process_id is None:
@@ -803,6 +807,13 @@ def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep
         con = _connect(MAIN_DB)
         try:
             con.execute("BEGIN")
+            chart_exists = con.execute(
+                "SELECT 1 FROM ChartsV2 WHERE id = ? LIMIT 1",
+                (payload.chart_id,),
+            ).fetchone()
+            if chart_exists is None:
+                raise ReferencedChartNotFoundError(payload.chart_id)
+
             request_id = _governance_change_request_repository.create(
                 con,
                 chart_id=payload.chart_id,
@@ -836,6 +847,11 @@ def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep
     try:
         data = runner.submit("write", _write)
         return {"ok": True, "data": data}
+    except ReferencedChartNotFoundError:
+        return _not_found_error_response(
+            message="chart not found",
+            details={"chart_id": str(payload.chart_id)},
+        )
     except sqlite3.IntegrityError as e:
         if _is_duplicate_change_request_idempotency_error(e):
             return _duplicate_idempotency_error_response(

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -31,13 +31,16 @@ from .aggregate_repository import (
     write_process,
     write_step_windows_bulk,
 )
+from .audit_event_writer import AuditEventWriter
 from .chart_repository import (
     ActiveChartsQueryCriteria,
     ChartRepository,
     ChartsHistoryQueryCriteria,
     ChartsQueryCriteria,
 )
-from .db import MAIN_DB, TEMP_DB, _connect_readonly, _init_schema
+from .datetime_util import to_utc_millis
+from .db import MAIN_DB, TEMP_DB, _connect, _connect_readonly, _init_schema
+from .governance_repository import GovernanceChangeRequestRepository
 from .judge_repository import (
     JudgeDataCorruptionError,
     JudgeRepository,
@@ -45,6 +48,8 @@ from .judge_repository import (
 )
 from .schemas import (
     AggregateWriteIn,
+    ChangeRequestIn,
+    ChangeRequestsQuery,
     ParameterIn,
     ProcessDeleteIn,
     ProcessInfoIn,
@@ -252,6 +257,8 @@ def _raise_api_error(
 RunnerDep = Annotated[DBTaskRunner, Depends(get_runner)]
 _chart_repository = ChartRepository()
 _judge_repository = JudgeRepository()
+_governance_change_request_repository = GovernanceChangeRequestRepository()
+_audit_event_writer = AuditEventWriter()
 
 
 @app.get("/charts")
@@ -349,7 +356,7 @@ def _normalize_query_datetime(raw: datetime | None) -> str | None:
             status_code=400,
             detail="from_ts and to_ts must be timezone-aware datetimes",
         )
-    return raw.astimezone(UTC).isoformat()
+    return to_utc_millis(raw.isoformat())
 
 
 def _validate_query_datetime_range(
@@ -437,6 +444,30 @@ def _not_found_error_response(*, message: str, details: dict[str, str]) -> JSONR
                 "details": details,
             },
         },
+    )
+
+
+def _duplicate_idempotency_error_response(*, idempotency_key: str) -> JSONResponse:
+    """重複 idempotency_key への 409 error envelope を返す。"""
+    return JSONResponse(
+        status_code=409,
+        content={
+            "ok": False,
+            "error": {
+                "code": "DUPLICATE_IDEMPOTENCY_KEY",
+                "message": "idempotency_key already exists",
+                "details": {"idempotency_key": idempotency_key},
+            },
+        },
+    )
+
+
+def _is_duplicate_change_request_idempotency_error(error: sqlite3.IntegrityError) -> bool:
+    """GovernanceChangeRequests.idempotency_key の UNIQUE 違反かを判定する。"""
+    message = str(error)
+    return (
+        "GovernanceChangeRequests.idempotency_key" in message
+        or "idx_change_requests_idempotency" in message
     )
 
 
@@ -737,6 +768,82 @@ def get_judge_result_by_id(
         raise HTTPException(status_code=500, detail="Internal server error") from e
     except Exception as e:
         _raise_api_error(operation="GET /judge/results/{result_id}", error=e)
+
+
+@app.get("/governance/change-requests")
+def get_governance_change_requests(
+    query: Annotated[ChangeRequestsQuery, Depends()],
+):
+    """ガバナンス変更申請一覧を返す。"""
+    con = _connect_readonly(MAIN_DB)
+    try:
+        rows = _governance_change_request_repository.list(
+            con,
+            status=query.status,
+            chart_id=query.chart_id,
+            from_ts=_normalize_query_datetime(query.from_ts),
+            to_ts=_normalize_query_datetime(query.to_ts),
+            limit=query.limit,
+            offset=query.offset,
+        )
+        return {"ok": True, "data": [asdict(row) for row in rows]}
+    except Exception as e:
+        _raise_api_error(operation="GET /governance/change-requests", error=e)
+    finally:
+        con.close()
+
+
+@app.post("/governance/change-requests")
+def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep):
+    """ガバナンス変更申請を作成する。"""
+
+    proposed_at = to_utc_millis(datetime.now(UTC).isoformat())
+
+    def _write() -> dict[str, int | str]:
+        con = _connect(MAIN_DB)
+        try:
+            con.execute("BEGIN")
+            request_id = _governance_change_request_repository.create(
+                con,
+                chart_id=payload.chart_id,
+                proposed_by=payload.proposed_by,
+                proposed_at=proposed_at,
+                change_payload=payload.change_payload,
+                expected_version=payload.expected_version,
+                idempotency_key=payload.idempotency_key,
+            )
+
+            _audit_event_writer.write(
+                con,
+                event_type="change_requested",
+                actor=payload.proposed_by,
+                actor_role="requester",
+                target_type="change_request",
+                target_id=request_id,
+                occurred_at=proposed_at,
+                correlation_id=payload.idempotency_key,
+            )
+
+            row = _governance_change_request_repository.find_by_id(con, request_id)
+            con.commit()
+            return {"request_id": request_id, "status": row.status}
+        except Exception:
+            con.rollback()
+            raise
+        finally:
+            con.close()
+
+    try:
+        data = runner.submit("write", _write)
+        return {"ok": True, "data": data}
+    except sqlite3.IntegrityError as e:
+        if _is_duplicate_change_request_idempotency_error(e):
+            return _duplicate_idempotency_error_response(
+                idempotency_key=payload.idempotency_key,
+            )
+        _raise_api_error(operation="POST /governance/change-requests", error=e)
+    except Exception as e:
+        _raise_api_error(operation="POST /governance/change-requests", error=e)
 
 
 @app.post("/processes")

--- a/src/portfolio_fdc/db_api/governance_repository.py
+++ b/src/portfolio_fdc/db_api/governance_repository.py
@@ -83,6 +83,48 @@ class GovernanceChangeRequestRepository:
         if cur.rowcount == 0:
             raise GovernanceNotFoundError(f"GovernanceChangeRequests id={record_id} not found")
 
+    def list(
+        self,
+        con: sqlite3.Connection,
+        *,
+        status: str | None = None,
+        chart_id: int | None = None,
+        from_ts: str | None = None,
+        to_ts: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[ChangeRequestRow]:
+        """条件に一致する申請一覧を返す。0 件時は空リストを返す。"""
+        sql = """
+            SELECT id, chart_id, status, proposed_by, proposed_at,
+                   change_payload, expected_version, idempotency_key
+            FROM GovernanceChangeRequests
+        """
+        where_clauses: list[str] = []
+        params: list[object] = []
+
+        if status is not None:
+            where_clauses.append("status = ?")
+            params.append(status)
+        if chart_id is not None:
+            where_clauses.append("chart_id = ?")
+            params.append(chart_id)
+        if from_ts is not None:
+            where_clauses.append("datetime(proposed_at) >= datetime(?)")
+            params.append(from_ts)
+        if to_ts is not None:
+            where_clauses.append("datetime(proposed_at) <= datetime(?)")
+            params.append(to_ts)
+
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+
+        sql += " ORDER BY datetime(proposed_at) DESC, id DESC LIMIT ? OFFSET ?"
+        params.extend((limit, offset))
+
+        rows = con.execute(sql, params).fetchall()
+        return [ChangeRequestRow(*row) for row in rows]
+
 
 # ---------------------------------------------------------------------------
 # GovernanceApprovals

--- a/src/portfolio_fdc/db_api/schemas.py
+++ b/src/portfolio_fdc/db_api/schemas.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from math import isfinite
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -98,4 +100,44 @@ class AggregateWriteIn(BaseModel):
             raise ValueError("step_windows process_id must match process.process_id")
         if any(item.process_id != pid for item in self.parameters):
             raise ValueError("parameters process_id must match process.process_id")
+        return self
+
+
+class ChangeRequestIn(BaseModel):
+    """`/governance/change-requests` POST 用の入力モデル。"""
+
+    chart_id: int = Field(ge=1)
+    proposed_by: str = Field(min_length=1, max_length=128)
+    change_payload: str = Field(min_length=1)
+    expected_version: int = Field(ge=1)
+    idempotency_key: str = Field(min_length=1, max_length=128)
+
+    @field_validator("change_payload")
+    @classmethod
+    def validate_change_payload_is_json(cls, value: str) -> str:
+        try:
+            json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError("change_payload must be valid JSON") from exc
+        return value
+
+
+class ChangeRequestsQuery(BaseModel):
+    """`/governance/change-requests` GET 用のクエリ入力モデル。"""
+
+    status: Literal["pending", "approved", "applied", "apply_failed", "rejected"] | None = None
+    chart_id: int | None = Field(default=None, ge=1)
+    from_ts: datetime | None = None
+    to_ts: datetime | None = None
+    limit: int = Field(default=100, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def validate_query_time_range(self) -> ChangeRequestsQuery:
+        if self.from_ts is not None and self.from_ts.tzinfo is None:
+            raise ValueError("from_ts must be timezone-aware")
+        if self.to_ts is not None and self.to_ts.tzinfo is None:
+            raise ValueError("to_ts must be timezone-aware")
+        if self.from_ts is not None and self.to_ts is not None:
+            validate_timestamp_range(self.from_ts, self.to_ts)
         return self

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -376,6 +376,44 @@ def test_get_change_requests_applies_offset(
     assert [row["id"] for row in rows] == [seeded.request_pending_chart_1]
 
 
+def test_get_change_requests_limit_exceeds_max(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.get(
+        "/governance/change-requests",
+        params={"chart_id": seeded.chart_1_id, "limit": 501},
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(
+        res.json(),
+        expected_loc_fragment="limit",
+        expected_message_fragment="less than or equal to 500",
+    )
+
+
+def test_get_change_requests_negative_offset(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.get(
+        "/governance/change-requests",
+        params={"chart_id": seeded.chart_1_id, "offset": -1},
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(
+        res.json(),
+        expected_loc_fragment="offset",
+        expected_message_fragment="greater than or equal to 0",
+    )
+
+
 def test_post_change_requests_success_returns_request_id_and_pending_status(
     client: TestClient,
     seeded_change_requests_context: SeededChangeRequestsContext,

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -271,6 +271,13 @@ def test_get_change_requests_returns_envelope_contract(
     body = res.json()
     assert body["ok"] is True
     assert isinstance(body["data"], list)
+    assert body["data"]
+    proposed_at_values = [row["proposed_at"] for row in body["data"]]
+    assert "2026-05-02T00:00:00.000Z" in proposed_at_values
+    for proposed_at in proposed_at_values:
+        assert isinstance(proposed_at, str)
+        parsed = datetime.fromisoformat(proposed_at.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None
 
 
 def test_get_change_requests_filters_by_status(
@@ -544,6 +551,29 @@ def test_post_change_requests_returns_409_for_duplicate_idempotency_key(
         assert body["ok"] is False
         assert body["error"]["code"] == "DUPLICATE_IDEMPOTENCY_KEY"
         assert body["error"]["details"]["idempotency_key"] == idempotency_key
+    finally:
+        _delete_change_request_by_idempotency(idempotency_key)
+
+
+def test_post_change_requests_returns_404_for_missing_chart_id(client: TestClient) -> None:
+    idempotency_key = f"post-missing-chart-{uuid4().hex[:12]}"
+    try:
+        res = client.post(
+            "/governance/change-requests",
+            json={
+                "chart_id": 9223372036854775807,
+                "proposed_by": "tester",
+                "change_payload": "{}",
+                "expected_version": 1,
+                "idempotency_key": idempotency_key,
+            },
+        )
+
+        assert res.status_code == 404
+        body = res.json()
+        assert body["ok"] is False
+        assert body["error"]["code"] == "NOT_FOUND"
+        assert body["error"]["details"]["chart_id"] == "9223372036854775807"
     finally:
         _delete_change_request_by_idempotency(idempotency_key)
 

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from portfolio_fdc.db_api.db import MAIN_DB, _connect, _init_schema
+from tests.utils.test_utils import assert_validation_error_envelope
+
+
+@dataclass(frozen=True)
+class SeededChangeRequestsContext:
+    chart_1_id: int
+    chart_2_id: int
+    request_pending_chart_1: int
+    request_approved_chart_1: int
+    request_pending_chart_2: int
+
+
+def _insert_chart_set(now: str, suffix: str) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        con.execute(
+            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
+            (f"governance_req_set_{suffix}", "test", now, "test"),
+        )
+        chart_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+        con.commit()
+        return chart_set_id
+    finally:
+        con.close()
+
+
+def _insert_chart(chart_set_id: int, suffix: str, parameter: str) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        cur = con.execute(
+            """
+            INSERT INTO ChartsV2(
+                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                updated_at, updated_by, update_reason, update_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chart_set_id,
+                f"TOOL_{suffix}",
+                "CH1",
+                f"RECIPE_{suffix}",
+                parameter,
+                1,
+                "mean",
+                1.0,
+                2.0,
+                0.8,
+                2.2,
+                "2026-05-01T00:00:00.000Z",
+                "tester",
+                "seed",
+                "test",
+            ),
+        )
+        con.commit()
+        row_id = cur.lastrowid
+        if row_id is None:
+            raise RuntimeError("Failed to insert chart")
+        return int(row_id)
+    finally:
+        con.close()
+
+
+def _insert_change_request(
+    *,
+    chart_id: int,
+    proposed_by: str,
+    proposed_at: str,
+    idempotency_key: str,
+) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceChangeRequests(
+                chart_id, proposed_by, proposed_at, change_payload,
+                expected_version, idempotency_key
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chart_id,
+                proposed_by,
+                proposed_at,
+                "{}",
+                1,
+                idempotency_key,
+            ),
+        )
+        con.commit()
+        row_id = cur.lastrowid
+        if row_id is None:
+            raise RuntimeError("Failed to insert change request")
+        return int(row_id)
+    finally:
+        con.close()
+
+
+def _update_change_request_status(request_id: int, status: str) -> None:
+    con = _connect(MAIN_DB)
+    try:
+        con.execute(
+            "UPDATE GovernanceChangeRequests SET status = ? WHERE id = ?",
+            (status, request_id),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _cleanup_seeded(chart_set_id: int, request_ids: tuple[int, int, int]) -> None:
+    con = _connect(MAIN_DB)
+    try:
+        con.execute(
+            "DELETE FROM GovernanceChangeRequests WHERE id IN (?, ?, ?)",
+            request_ids,
+        )
+        con.execute("DELETE FROM ChartsV2 WHERE chart_set_id = ?", (chart_set_id,))
+        con.execute("DELETE FROM ChartSet WHERE chart_set_id = ?", (chart_set_id,))
+        con.commit()
+    finally:
+        con.close()
+
+
+def _delete_change_request_by_idempotency(idempotency_key: str) -> None:
+    con = _connect(MAIN_DB)
+    try:
+        request_ids = [
+            int(row[0])
+            for row in con.execute(
+                "SELECT id FROM GovernanceChangeRequests WHERE idempotency_key = ?",
+                (idempotency_key,),
+            ).fetchall()
+        ]
+        if request_ids:
+            con.executemany(
+                "DELETE FROM GovernanceAuditEvents WHERE target_type = ? AND target_id = ?",
+                [("change_request", request_id) for request_id in request_ids],
+            )
+        con.execute(
+            "DELETE FROM GovernanceAuditEvents WHERE correlation_id = ?",
+            (idempotency_key,),
+        )
+        con.execute(
+            "DELETE FROM GovernanceChangeRequests WHERE idempotency_key = ?",
+            (idempotency_key,),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _count_audit_events_by_correlation_id(correlation_id: str) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        row = con.execute(
+            "SELECT COUNT(*) FROM GovernanceAuditEvents WHERE correlation_id = ?",
+            (correlation_id,),
+        ).fetchone()
+        return int(row[0])
+    finally:
+        con.close()
+
+
+def _find_latest_audit_event_by_correlation_id(correlation_id: str) -> tuple[str, str, int] | None:
+    con = _connect(MAIN_DB)
+    try:
+        row = con.execute(
+            """
+            SELECT event_type, target_type, target_id
+            FROM GovernanceAuditEvents
+            WHERE correlation_id = ?
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (correlation_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return (str(row[0]), str(row[1]), int(row[2]))
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def seeded_change_requests_context() -> Iterator[SeededChangeRequestsContext]:
+    _init_schema(MAIN_DB)
+    suffix = uuid4().hex[:10]
+    now = datetime.now(UTC).isoformat()
+    chart_set_id = _insert_chart_set(now, suffix)
+    chart_1 = _insert_chart(chart_set_id, suffix, "param_a")
+    chart_2 = _insert_chart(chart_set_id, suffix, "param_b")
+
+    req_pending_chart_1 = _insert_change_request(
+        chart_id=chart_1,
+        proposed_by="alice",
+        proposed_at="2026-05-01T00:00:00.000Z",
+        idempotency_key=f"{suffix}-k1",
+    )
+    req_approved_chart_1 = _insert_change_request(
+        chart_id=chart_1,
+        proposed_by="bob",
+        proposed_at="2026-05-02T00:00:00.000Z",
+        idempotency_key=f"{suffix}-k2",
+    )
+    req_pending_chart_2 = _insert_change_request(
+        chart_id=chart_2,
+        proposed_by="carol",
+        proposed_at="2026-05-03T00:00:00.000Z",
+        idempotency_key=f"{suffix}-k3",
+    )
+    _update_change_request_status(req_approved_chart_1, "approved")
+
+    try:
+        yield SeededChangeRequestsContext(
+            chart_1_id=chart_1,
+            chart_2_id=chart_2,
+            request_pending_chart_1=req_pending_chart_1,
+            request_approved_chart_1=req_approved_chart_1,
+            request_pending_chart_2=req_pending_chart_2,
+        )
+    finally:
+        _cleanup_seeded(
+            chart_set_id,
+            (req_pending_chart_1, req_approved_chart_1, req_pending_chart_2),
+        )
+
+
+def test_get_change_requests_returns_empty_list_when_no_match(client: TestClient) -> None:
+    res = client.get(
+        "/governance/change-requests",
+        params={"chart_id": 9223372036854775807},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"] == []
+
+
+def test_get_change_requests_returns_envelope_contract(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.get(
+        "/governance/change-requests",
+        params={"chart_id": seeded.chart_1_id},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert isinstance(body["data"], list)
+
+
+def test_get_change_requests_filters_by_status(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.get(
+        "/governance/change-requests",
+        params={"status": "approved", "chart_id": seeded.chart_1_id},
+    )
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert [row["id"] for row in rows] == [seeded.request_approved_chart_1]
+    assert all(row["status"] == "approved" for row in rows)
+
+
+def test_get_change_requests_filters_by_chart_id(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.get(
+        "/governance/change-requests",
+        params={"chart_id": seeded.chart_2_id},
+    )
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert [row["id"] for row in rows] == [seeded.request_pending_chart_2]
+
+
+def test_get_change_requests_filters_by_from_to(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.get(
+        "/governance/change-requests",
+        params={
+            "from_ts": "2026-05-02T00:00:00Z",
+            "to_ts": "2026-05-03T00:00:00Z",
+        },
+    )
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert [row["id"] for row in rows] == [
+        seeded.request_pending_chart_2,
+        seeded.request_approved_chart_1,
+    ]
+
+
+def test_get_change_requests_applies_limit(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.get(
+        "/governance/change-requests",
+        params={"chart_id": seeded.chart_1_id, "limit": 1},
+    )
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert len(rows) == 1
+
+
+def test_get_change_requests_applies_offset(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.get(
+        "/governance/change-requests",
+        params={"chart_id": seeded.chart_1_id, "offset": 1},
+    )
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert [row["id"] for row in rows] == [seeded.request_pending_chart_1]
+
+
+def test_post_change_requests_success_returns_request_id_and_pending_status(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    idempotency_key = f"post-ok-{uuid4().hex[:12]}"
+    try:
+        res = client.post(
+            "/governance/change-requests",
+            json={
+                "chart_id": seeded.chart_1_id,
+                "proposed_by": "tester",
+                "change_payload": '{"warning_ucl": 2.5}',
+                "expected_version": 1,
+                "idempotency_key": idempotency_key,
+            },
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert isinstance(body["data"]["request_id"], int)
+        assert body["data"]["status"] == "pending"
+    finally:
+        _delete_change_request_by_idempotency(idempotency_key)
+
+
+def test_post_change_requests_success_envelope_contract(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    idempotency_key = f"post-envelope-{uuid4().hex[:12]}"
+    try:
+        res = client.post(
+            "/governance/change-requests",
+            json={
+                "chart_id": seeded.chart_1_id,
+                "proposed_by": "tester",
+                "change_payload": "{}",
+                "expected_version": 1,
+                "idempotency_key": idempotency_key,
+            },
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert "data" in body
+    finally:
+        _delete_change_request_by_idempotency(idempotency_key)
+
+
+def test_post_change_requests_returns_422_for_missing_required_field(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+
+    res = client.post(
+        "/governance/change-requests",
+        json={
+            "chart_id": seeded.chart_1_id,
+            "proposed_by": "tester",
+            "change_payload": "{}",
+            "expected_version": 1,
+        },
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(
+        res.json(),
+        expected_loc_fragment="idempotency_key",
+    )
+
+
+def test_post_change_requests_returns_422_for_non_integer_chart_id(client: TestClient) -> None:
+    res = client.post(
+        "/governance/change-requests",
+        json={
+            "chart_id": "abc",
+            "proposed_by": "tester",
+            "change_payload": "{}",
+            "expected_version": 1,
+            "idempotency_key": f"post-invalid-chart-{uuid4().hex[:8]}",
+        },
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(
+        res.json(),
+        expected_loc_fragment="chart_id",
+    )
+
+
+def test_post_change_requests_returns_409_for_duplicate_idempotency_key(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    idempotency_key = f"post-dup-{uuid4().hex[:12]}"
+    try:
+        first = client.post(
+            "/governance/change-requests",
+            json={
+                "chart_id": seeded.chart_1_id,
+                "proposed_by": "tester",
+                "change_payload": "{}",
+                "expected_version": 1,
+                "idempotency_key": idempotency_key,
+            },
+        )
+        assert first.status_code == 200
+
+        second = client.post(
+            "/governance/change-requests",
+            json={
+                "chart_id": seeded.chart_1_id,
+                "proposed_by": "tester",
+                "change_payload": "{}",
+                "expected_version": 1,
+                "idempotency_key": idempotency_key,
+            },
+        )
+
+        assert second.status_code == 409
+        body = second.json()
+        assert body["ok"] is False
+        assert body["error"]["code"] == "DUPLICATE_IDEMPOTENCY_KEY"
+        assert body["error"]["details"]["idempotency_key"] == idempotency_key
+    finally:
+        _delete_change_request_by_idempotency(idempotency_key)
+
+
+def test_post_change_requests_writes_single_audit_event(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    idempotency_key = f"post-audit-count-{uuid4().hex[:12]}"
+    try:
+        before_count = _count_audit_events_by_correlation_id(idempotency_key)
+        assert before_count == 0
+
+        res = client.post(
+            "/governance/change-requests",
+            json={
+                "chart_id": seeded.chart_1_id,
+                "proposed_by": "tester",
+                "change_payload": "{}",
+                "expected_version": 1,
+                "idempotency_key": idempotency_key,
+            },
+        )
+        assert res.status_code == 200
+
+        after_count = _count_audit_events_by_correlation_id(idempotency_key)
+        assert after_count == 1
+    finally:
+        _delete_change_request_by_idempotency(idempotency_key)
+
+
+def test_post_change_requests_audit_event_type_is_change_requested(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    idempotency_key = f"post-audit-type-{uuid4().hex[:12]}"
+    try:
+        res = client.post(
+            "/governance/change-requests",
+            json={
+                "chart_id": seeded.chart_1_id,
+                "proposed_by": "tester",
+                "change_payload": "{}",
+                "expected_version": 1,
+                "idempotency_key": idempotency_key,
+            },
+        )
+        assert res.status_code == 200
+        request_id = int(res.json()["data"]["request_id"])
+
+        latest_event = _find_latest_audit_event_by_correlation_id(idempotency_key)
+        assert latest_event is not None
+        event_type, target_type, target_id = latest_event
+        assert event_type == "change_requested"
+        assert target_type == "change_request"
+        assert target_id == request_id
+    finally:
+        _delete_change_request_by_idempotency(idempotency_key)

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -119,15 +119,17 @@ def _update_change_request_status(request_id: int, status: str) -> None:
         con.close()
 
 
-def _cleanup_seeded(chart_set_id: int, request_ids: tuple[int, int, int]) -> None:
+def _cleanup_seeded(chart_set_id: int | None, request_ids: list[int]) -> None:
     con = _connect(MAIN_DB)
     try:
-        con.execute(
-            "DELETE FROM GovernanceChangeRequests WHERE id IN (?, ?, ?)",
-            request_ids,
-        )
-        con.execute("DELETE FROM ChartsV2 WHERE chart_set_id = ?", (chart_set_id,))
-        con.execute("DELETE FROM ChartSet WHERE chart_set_id = ?", (chart_set_id,))
+        if request_ids:
+            con.executemany(
+                "DELETE FROM GovernanceChangeRequests WHERE id = ?",
+                [(request_id,) for request_id in request_ids],
+            )
+        if chart_set_id is not None:
+            con.execute("DELETE FROM ChartsV2 WHERE chart_set_id = ?", (chart_set_id,))
+            con.execute("DELETE FROM ChartSet WHERE chart_set_id = ?", (chart_set_id,))
         con.commit()
     finally:
         con.close()
@@ -195,34 +197,42 @@ def _find_latest_audit_event_by_correlation_id(correlation_id: str) -> tuple[str
 
 @pytest.fixture
 def seeded_change_requests_context() -> Iterator[SeededChangeRequestsContext]:
-    _init_schema(MAIN_DB)
-    suffix = uuid4().hex[:10]
-    now = datetime.now(UTC).isoformat()
-    chart_set_id = _insert_chart_set(now, suffix)
-    chart_1 = _insert_chart(chart_set_id, suffix, "param_a")
-    chart_2 = _insert_chart(chart_set_id, suffix, "param_b")
-
-    req_pending_chart_1 = _insert_change_request(
-        chart_id=chart_1,
-        proposed_by="alice",
-        proposed_at="2026-05-01T00:00:00.000Z",
-        idempotency_key=f"{suffix}-k1",
-    )
-    req_approved_chart_1 = _insert_change_request(
-        chart_id=chart_1,
-        proposed_by="bob",
-        proposed_at="2026-05-02T00:00:00.000Z",
-        idempotency_key=f"{suffix}-k2",
-    )
-    req_pending_chart_2 = _insert_change_request(
-        chart_id=chart_2,
-        proposed_by="carol",
-        proposed_at="2026-05-03T00:00:00.000Z",
-        idempotency_key=f"{suffix}-k3",
-    )
-    _update_change_request_status(req_approved_chart_1, "approved")
+    chart_set_id: int | None = None
+    chart_1: int | None = None
+    chart_2: int | None = None
+    created_request_ids: list[int] = []
 
     try:
+        _init_schema(MAIN_DB)
+        suffix = uuid4().hex[:10]
+        now = datetime.now(UTC).isoformat()
+        chart_set_id = _insert_chart_set(now, suffix)
+        chart_1 = _insert_chart(chart_set_id, suffix, "param_a")
+        chart_2 = _insert_chart(chart_set_id, suffix, "param_b")
+
+        req_pending_chart_1 = _insert_change_request(
+            chart_id=chart_1,
+            proposed_by="alice",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            idempotency_key=f"{suffix}-k1",
+        )
+        created_request_ids.append(req_pending_chart_1)
+        req_approved_chart_1 = _insert_change_request(
+            chart_id=chart_1,
+            proposed_by="bob",
+            proposed_at="2026-05-02T00:00:00.000Z",
+            idempotency_key=f"{suffix}-k2",
+        )
+        created_request_ids.append(req_approved_chart_1)
+        req_pending_chart_2 = _insert_change_request(
+            chart_id=chart_2,
+            proposed_by="carol",
+            proposed_at="2026-05-03T00:00:00.000Z",
+            idempotency_key=f"{suffix}-k3",
+        )
+        created_request_ids.append(req_pending_chart_2)
+        _update_change_request_status(req_approved_chart_1, "approved")
+
         yield SeededChangeRequestsContext(
             chart_1_id=chart_1,
             chart_2_id=chart_2,
@@ -231,10 +241,7 @@ def seeded_change_requests_context() -> Iterator[SeededChangeRequestsContext]:
             request_pending_chart_2=req_pending_chart_2,
         )
     finally:
-        _cleanup_seeded(
-            chart_set_id,
-            (req_pending_chart_1, req_approved_chart_1, req_pending_chart_2),
-        )
+        _cleanup_seeded(chart_set_id, created_request_ids)
 
 
 def test_get_change_requests_returns_empty_list_when_no_match(client: TestClient) -> None:
@@ -319,6 +326,22 @@ def test_get_change_requests_filters_by_from_to(
         seeded.request_pending_chart_2,
         seeded.request_approved_chart_1,
     ]
+
+
+def test_get_change_requests_invalid_datetime_returns_422(client: TestClient) -> None:
+    res = client.get(
+        "/governance/change-requests",
+        params={
+            "from_ts": "invalid-date",
+            "to_ts": "2026-13-01T00:00:00Z",
+        },
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(
+        res.json(),
+        expected_loc_fragment="from_ts",
+    )
 
 
 def test_get_change_requests_applies_limit(

--- a/tests/db_api/test_governance_repository.py
+++ b/tests/db_api/test_governance_repository.py
@@ -96,6 +96,27 @@ def test_init_schema_does_not_alter_existing_columns(db_path: Path) -> None:
 class TestGovernanceChangeRequestRepository:
     repo = GovernanceChangeRequestRepository()
 
+    def _create_request(
+        self,
+        con: sqlite3.Connection,
+        *,
+        chart_id: int,
+        proposed_by: str,
+        proposed_at: str,
+        idempotency_key: str,
+    ) -> int:
+        rid = self.repo.create(
+            con,
+            chart_id=chart_id,
+            proposed_by=proposed_by,
+            proposed_at=proposed_at,
+            change_payload="{}",
+            expected_version=1,
+            idempotency_key=idempotency_key,
+        )
+        con.commit()
+        return rid
+
     def test_create_and_find_by_id(self, con: sqlite3.Connection) -> None:
         cid = _chart_id(con)
         new_id = self.repo.create(
@@ -166,6 +187,118 @@ class TestGovernanceChangeRequestRepository:
                 expected_version=1,
                 idempotency_key="dup-key",
             )
+
+    def test_list_returns_empty_when_no_records(self, con: sqlite3.Connection) -> None:
+        rows = self.repo.list(con)
+        assert rows == []
+
+    def test_list_filters_by_status_and_chart_id(self, con: sqlite3.Connection) -> None:
+        chart_1 = _chart_id(con)
+        chart_2_row_id = con.execute(
+            """
+            INSERT INTO ChartsV2
+                (chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                 step_no, feature_type, updated_at)
+            VALUES (1, 'T01', 'C01', 'R01', 'param2', 2, 'mean', '2026-01-01T00:00:00.000Z')
+            """
+        ).lastrowid
+        if chart_2_row_id is None:
+            raise RuntimeError("Failed to insert chart row for test")
+        chart_2 = int(chart_2_row_id)
+        con.commit()
+
+        req_1 = self._create_request(
+            con,
+            chart_id=chart_1,
+            proposed_by="alice",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            idempotency_key="list-key-1",
+        )
+        req_2 = self._create_request(
+            con,
+            chart_id=chart_1,
+            proposed_by="bob",
+            proposed_at="2026-05-01T01:00:00.000Z",
+            idempotency_key="list-key-2",
+        )
+        req_3 = self._create_request(
+            con,
+            chart_id=chart_2,
+            proposed_by="carol",
+            proposed_at="2026-05-01T02:00:00.000Z",
+            idempotency_key="list-key-3",
+        )
+        self.repo.update_status(con, req_2, "approved")
+        con.commit()
+
+        rows = self.repo.list(con, status="pending", chart_id=chart_1)
+
+        assert [r.id for r in rows] == [req_1]
+        assert all(r.status == "pending" for r in rows)
+        assert all(r.chart_id == chart_1 for r in rows)
+        assert req_3 not in [r.id for r in rows]
+
+    def test_list_filters_by_from_to(self, con: sqlite3.Connection) -> None:
+        chart_id = _chart_id(con)
+        req_1 = self._create_request(
+            con,
+            chart_id=chart_id,
+            proposed_by="alice",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            idempotency_key="range-key-1",
+        )
+        req_2 = self._create_request(
+            con,
+            chart_id=chart_id,
+            proposed_by="bob",
+            proposed_at="2026-05-02T00:00:00.000Z",
+            idempotency_key="range-key-2",
+        )
+        req_3 = self._create_request(
+            con,
+            chart_id=chart_id,
+            proposed_by="carol",
+            proposed_at="2026-05-03T00:00:00.000Z",
+            idempotency_key="range-key-3",
+        )
+
+        rows = self.repo.list(
+            con,
+            from_ts="2026-05-02T00:00:00.000Z",
+            to_ts="2026-05-03T00:00:00.000Z",
+        )
+
+        assert [r.id for r in rows] == [req_3, req_2]
+        assert req_1 not in [r.id for r in rows]
+
+    def test_list_applies_limit_and_offset(self, con: sqlite3.Connection) -> None:
+        chart_id = _chart_id(con)
+        self._create_request(
+            con,
+            chart_id=chart_id,
+            proposed_by="alice",
+            proposed_at="2026-05-01T00:00:00.000Z",
+            idempotency_key="page-key-1",
+        )
+        req_2 = self._create_request(
+            con,
+            chart_id=chart_id,
+            proposed_by="bob",
+            proposed_at="2026-05-02T00:00:00.000Z",
+            idempotency_key="page-key-2",
+        )
+        self._create_request(
+            con,
+            chart_id=chart_id,
+            proposed_by="carol",
+            proposed_at="2026-05-03T00:00:00.000Z",
+            idempotency_key="page-key-3",
+        )
+
+        rows = self.repo.list(con, limit=1, offset=1)
+
+        assert len(rows) == 1
+        assert rows[0].id == req_2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- POST /governance/change-requests を実装（DBTaskRunner 経由、409 duplicate idempotency envelope、監査イベント記録）
- GET /governance/change-requests を実装（read-only 直接接続、status/chart_id/from_ts/to_ts/limit/offset）
- GovernanceChangeRequestRepository.list() を追加（フィルタ、ページネーション、0件時空配列）
- ChangeRequestIn / ChangeRequestsQuery を追加（JSONパース検証、datetime クエリ検証）
- #141 の checklist/decision-log と関連 docs を更新

## Tests
- pytest tests/db_api/test_db_api_governance_change_requests_endpoint.py -q
- pytest tests/db_api/test_governance_repository.py -q
- pytest tests/db_api/test_db_api_charts_history_endpoint.py tests/judge/test_db_api_judge_results_endpoint.py -q

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 実装概要（短縮）
Issue #141 のガバナンス変更申請エンドポイントを実装（POST /governance/change-requests、GET /governance/change-requests）。書き込みは DBTaskRunner 経由でトランザクション内に実行、読み取りは read-only 直接接続で分離。監査イベントを記録し、idempotency/envelope の重複は 409 とする。GET は status, chart_id, from_ts/to_ts のフィルタと limit/offset ページネーションを提供し、0件時は ok=true, data=[] を返す。docs（db-api-endpoints.md、chart-governance-playbook.md、decision-log.md）を更新。

### 主要変更点（箇条書き）
- POST /governance/change-requests
  - 入力検証: ChangeRequestIn（chart_id, proposed_by, change_payload の JSON 検証, expected_version, idempotency_key）
  - 書き込みは DBTaskRunner の write（トランザクション内）、成功時に {request_id, status="pending"} を返却
  - idempotency_key 重複で 409 を返す（エンベロープ契約）
  - 監査イベント記録（event_type: "change_requested", correlation_id = idempotency_key）
  - 存在しない chart_id は 404 を返す（関連コミットで明示的にハンドリング）
- GET /governance/change-requests
  - _connect_readonly による直接読み取り（読み書き経路を分離）
  - フィルタ: status, chart_id, from_ts/to_ts（datetime のタイムゾーン検証あり）
  - ページネーション: limit (1–500, default 100), offset (default 0)
  - 0件時は ok=true, data=[] を返す
- リポジトリ/スキーマ
  - GovernanceChangeRequestRepository.list() を追加（動的 WHERE、フィルタ・limit/offset）
  - ChangeRequestIn / ChangeRequestsQuery を追加（JSON パース検証、timestamp 範囲／タイムゾーン検証）
- ドキュメント
  - db-api-endpoints.md, chart-governance-playbook.md, decision-log.md を更新（エンドポイント仕様・設計/運用判断の反映）
- テスト
  - tests/db_api/test_db_api_governance_change_requests_endpoint.py：POST/GET の多数ケース、監査イベント検証、idempotency 重複、404（非存在 chart_id）などを追加
  - tests/db_api/test_governance_repository.py：Repository.list のフィルタ・ページネーション検証

### テスト網羅（短評）
- カバー済み主要ケース:
  - POST 正常系（request_id/status 返却）、422（必須欠如・chart_id 非整数）、409（idempotency 重複）、404（存在しない chart_id）
  - GET: 空結果、status/chart_id/from_ts/to_ts フィルタ、limit/offset の動作と境界系テスト
  - 監査イベントについては、POST 成功でイベントが 1 件書かれることを検証するテストあり
- 追加テストが既に含まれているため基本的な契約要件はカバーされている印象

### リスク・テストギャップ（要注意、短く）
1. change_payload の「無効な JSON」を明確に検証するテストが見当たらない（ChangeRequestIn に JSON 検証はあるが、失敗パスの専用テストが不足している可能性）。  
2. from_ts/to_ts の境界・形式の網羅が限定的：ナイーブな（タイムゾーン無し）datetime 拒否や from_ts > to_ts の明示的なエラーケースの追加確認を推奨。  
3. 監査イベントのトランザクション境界（イベント書き込みが同一トランザクション内かどうか）に関する運用リスク。現在のテストは「イベントが書かれる」ことを確認しているが、ロールバック時の整合性（イベントのみ残る等）を検証するテストは無い。  
4. その他の DB 障害／別種の IntegrityError 発生時の HTTP エラーハンドリング一貫性をさらに強化する余地あり。

### 推奨アクション（短く）
- 無効 JSON の投げ込みケース、from_ts/to_ts の無効レンジ・タイムゾーン不整合、およびロールバック時の監査イベント整合性（イベントが独立して残らないこと）の追加テストを実装すること。  
- トランザクション内での監査イベント扱い（書き込みタイミング）についてチームで意図を確認し、期待動作をドキュメント化してテスト化すること。  
- DB/トランザクション障害発生時のエラーハンドリングポリシーを再確認し、必要に応じてエラー応答の正規化テストを追加すること。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->