### PR TITLE
fix(db_api): align change-request validation with decision log

### DIFF
--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -491,6 +491,14 @@ def _is_governance_change_request_chart_fk_error(error: sqlite3.IntegrityError) 
     return "foreign key constraint failed" in str(error).lower()
 
 
+class _GovernanceChangeRequestIdempotencyConflict(Exception):
+    """change-request 作成時の重複 idempotency_key を表す内部例外。"""
+
+
+class _GovernanceChangeRequestChartFkViolation(Exception):
+    """change-request 作成時の chart_id 外部キー違反を表す内部例外。"""
+
+
 def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
     """ProcessInfo.raw_csv_path からドリルダウン表示用の波形プレビューを返す。
 
@@ -823,15 +831,22 @@ def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep
         con = _connect(MAIN_DB)
         try:
             con.execute("BEGIN")
-            request_id = _governance_change_request_repository.create(
-                con,
-                chart_id=payload.chart_id,
-                proposed_by=payload.proposed_by,
-                proposed_at=proposed_at,
-                change_payload=payload.change_payload,
-                expected_version=payload.expected_version,
-                idempotency_key=payload.idempotency_key,
-            )
+            try:
+                request_id = _governance_change_request_repository.create(
+                    con,
+                    chart_id=payload.chart_id,
+                    proposed_by=payload.proposed_by,
+                    proposed_at=proposed_at,
+                    change_payload=payload.change_payload,
+                    expected_version=payload.expected_version,
+                    idempotency_key=payload.idempotency_key,
+                )
+            except sqlite3.IntegrityError as e:
+                if _is_duplicate_change_request_idempotency_error(e):
+                    raise _GovernanceChangeRequestIdempotencyConflict from e
+                if _is_governance_change_request_chart_fk_error(e):
+                    raise _GovernanceChangeRequestChartFkViolation from e
+                raise
 
             _audit_event_writer.write(
                 con,
@@ -856,22 +871,20 @@ def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep
     try:
         data = runner.submit("write", _write)
         return {"ok": True, "data": data}
-    except sqlite3.IntegrityError as e:
-        if _is_duplicate_change_request_idempotency_error(e):
-            return _duplicate_idempotency_error_response(
-                idempotency_key=payload.idempotency_key,
-            )
-        if _is_governance_change_request_chart_fk_error(e):
-            return _validation_error_response(
-                issues=[
-                    {
-                        "loc": ["body", "chart_id"],
-                        "msg": "chart_id must reference an existing chart",
-                        "type": "value_error",
-                    }
-                ]
-            )
-        _raise_api_error(operation="POST /governance/change-requests", error=e)
+    except _GovernanceChangeRequestIdempotencyConflict:
+        return _duplicate_idempotency_error_response(
+            idempotency_key=payload.idempotency_key,
+        )
+    except _GovernanceChangeRequestChartFkViolation:
+        return _validation_error_response(
+            issues=[
+                {
+                    "loc": ["body", "chart_id"],
+                    "msg": "chart_id must reference an existing chart",
+                    "type": "value_error",
+                }
+            ]
+        )
     except Exception as e:
         _raise_api_error(operation="POST /governance/change-requests", error=e)
 

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -82,10 +82,6 @@ JUDGE_LEVEL_PATTERN = r"^(OK|WARN|NG)$"
 RESULT_ID_PATTERN = r"^JR_[0-9]+$"
 
 
-class ReferencedChartNotFoundError(LookupError):
-    """変更申請で参照した chart_id が存在しない場合に送出する。"""
-
-
 def _legacy_delete_headers(process_id: str | None) -> dict[str, str]:
     """旧 DELETE `/processes` の移行ヘッダを生成する。"""
     if process_id is None:
@@ -466,6 +462,21 @@ def _duplicate_idempotency_error_response(*, idempotency_key: str) -> JSONRespon
     )
 
 
+def _validation_error_response(*, issues: list[dict[str, object]]) -> JSONResponse:
+    """契約準拠の 422 validation error envelope を返す。"""
+    return JSONResponse(
+        status_code=422,
+        content={
+            "ok": False,
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "Validation error",
+                "details": {"issues": issues},
+            },
+        },
+    )
+
+
 def _is_duplicate_change_request_idempotency_error(error: sqlite3.IntegrityError) -> bool:
     """GovernanceChangeRequests.idempotency_key の UNIQUE 違反かを判定する。"""
     message = str(error)
@@ -473,6 +484,11 @@ def _is_duplicate_change_request_idempotency_error(error: sqlite3.IntegrityError
         "GovernanceChangeRequests.idempotency_key" in message
         or "idx_change_requests_idempotency" in message
     )
+
+
+def _is_governance_change_request_chart_fk_error(error: sqlite3.IntegrityError) -> bool:
+    """GovernanceChangeRequests.chart_id の外部キー制約違反かを判定する。"""
+    return "foreign key constraint failed" in str(error).lower()
 
 
 def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
@@ -807,13 +823,6 @@ def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep
         con = _connect(MAIN_DB)
         try:
             con.execute("BEGIN")
-            chart_exists = con.execute(
-                "SELECT 1 FROM ChartsV2 WHERE id = ? LIMIT 1",
-                (payload.chart_id,),
-            ).fetchone()
-            if chart_exists is None:
-                raise ReferencedChartNotFoundError(payload.chart_id)
-
             request_id = _governance_change_request_repository.create(
                 con,
                 chart_id=payload.chart_id,
@@ -847,15 +856,20 @@ def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep
     try:
         data = runner.submit("write", _write)
         return {"ok": True, "data": data}
-    except ReferencedChartNotFoundError:
-        return _not_found_error_response(
-            message="chart not found",
-            details={"chart_id": str(payload.chart_id)},
-        )
     except sqlite3.IntegrityError as e:
         if _is_duplicate_change_request_idempotency_error(e):
             return _duplicate_idempotency_error_response(
                 idempotency_key=payload.idempotency_key,
+            )
+        if _is_governance_change_request_chart_fk_error(e):
+            return _validation_error_response(
+                issues=[
+                    {
+                        "loc": ["body", "chart_id"],
+                        "msg": "chart_id must reference an existing chart",
+                        "type": "value_error",
+                    }
+                ]
             )
         _raise_api_error(operation="POST /governance/change-requests", error=e)
     except Exception as e:

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -555,7 +555,9 @@ def test_post_change_requests_returns_409_for_duplicate_idempotency_key(
         _delete_change_request_by_idempotency(idempotency_key)
 
 
-def test_post_change_requests_returns_404_for_missing_chart_id(client: TestClient) -> None:
+def test_post_change_requests_accepts_missing_chart_id_for_apply_phase_validation(
+    client: TestClient,
+) -> None:
     idempotency_key = f"post-missing-chart-{uuid4().hex[:12]}"
     try:
         res = client.post(
@@ -569,11 +571,12 @@ def test_post_change_requests_returns_404_for_missing_chart_id(client: TestClien
             },
         )
 
-        assert res.status_code == 404
-        body = res.json()
-        assert body["ok"] is False
-        assert body["error"]["code"] == "NOT_FOUND"
-        assert body["error"]["details"]["chart_id"] == "9223372036854775807"
+        assert res.status_code == 422
+        assert_validation_error_envelope(
+            res.json(),
+            expected_loc_fragment="chart_id",
+            expected_message_fragment="existing chart",
+        )
     finally:
         _delete_change_request_by_idempotency(idempotency_key)
 


### PR DESCRIPTION
## Summary
- Align POST /governance/change-requests with decision-log guidance.
- Remove the pre-insert 404 branch for missing chart_id.
- Normalize foreign-key failures to a 422 validation envelope so the endpoint no longer returns 404 for this case.

## Verification
- pytest -v tests/db_api/test_db_api_governance_change_requests_endpoint.py

## Notes
- This keeps the implementation aligned with the recorded decision while preserving the existing DB schema constraint behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 概要
POST /governance/change-requests の検証動作を決定ログに合わせて修正。事前の chart 存在チェック（404返却）を削除し、外部キー違反は 422 の validation envelope、idempotency_key 重複は 409 の構造化エラーにマップするように変更。DB スキーマの制約そのものは維持。

## 主な変更点
- POST /governance/change-requests: 事前 chart 存在チェックと ReferencedChartNotFoundError による 404 を削除。トランザクション内で作成→監査イベント書込→作成レコード再取得を実施し、status を付与して応答。
- エラー分類:
  - idempotency_key の UNIQUE 違反 → 409（重複エンベロープ）
  - chart_id の外部キー違反 → 422（validation envelope）
  - これらは sqlite3.IntegrityError を内部で判定して変換
- UTC 時刻正規化の返却形式を ISO 文字列から to_utc_millis(raw.isoformat()) に変更
- 新規ヘルパと内部例外追加（重複判定、chart FK 判定、422/409 レスポンス生成など）
- GET /governance/change-requests: readonly 接続で一覧取得（フィルタ / ページネーション対応）

## テスト
- 追加テストモジュールで GET/POST に対する約18件のケースを追加
  - GET: 空レスポンス、status/chart_id/時間フィルタ、limit/offset 検証、無効な日時での 422
  - POST: 成功時の request_id と pending status、idempotency_key 必須/重複での 409、chart_id 型検証/外部キー違反での 422、監査イベントが単一で正しい内容で書き込まれることを検証
- テスト実行: pytest -v tests/db_api/test_db_api_governance_change_requests_endpoint.py

## リスク
- 互換性: 以前は chart_id の欠如や FK 失敗で 404 を返していた呼び出し元のハンドリングが変わる（404 → 422/409）。クライアント側調整が必要な可能性。
- FK エラー判定: sqlite3.IntegrityError をメッセージ等で判定しているため、DB 実装やメッセージの変化に弱い（判定ロジックの堅牢性がリスク）。
- 並行性: idempotency_key の競合やトランザクション内での監査イベント処理を含むため、並行 POST におけるレース条件の影響が残る可能性。

## テストギャップ
- 監査イベント書込後にトランザクションがロールバックされた場合の振る舞いを明示的に検証するテストが不足
- 外部キー違反判定ロジック（DB のエラーメッセージ依存）に対する耐性テストが不足
- 高並列負荷下での idempotency_key 重複競合（レース条件）に関する負荷/競合テストが存在しない
- GET の時間フィルタに関する境界（inclusive/exclusive）テストが不十分

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/197)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->