### PR TITLE
feat(db_api): implement governance approve/apply endpoints for #142

### DIFF
--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -40,7 +40,11 @@ from .chart_repository import (
 )
 from .datetime_util import to_utc_millis
 from .db import MAIN_DB, TEMP_DB, _connect, _connect_readonly, _init_schema
-from .governance_repository import GovernanceChangeRequestRepository
+from .governance_repository import (
+    GovernanceApprovalsRepository,
+    GovernanceChangeRequestRepository,
+    GovernanceNotFoundError,
+)
 from .judge_repository import (
     JudgeDataCorruptionError,
     JudgeRepository,
@@ -48,6 +52,7 @@ from .judge_repository import (
 )
 from .schemas import (
     AggregateWriteIn,
+    ChangeRequestApproveIn,
     ChangeRequestIn,
     ChangeRequestsQuery,
     ParameterIn,
@@ -258,6 +263,7 @@ RunnerDep = Annotated[DBTaskRunner, Depends(get_runner)]
 _chart_repository = ChartRepository()
 _judge_repository = JudgeRepository()
 _governance_change_request_repository = GovernanceChangeRequestRepository()
+_governance_approvals_repository = GovernanceApprovalsRepository()
 _audit_event_writer = AuditEventWriter()
 
 
@@ -462,6 +468,21 @@ def _duplicate_idempotency_error_response(*, idempotency_key: str) -> JSONRespon
     )
 
 
+def _conflict_error_response(*, code: str, message: str, details: dict[str, str]) -> JSONResponse:
+    """契約準拠の 409 error envelope を返す。"""
+    return JSONResponse(
+        status_code=409,
+        content={
+            "ok": False,
+            "error": {
+                "code": code,
+                "message": message,
+                "details": details,
+            },
+        },
+    )
+
+
 def _validation_error_response(*, issues: list[dict[str, object]]) -> JSONResponse:
     """契約準拠の 422 validation error envelope を返す。"""
     return JSONResponse(
@@ -497,6 +518,14 @@ class _GovernanceChangeRequestIdempotencyConflict(Exception):
 
 class _GovernanceChangeRequestChartFkViolation(Exception):
     """change-request 作成時の chart_id 外部キー違反を表す内部例外。"""
+
+
+class _GovernanceApproveAlreadyApproved(Exception):
+    """approve 対象が既に approved の場合に送出する内部例外。"""
+
+
+class _GovernanceApproveInvalidState(Exception):
+    """approve 対象の status が pending 以外の場合に送出する内部例外。"""
 
 
 def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
@@ -887,6 +916,85 @@ def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep
         )
     except Exception as e:
         _raise_api_error(operation="POST /governance/change-requests", error=e)
+
+
+@app.post("/governance/change-requests/{request_id}/approve")
+def approve_governance_change_request(
+    payload: ChangeRequestApproveIn,
+    runner: RunnerDep,
+    request_id: int = Path(ge=1),
+):
+    """ガバナンス変更申請を承認する。"""
+
+    approved_at = to_utc_millis(datetime.now(UTC).isoformat())
+
+    def _write() -> dict[str, int | str]:
+        con = _connect(MAIN_DB)
+        try:
+            con.execute("BEGIN")
+            row = _governance_change_request_repository.find_by_id(con, request_id)
+
+            if row.status == "approved":
+                raise _GovernanceApproveAlreadyApproved
+            if row.status != "pending":
+                raise _GovernanceApproveInvalidState
+
+            _governance_approvals_repository.create(
+                con,
+                request_id=request_id,
+                approved_by=payload.approved_by,
+                approved_by_role=payload.approved_by_role,
+                approved_at=approved_at,
+                comment=payload.comment,
+            )
+            _governance_change_request_repository.update_status(
+                con,
+                record_id=request_id,
+                new_status="approved",
+            )
+            _audit_event_writer.write(
+                con,
+                event_type="change_approved",
+                actor=payload.approved_by,
+                actor_role=payload.approved_by_role,
+                target_type="change_request",
+                target_id=request_id,
+                occurred_at=approved_at,
+                correlation_id=f"request:{request_id}",
+            )
+            con.commit()
+            return {"request_id": request_id, "status": "approved"}
+        except Exception:
+            con.rollback()
+            raise
+        finally:
+            con.close()
+
+    try:
+        data = runner.submit("write", _write)
+        return {"ok": True, "data": data}
+    except GovernanceNotFoundError:
+        return _not_found_error_response(
+            message="change request not found",
+            details={"request_id": str(request_id)},
+        )
+    except _GovernanceApproveAlreadyApproved:
+        return _conflict_error_response(
+            code="ALREADY_APPROVED",
+            message="change request is already approved",
+            details={"request_id": str(request_id)},
+        )
+    except _GovernanceApproveInvalidState:
+        return _conflict_error_response(
+            code="INVALID_STATUS_TRANSITION",
+            message="only pending change request can be approved",
+            details={"request_id": str(request_id)},
+        )
+    except Exception as e:
+        _raise_api_error(
+            operation="POST /governance/change-requests/{request_id}/approve",
+            error=e,
+        )
 
 
 @app.post("/processes")

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os as _os
 import pathlib
@@ -52,6 +53,7 @@ from .judge_repository import (
 )
 from .schemas import (
     AggregateWriteIn,
+    ChangeRequestApplyIn,
     ChangeRequestApproveIn,
     ChangeRequestIn,
     ChangeRequestsQuery,
@@ -483,6 +485,23 @@ def _conflict_error_response(*, code: str, message: str, details: dict[str, str]
     )
 
 
+def _bad_request_error_response(
+    *, code: str, message: str, details: dict[str, str]
+) -> JSONResponse:
+    """契約準拠の 400 error envelope を返す。"""
+    return JSONResponse(
+        status_code=400,
+        content={
+            "ok": False,
+            "error": {
+                "code": code,
+                "message": message,
+                "details": details,
+            },
+        },
+    )
+
+
 def _validation_error_response(*, issues: list[dict[str, object]]) -> JSONResponse:
     """契約準拠の 422 validation error envelope を返す。"""
     return JSONResponse(
@@ -526,6 +545,81 @@ class _GovernanceApproveAlreadyApproved(Exception):
 
 class _GovernanceApproveInvalidState(Exception):
     """approve 対象の status が pending 以外の場合に送出する内部例外。"""
+
+
+class _GovernanceApplyInvalidState(Exception):
+    """apply 対象の status が approved 以外の場合に送出する内部例外。"""
+
+
+class _GovernanceApplyChartNotFound(Exception):
+    """apply 対象 chart が存在しない場合に送出する内部例外。"""
+
+
+class _GovernanceApplyVersionConflict(Exception):
+    """expected_version と current.version が不一致の場合に送出する内部例外。"""
+
+    def __init__(self, *, current_version: int, current_updated_at: str, chart_id: int) -> None:
+        self.current_version = current_version
+        self.current_updated_at = current_updated_at
+        self.chart_id = chart_id
+
+
+class _GovernanceApplyValidationError(Exception):
+    """apply payload がしきい値整合性を満たさない場合に送出する内部例外。"""
+
+    def __init__(self, *, message: str) -> None:
+        self.message = message
+
+
+def _parse_threshold_patch(change_payload: str) -> dict[str, float | None]:
+    """change_payload からしきい値更新パッチを抽出する。"""
+    payload = json.loads(change_payload)
+    if not isinstance(payload, dict):
+        raise _GovernanceApplyValidationError(message="change_payload must be an object")
+
+    aliases = {
+        "warn_low": "warn_low",
+        "warning_lcl": "warn_low",
+        "warn_high": "warn_high",
+        "warning_ucl": "warn_high",
+        "crit_low": "crit_low",
+        "critical_lcl": "crit_low",
+        "crit_high": "crit_high",
+        "critical_ucl": "crit_high",
+    }
+    patch: dict[str, float | None] = {}
+    for key, value in payload.items():
+        mapped = aliases.get(str(key))
+        if mapped is None:
+            continue
+        if value is None:
+            patch[mapped] = None
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise _GovernanceApplyValidationError(message=f"{key} must be a number or null")
+        numeric = float(value)
+        if numeric != numeric or numeric in (float("inf"), float("-inf")):
+            raise _GovernanceApplyValidationError(message=f"{key} must be finite")
+        patch[mapped] = numeric
+    return patch
+
+
+def _validate_threshold_consistency(
+    *,
+    warn_low: float | None,
+    warn_high: float | None,
+    crit_low: float | None,
+    crit_high: float | None,
+) -> None:
+    """しきい値の大小関係を検証する。"""
+    if warn_low is not None and warn_high is not None and warn_low > warn_high:
+        raise _GovernanceApplyValidationError(
+            message="warn_low must be less than or equal to warn_high"
+        )
+    if crit_low is not None and crit_high is not None and crit_low > crit_high:
+        raise _GovernanceApplyValidationError(
+            message="crit_low must be less than or equal to crit_high"
+        )
 
 
 def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
@@ -993,6 +1087,233 @@ def approve_governance_change_request(
     except Exception as e:
         _raise_api_error(
             operation="POST /governance/change-requests/{request_id}/approve",
+            error=e,
+        )
+
+
+@app.post("/governance/change-requests/{request_id}/apply")
+def apply_governance_change_request(
+    payload: ChangeRequestApplyIn,
+    runner: RunnerDep,
+    request_id: int = Path(ge=1),
+):
+    """承認済みのガバナンス変更申請を反映する。"""
+
+    applied_at = to_utc_millis(datetime.now(UTC).isoformat())
+
+    def _write() -> dict[str, object]:
+        con = _connect(MAIN_DB)
+        try:
+            con.execute("BEGIN")
+            req = _governance_change_request_repository.find_by_id(con, request_id)
+            if req.status != "approved":
+                raise _GovernanceApplyInvalidState
+
+            chart_row = con.execute(
+                """
+                SELECT
+                    id, chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                    step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                    version, updated_at
+                FROM ChartsV2
+                WHERE id = ?
+                """,
+                (req.chart_id,),
+            ).fetchone()
+            if chart_row is None:
+                raise _GovernanceApplyChartNotFound
+
+            (
+                chart_id,
+                chart_set_id,
+                tool_id,
+                chamber_id,
+                recipe_id,
+                parameter,
+                step_no,
+                feature_type,
+                old_warn_low,
+                old_warn_high,
+                old_crit_low,
+                old_crit_high,
+                current_version,
+                current_updated_at,
+            ) = chart_row
+
+            if int(current_version) != int(req.expected_version):
+                raise _GovernanceApplyVersionConflict(
+                    current_version=int(current_version),
+                    current_updated_at=str(current_updated_at),
+                    chart_id=int(chart_id),
+                )
+
+            patch = _parse_threshold_patch(req.change_payload)
+            new_warn_low = patch.get("warn_low", old_warn_low)
+            new_warn_high = patch.get("warn_high", old_warn_high)
+            new_crit_low = patch.get("crit_low", old_crit_low)
+            new_crit_high = patch.get("crit_high", old_crit_high)
+
+            _validate_threshold_consistency(
+                warn_low=new_warn_low,
+                warn_high=new_warn_high,
+                crit_low=new_crit_low,
+                crit_high=new_crit_high,
+            )
+
+            is_noop = (
+                old_warn_low == new_warn_low
+                and old_warn_high == new_warn_high
+                and old_crit_low == new_crit_low
+                and old_crit_high == new_crit_high
+            )
+
+            resulting_version = int(current_version)
+            if not is_noop:
+                resulting_version = int(current_version) + 1
+                con.execute(
+                    """
+                    UPDATE ChartsV2
+                    SET warn_low = ?, warn_high = ?, crit_low = ?, crit_high = ?,
+                        version = ?, updated_at = ?, updated_by = ?,
+                        update_reason = ?, update_source = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        new_warn_low,
+                        new_warn_high,
+                        new_crit_low,
+                        new_crit_high,
+                        resulting_version,
+                        applied_at,
+                        payload.applied_by,
+                        payload.reason,
+                        "governance_apply",
+                        chart_id,
+                    ),
+                )
+                con.execute(
+                    """
+                    INSERT INTO ChartsHistory(
+                        chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                        step_no, feature_type,
+                        old_warn_low, old_warn_high, old_crit_low, old_crit_high,
+                        new_warn_low, new_warn_high, new_crit_low, new_crit_high,
+                        changed_at, changed_by, change_reason, change_source, chart_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        chart_set_id,
+                        tool_id,
+                        chamber_id,
+                        recipe_id,
+                        parameter,
+                        step_no,
+                        feature_type,
+                        old_warn_low,
+                        old_warn_high,
+                        old_crit_low,
+                        old_crit_high,
+                        new_warn_low,
+                        new_warn_high,
+                        new_crit_low,
+                        new_crit_high,
+                        applied_at,
+                        payload.applied_by,
+                        payload.reason,
+                        "governance_apply",
+                        chart_id,
+                    ),
+                )
+
+            con.execute(
+                """
+                INSERT OR REPLACE INTO GovernanceApplyResults(
+                    request_id, applied_at, success, resulting_version,
+                    error_code, error_message
+                ) VALUES (?, ?, 1, ?, NULL, NULL)
+                """,
+                (request_id, applied_at, resulting_version),
+            )
+            _governance_change_request_repository.update_status(
+                con,
+                record_id=request_id,
+                new_status="applied",
+            )
+            _audit_event_writer.write(
+                con,
+                event_type="change_applied",
+                actor=payload.applied_by,
+                actor_role=payload.applied_by_role,
+                target_type="change_request",
+                target_id=request_id,
+                occurred_at=applied_at,
+                correlation_id=f"request:{request_id}",
+            )
+            con.commit()
+            return {
+                "request_id": request_id,
+                "status": "applied",
+                "resulting_version": resulting_version,
+                "noop": is_noop,
+            }
+        except Exception:
+            con.rollback()
+            raise
+        finally:
+            con.close()
+
+    try:
+        data = runner.submit("write", _write)
+        return {"ok": True, "data": data}
+    except GovernanceNotFoundError:
+        return _not_found_error_response(
+            message="change request not found",
+            details={"request_id": str(request_id)},
+        )
+    except _GovernanceApplyInvalidState:
+        return _conflict_error_response(
+            code="INVALID_STATUS_TRANSITION",
+            message="only approved change request can be applied",
+            details={"request_id": str(request_id)},
+        )
+    except _GovernanceApplyChartNotFound:
+        return _bad_request_error_response(
+            code="CHART_NOT_FOUND",
+            message="target chart not found",
+            details={"request_id": str(request_id)},
+        )
+    except _GovernanceApplyVersionConflict as e:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "ok": False,
+                "error": {
+                    "code": "STALE_EXPECTED_VERSION",
+                    "message": "expected_version does not match current version",
+                    "details": {
+                        "request_id": str(request_id),
+                        "current": {
+                            "chart_id": e.chart_id,
+                            "version": e.current_version,
+                            "updated_at": e.current_updated_at,
+                        },
+                    },
+                },
+            },
+        )
+    except _GovernanceApplyValidationError as e:
+        return _validation_error_response(
+            issues=[
+                {
+                    "loc": ["body", "change_payload"],
+                    "msg": e.message,
+                    "type": "value_error",
+                }
+            ]
+        )
+    except Exception as e:
+        _raise_api_error(
+            operation="POST /governance/change-requests/{request_id}/apply",
             error=e,
         )
 

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os as _os
 import pathlib
 import sqlite3
@@ -620,6 +621,18 @@ def _validate_threshold_consistency(
         raise _GovernanceApplyValidationError(
             message="crit_low must be less than or equal to crit_high"
         )
+    if crit_low is not None and warn_low is not None and crit_low > warn_low:
+        raise _GovernanceApplyValidationError(
+            message="crit_low must be less than or equal to warn_low"
+        )
+    if warn_high is not None and crit_high is not None and warn_high > crit_high:
+        raise _GovernanceApplyValidationError(
+            message="warn_high must be less than or equal to crit_high"
+        )
+    if crit_low is not None and warn_high is not None and crit_low > warn_high:
+        raise _GovernanceApplyValidationError(
+            message="crit_low must be less than or equal to warn_high"
+        )
 
 
 def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
@@ -1160,11 +1173,18 @@ def apply_governance_change_request(
                 crit_high=new_crit_high,
             )
 
+            def _thresh_eq(a: float | None, b: float | None) -> bool:
+                if a is None and b is None:
+                    return True
+                if a is None or b is None:
+                    return False
+                return math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-12)
+
             is_noop = (
-                old_warn_low == new_warn_low
-                and old_warn_high == new_warn_high
-                and old_crit_low == new_crit_low
-                and old_crit_high == new_crit_high
+                _thresh_eq(old_warn_low, new_warn_low)
+                and _thresh_eq(old_warn_high, new_warn_high)
+                and _thresh_eq(old_crit_low, new_crit_low)
+                and _thresh_eq(old_crit_high, new_crit_high)
             )
 
             resulting_version = int(current_version)

--- a/src/portfolio_fdc/db_api/schemas.py
+++ b/src/portfolio_fdc/db_api/schemas.py
@@ -141,3 +141,11 @@ class ChangeRequestsQuery(BaseModel):
         if self.from_ts is not None and self.to_ts is not None:
             validate_timestamp_range(self.from_ts, self.to_ts)
         return self
+
+
+class ChangeRequestApproveIn(BaseModel):
+    """`/governance/change-requests/{request_id}/approve` POST 用の入力モデル。"""
+
+    approved_by: str = Field(min_length=1, max_length=128)
+    approved_by_role: str = Field(min_length=1, max_length=64)
+    comment: str | None = Field(default=None, max_length=1000)

--- a/src/portfolio_fdc/db_api/schemas.py
+++ b/src/portfolio_fdc/db_api/schemas.py
@@ -149,3 +149,11 @@ class ChangeRequestApproveIn(BaseModel):
     approved_by: str = Field(min_length=1, max_length=128)
     approved_by_role: str = Field(min_length=1, max_length=64)
     comment: str | None = Field(default=None, max_length=1000)
+
+
+class ChangeRequestApplyIn(BaseModel):
+    """`/governance/change-requests/{request_id}/apply` POST 用の入力モデル。"""
+
+    applied_by: str = Field(min_length=1, max_length=128)
+    applied_by_role: str = Field(min_length=1, max_length=64)
+    reason: str | None = Field(default=None, max_length=1000)

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -262,15 +262,15 @@ def _update_chart_version(chart_id: int, version: int) -> None:
 
 def _force_change_request_chart_id(request_id: int, chart_id: int) -> None:
     con = _connect(MAIN_DB)
+    con.execute("PRAGMA foreign_keys = OFF")
     try:
-        con.execute("PRAGMA foreign_keys = OFF")
         con.execute(
             "UPDATE GovernanceChangeRequests SET chart_id = ? WHERE id = ?",
             (chart_id, request_id),
         )
-        con.execute("PRAGMA foreign_keys = ON")
         con.commit()
     finally:
+        con.execute("PRAGMA foreign_keys = ON")
         con.close()
 
 
@@ -621,6 +621,56 @@ def test_post_apply_change_requests_success_noop_does_not_add_history(
     assert body["data"]["noop"] is True
     assert _find_change_request_status(request_id) == "applied"
     assert _count_chart_history(chart_id) == before_history
+
+
+def test_post_apply_change_requests_success_with_threshold_change(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    chart_id = seeded.chart_1_id
+    idempotency_key = f"test-threshold-change-{uuid4().hex[:8]}"
+    previous_version = 1  # ChartsV2 version DEFAULT 1
+
+    request_id = _insert_change_request(
+        chart_id=chart_id,
+        proposed_by="test-user",
+        proposed_at="2026-05-10T00:00:00.000Z",
+        idempotency_key=idempotency_key,
+        change_payload='{"warn_low": 1.5}',
+        expected_version=previous_version,
+    )
+    _update_change_request_status(request_id, "approved")
+
+    try:
+        before_history = _count_chart_history(chart_id)
+
+        res = client.post(
+            f"/governance/change-requests/{request_id}/apply",
+            json={
+                "applied_by": "ops-user",
+                "applied_by_role": "ops",
+                "reason": "apply threshold change",
+            },
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert body["data"]["request_id"] == request_id
+        assert body["data"]["noop"] is False
+        assert body["data"]["status"] == "applied"
+        assert _find_change_request_status(request_id) == "applied"
+        assert _count_chart_history(chart_id) == before_history + 1
+        assert body["data"]["resulting_version"] > previous_version
+    finally:
+        con = _connect(MAIN_DB)
+        try:
+            con.execute("DELETE FROM ChartsHistory WHERE chart_id = ?", (chart_id,))
+            con.commit()
+        finally:
+            con.close()
+        _cleanup_seeded(None, [request_id])
 
 
 def test_post_apply_change_requests_returns_404_when_request_not_found(

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -124,6 +124,14 @@ def _cleanup_seeded(chart_set_id: int | None, request_ids: list[int]) -> None:
     try:
         if request_ids:
             con.executemany(
+                "DELETE FROM GovernanceApprovals WHERE request_id = ?",
+                [(request_id,) for request_id in request_ids],
+            )
+            con.executemany(
+                "DELETE FROM GovernanceApplyResults WHERE request_id = ?",
+                [(request_id,) for request_id in request_ids],
+            )
+            con.executemany(
                 "DELETE FROM GovernanceChangeRequests WHERE id = ?",
                 [(request_id,) for request_id in request_ids],
             )
@@ -146,6 +154,14 @@ def _delete_change_request_by_idempotency(idempotency_key: str) -> None:
             ).fetchall()
         ]
         if request_ids:
+            con.executemany(
+                "DELETE FROM GovernanceApprovals WHERE request_id = ?",
+                [(request_id,) for request_id in request_ids],
+            )
+            con.executemany(
+                "DELETE FROM GovernanceApplyResults WHERE request_id = ?",
+                [(request_id,) for request_id in request_ids],
+            )
             con.executemany(
                 "DELETE FROM GovernanceAuditEvents WHERE target_type = ? AND target_id = ?",
                 [("change_request", request_id) for request_id in request_ids],
@@ -191,6 +207,32 @@ def _find_latest_audit_event_by_correlation_id(correlation_id: str) -> tuple[str
         if row is None:
             return None
         return (str(row[0]), str(row[1]), int(row[2]))
+    finally:
+        con.close()
+
+
+def _find_change_request_status(request_id: int) -> str:
+    con = _connect(MAIN_DB)
+    try:
+        row = con.execute(
+            "SELECT status FROM GovernanceChangeRequests WHERE id = ?",
+            (request_id,),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("Change request not found")
+        return str(row[0])
+    finally:
+        con.close()
+
+
+def _find_approval_count(request_id: int) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        row = con.execute(
+            "SELECT COUNT(*) FROM GovernanceApprovals WHERE request_id = ?",
+            (request_id,),
+        ).fetchone()
+        return int(row[0])
     finally:
         con.close()
 
@@ -446,6 +488,74 @@ def test_post_change_requests_success_returns_request_id_and_pending_status(
         assert body["data"]["status"] == "pending"
     finally:
         _delete_change_request_by_idempotency(idempotency_key)
+
+
+def test_post_approve_change_requests_success_transitions_to_approved(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    request_id = seeded.request_pending_chart_1
+
+    res = client.post(
+        f"/governance/change-requests/{request_id}/approve",
+        json={
+            "approved_by": "ops-user",
+            "approved_by_role": "ops",
+            "comment": "looks good",
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"]["request_id"] == request_id
+    assert body["data"]["status"] == "approved"
+    assert _find_change_request_status(request_id) == "approved"
+    assert _find_approval_count(request_id) == 1
+
+
+def test_post_approve_change_requests_returns_404_when_request_not_found(
+    client: TestClient,
+) -> None:
+    request_id = 9223372036854775807
+
+    res = client.post(
+        f"/governance/change-requests/{request_id}/approve",
+        json={
+            "approved_by": "ops-user",
+            "approved_by_role": "ops",
+        },
+    )
+
+    assert res.status_code == 404
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "NOT_FOUND"
+    assert body["error"]["details"]["request_id"] == str(request_id)
+
+
+def test_post_approve_change_requests_returns_409_for_duplicate_approval(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    request_id = seeded.request_approved_chart_1
+
+    res = client.post(
+        f"/governance/change-requests/{request_id}/approve",
+        json={
+            "approved_by": "ops-user",
+            "approved_by_role": "ops",
+            "comment": "duplicate approval",
+        },
+    )
+
+    assert res.status_code == 409
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "ALREADY_APPROVED"
+    assert body["error"]["details"]["request_id"] == str(request_id)
 
 
 def test_post_change_requests_success_envelope_contract(

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -79,6 +79,8 @@ def _insert_change_request(
     proposed_by: str,
     proposed_at: str,
     idempotency_key: str,
+    change_payload: str = "{}",
+    expected_version: int = 1,
 ) -> int:
     con = _connect(MAIN_DB)
     try:
@@ -93,8 +95,8 @@ def _insert_change_request(
                 chart_id,
                 proposed_by,
                 proposed_at,
-                "{}",
-                1,
+                change_payload,
+                expected_version,
                 idempotency_key,
             ),
         )
@@ -233,6 +235,41 @@ def _find_approval_count(request_id: int) -> int:
             (request_id,),
         ).fetchone()
         return int(row[0])
+    finally:
+        con.close()
+
+
+def _count_chart_history(chart_id: int) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        row = con.execute(
+            "SELECT COUNT(*) FROM ChartsHistory WHERE chart_id = ?",
+            (chart_id,),
+        ).fetchone()
+        return int(row[0])
+    finally:
+        con.close()
+
+
+def _update_chart_version(chart_id: int, version: int) -> None:
+    con = _connect(MAIN_DB)
+    try:
+        con.execute("UPDATE ChartsV2 SET version = ? WHERE id = ?", (version, chart_id))
+        con.commit()
+    finally:
+        con.close()
+
+
+def _force_change_request_chart_id(request_id: int, chart_id: int) -> None:
+    con = _connect(MAIN_DB)
+    try:
+        con.execute("PRAGMA foreign_keys = OFF")
+        con.execute(
+            "UPDATE GovernanceChangeRequests SET chart_id = ? WHERE id = ?",
+            (chart_id, request_id),
+        )
+        con.execute("PRAGMA foreign_keys = ON")
+        con.commit()
     finally:
         con.close()
 
@@ -556,6 +593,163 @@ def test_post_approve_change_requests_returns_409_for_duplicate_approval(
     assert body["ok"] is False
     assert body["error"]["code"] == "ALREADY_APPROVED"
     assert body["error"]["details"]["request_id"] == str(request_id)
+
+
+def test_post_apply_change_requests_success_noop_does_not_add_history(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    request_id = seeded.request_approved_chart_1
+    chart_id = seeded.chart_1_id
+    before_history = _count_chart_history(chart_id)
+
+    res = client.post(
+        f"/governance/change-requests/{request_id}/apply",
+        json={
+            "applied_by": "ops-user",
+            "applied_by_role": "ops",
+            "reason": "apply no-op",
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"]["request_id"] == request_id
+    assert body["data"]["status"] == "applied"
+    assert body["data"]["noop"] is True
+    assert _find_change_request_status(request_id) == "applied"
+    assert _count_chart_history(chart_id) == before_history
+
+
+def test_post_apply_change_requests_returns_404_when_request_not_found(
+    client: TestClient,
+) -> None:
+    request_id = 9223372036854775807
+    res = client.post(
+        f"/governance/change-requests/{request_id}/apply",
+        json={
+            "applied_by": "ops-user",
+            "applied_by_role": "ops",
+        },
+    )
+
+    assert res.status_code == 404
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "NOT_FOUND"
+    assert body["error"]["details"]["request_id"] == str(request_id)
+
+
+def test_post_apply_change_requests_returns_409_when_not_approved(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    request_id = seeded.request_pending_chart_1
+    res = client.post(
+        f"/governance/change-requests/{request_id}/apply",
+        json={
+            "applied_by": "ops-user",
+            "applied_by_role": "ops",
+        },
+    )
+
+    assert res.status_code == 409
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "INVALID_STATUS_TRANSITION"
+
+
+def test_post_apply_change_requests_returns_409_for_stale_expected_version(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    _update_chart_version(seeded.chart_1_id, 3)
+
+    request_id = seeded.request_approved_chart_1
+    res = client.post(
+        f"/governance/change-requests/{request_id}/apply",
+        json={
+            "applied_by": "ops-user",
+            "applied_by_role": "ops",
+        },
+    )
+
+    assert res.status_code == 409
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "STALE_EXPECTED_VERSION"
+    current = body["error"]["details"]["current"]
+    assert current["chart_id"] == seeded.chart_1_id
+    assert current["version"] == 3
+
+
+def test_post_apply_change_requests_returns_422_for_invalid_threshold_consistency(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    request_id = _insert_change_request(
+        chart_id=seeded.chart_2_id,
+        proposed_by="ops",
+        proposed_at="2026-05-04T00:00:00.000Z",
+        idempotency_key=f"apply-invalid-{uuid4().hex[:12]}",
+        change_payload='{"warn_low": 5.0, "warn_high": 2.0}',
+        expected_version=1,
+    )
+    _update_change_request_status(request_id, "approved")
+    try:
+        res = client.post(
+            f"/governance/change-requests/{request_id}/apply",
+            json={
+                "applied_by": "ops-user",
+                "applied_by_role": "ops",
+            },
+        )
+        assert res.status_code == 422
+        assert_validation_error_envelope(
+            res.json(),
+            expected_loc_fragment="change_payload",
+            expected_message_fragment="warn_low",
+        )
+    finally:
+        con = _connect(MAIN_DB)
+        try:
+            con.execute("DELETE FROM GovernanceApplyResults WHERE request_id = ?", (request_id,))
+            con.execute("DELETE FROM GovernanceApprovals WHERE request_id = ?", (request_id,))
+            con.execute(
+                "DELETE FROM GovernanceAuditEvents WHERE target_type = ? AND target_id = ?",
+                ("change_request", request_id),
+            )
+            con.execute("DELETE FROM GovernanceChangeRequests WHERE id = ?", (request_id,))
+            con.commit()
+        finally:
+            con.close()
+
+
+def test_post_apply_change_requests_returns_400_when_chart_missing(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    request_id = seeded.request_approved_chart_1
+    _force_change_request_chart_id(request_id, 9223372036854775701)
+
+    res = client.post(
+        f"/governance/change-requests/{request_id}/apply",
+        json={
+            "applied_by": "ops-user",
+            "applied_by_role": "ops",
+        },
+    )
+
+    assert res.status_code == 400
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "CHART_NOT_FOUND"
 
 
 def test_post_change_requests_success_envelope_contract(


### PR DESCRIPTION
## Summary
- Add POST /governance/change-requests/{request_id}/approve with status transition and audit recording.
- Add POST /governance/change-requests/{request_id}/apply with approved-only guard, expected_version conflict handling, no-op handling, history write, and apply result write.
- Extend governance endpoint tests to cover approve/apply core scenarios required by Issue #142.

## Commits
1. eat(db_api): add governance approve endpoint and tests
2. eat(db_api): add governance apply endpoint and tests
 
## Verification
- pytest -v tests/db_api/test_db_api_governance_change_requests_endpoint.py

## Scope
- Implements #142 core API behavior for approve/apply and related endpoint tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 承認・反映エンドポイントの実装（更新済）

### 追加された機能（短く）
- POST /governance/change-requests/{request_id}/approve：pending → approved、承認レコード作成、監査イベント記録、404/409/400 のエンベロープ応答対応
- POST /governance/change-requests/{request_id}/apply：approved だけ適用可能、expected_version による競合検出（詳細な 409 応答）、no-op 検出（math.isclose を利用）、ChartsV2 更新・ChartsHistory 追加、GovernanceApplyResults 永続化、監査イベント記録
- ガバナンス用の内部例外と 409/400 エラーヘルパーを追加
- change_payload のパース/検証強化（閾値フィールドの別名対応、有界数/nullable 検証、閾値ペア整合性チェック：crit_low<=warn_low、warn_high<=crit_high、crit_low<=warn_high）
- PRAGMA foreign_keys の復帰を finally で保証する修正
- スキーマ追加：ChangeRequestApproveIn、ChangeRequestApplyIn

### テスト（短く）
- approve/apply のエンドポイントテストを追加（no-op 適用、閾値変更の適用で ChartsHistory 増加とバージョンインクリメント、404/409/422/400 の主要エラーケースを網羅）
- テストの DB ヘルパーを拡張（承認数カウント、履歴カウント、強制的な chart_id 書き換え等）

### リスク・注意点（短く）
- 楽観的ロック依存：expected_version による競合検出はあるが、複数同時 apply に対する完全な防御はトランザクション/DB ロック実装に依存
- 例外→HTTP マッピングの一貫性確認が必要（内部例外が増えているため）
- apply の部分的成功/失敗時の外部観測点（監査ログ・履歴・ApplyResults）の整合性を運用観点で確認する必要あり
- no-op 判定は数値比較の緩和で改善されたが、境界ケース（非常に小さい差や浮動小数点表現）での挙動確認が必要

### テストギャップ（短く）
- 並行実行シナリオの負荷/競合テスト（同一チャートへの同時 apply）は未実装
- apply の再試行／幂等性を検証する専用テストがない（部分失敗後の整合性確認含む）
- 監査イベントの内容（ペイロードやメタ情報）が期待通り記録されているかを詳細に検証するテストが不足

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/198)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->