### PR TITLE
feat(db_api): add governance audit-events read endpoint

### DIFF
--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -28,12 +28,12 @@
 | `GET`    | `/judge/results`                                    | dashboard read | implemented | dashboard       | Issue #132              | 判定結果一覧                                 |
 | `GET`    | `/judge/results/{result_id}`                        | dashboard read | implemented | dashboard       | Issue #133              | 判定詳細（トレース情報含む）                 |
 | `POST`   | `/governance/change-requests`                       | governance     | implemented | dashboard/ops   | source: `db_api/app.py` | 通常変更の申請作成                           |
-| `POST`   | `/governance/change-requests/{request_id}/approve`  | governance     | planned     | ops             | Issue #102              | 変更申請の承認                               |
-| `POST`   | `/governance/change-requests/{request_id}/apply`    | governance     | planned     | ops             | Issue #102              | 承認済み申請の反映                           |
+| `POST`   | `/governance/change-requests/{request_id}/approve`  | governance     | implemented | ops             | source: `db_api/app.py` | 変更申請の承認                               |
+| `POST`   | `/governance/change-requests/{request_id}/apply`    | governance     | implemented | ops             | source: `db_api/app.py` | 承認済み申請の反映                           |
 | `POST`   | `/governance/emergency-changes`                     | governance     | planned     | dashboard/ops   | Issue #102              | 緊急変更の即時反映                           |
 | `POST`   | `/governance/emergency-changes/{request_id}/ratify` | governance     | planned     | ops             | Issue #102              | 緊急変更の事後追認                           |
 | `GET`    | `/governance/change-requests`                       | governance     | implemented | ops/audit       | source: `db_api/app.py` | 変更申請の検索                               |
-| `GET`    | `/governance/audit-events`                          | governance     | planned     | ops/audit       | Issue #102              | 監査イベントの検索                           |
+| `GET`    | `/governance/audit-events`                          | governance     | implemented | ops/audit       | source: `db_api/app.py` | 監査イベントの検索                           |
 | `POST`   | `/governance/notifications/{event_id}/retry`        | governance     | planned     | ops             | Issue #102              | 通知失敗時の再送                             |
 
 ## Notes
@@ -49,7 +49,7 @@
 
 ## Read-only Endpoint Access Pattern
 
-- `GET /charts*` と `GET /governance/change-requests` は read-only のため `_connect_readonly(MAIN_DB)` で直接接続し、`DBTaskRunner` 経由は不要
+- `GET /charts*` と `GET /governance/change-requests` / `GET /governance/audit-events` は read-only のため `_connect_readonly(MAIN_DB)` で直接接続し、`DBTaskRunner` 経由は不要
 - `DBTaskRunner` は write タスク直列化・排他制御専用で、read では並行接続をサポート
 
 ## Consumer Permission Scope

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -58,6 +58,7 @@ from .schemas import (
     ChangeRequestApproveIn,
     ChangeRequestIn,
     ChangeRequestsQuery,
+    GovernanceAuditEventsQuery,
     ParameterIn,
     ProcessDeleteIn,
     ProcessInfoIn,
@@ -953,6 +954,71 @@ def get_governance_change_requests(
         return {"ok": True, "data": [asdict(row) for row in rows]}
     except Exception as e:
         _raise_api_error(operation="GET /governance/change-requests", error=e)
+    finally:
+        con.close()
+
+
+@app.get("/governance/audit-events")
+def get_governance_audit_events(
+    query: Annotated[GovernanceAuditEventsQuery, Depends()],
+):
+    """ガバナンス監査イベント一覧を返す。"""
+    con = _connect_readonly(MAIN_DB)
+    try:
+        _validate_query_datetime_range(query.from_ts, query.to_ts, require_pair=False)
+
+        sql = """
+            SELECT
+                id, event_type, actor, actor_role, target_type, target_id,
+                occurred_at, before_json, after_json, correlation_id
+            FROM GovernanceAuditEvents
+        """
+        where_clauses: list[str] = []
+        params: list[object] = []
+
+        if query.event_type is not None:
+            where_clauses.append("event_type = ?")
+            params.append(query.event_type)
+        if query.target_type is not None:
+            where_clauses.append("target_type = ?")
+            params.append(query.target_type)
+        if query.target_id is not None:
+            where_clauses.append("target_id = ?")
+            params.append(query.target_id)
+        if query.from_ts is not None:
+            where_clauses.append("datetime(occurred_at) >= datetime(?)")
+            params.append(_normalize_query_datetime(query.from_ts))
+        if query.to_ts is not None:
+            where_clauses.append("datetime(occurred_at) <= datetime(?)")
+            params.append(_normalize_query_datetime(query.to_ts))
+
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+
+        sql += " ORDER BY datetime(occurred_at) DESC, id DESC LIMIT ? OFFSET ?"
+        params.extend((query.limit, query.offset))
+
+        rows = con.execute(sql, params).fetchall()
+        data = [
+            {
+                "id": int(row[0]),
+                "event_type": str(row[1]),
+                "actor": str(row[2]),
+                "actor_role": str(row[3]),
+                "target_type": str(row[4]),
+                "target_id": int(row[5]),
+                "occurred_at": str(row[6]),
+                "before_json": row[7],
+                "after_json": row[8],
+                "correlation_id": row[9],
+            }
+            for row in rows
+        ]
+        return {"ok": True, "data": data}
+    except HTTPException:
+        raise
+    except Exception as e:
+        _raise_api_error(operation="GET /governance/audit-events", error=e)
     finally:
         con.close()
 

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -986,16 +986,16 @@ def get_governance_audit_events(
             where_clauses.append("target_id = ?")
             params.append(query.target_id)
         if query.from_ts is not None:
-            where_clauses.append("datetime(occurred_at) >= datetime(?)")
+            where_clauses.append("occurred_at >= ?")
             params.append(_normalize_query_datetime(query.from_ts))
         if query.to_ts is not None:
-            where_clauses.append("datetime(occurred_at) <= datetime(?)")
+            where_clauses.append("occurred_at <= ?")
             params.append(_normalize_query_datetime(query.to_ts))
 
         if where_clauses:
             sql += " WHERE " + " AND ".join(where_clauses)
 
-        sql += " ORDER BY datetime(occurred_at) DESC, id DESC LIMIT ? OFFSET ?"
+        sql += " ORDER BY occurred_at DESC, id DESC LIMIT ? OFFSET ?"
         params.extend((query.limit, query.offset))
 
         rows = con.execute(sql, params).fetchall()

--- a/src/portfolio_fdc/db_api/schemas.py
+++ b/src/portfolio_fdc/db_api/schemas.py
@@ -143,6 +143,18 @@ class ChangeRequestsQuery(BaseModel):
         return self
 
 
+class GovernanceAuditEventsQuery(BaseModel):
+    """`/governance/audit-events` GET 用のクエリ入力モデル。"""
+
+    event_type: str | None = Field(default=None, min_length=1, max_length=64)
+    target_type: str | None = Field(default=None, min_length=1, max_length=64)
+    target_id: int | None = Field(default=None, ge=1)
+    from_ts: datetime | None = None
+    to_ts: datetime | None = None
+    limit: int = Field(default=100, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+
+
 class ChangeRequestApproveIn(BaseModel):
     """`/governance/change-requests/{request_id}/approve` POST 用の入力モデル。"""
 

--- a/tests/db_api/test_db_api_governance_audit_events_endpoint.py
+++ b/tests/db_api/test_db_api_governance_audit_events_endpoint.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from portfolio_fdc.db_api.db import MAIN_DB, _connect
+
+
+def _insert_audit_event(
+    *,
+    event_type: str,
+    actor: str,
+    actor_role: str,
+    target_type: str,
+    target_id: int,
+    occurred_at: str,
+    correlation_id: str,
+) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceAuditEvents(
+                event_type, actor, actor_role, target_type, target_id,
+                occurred_at, before_json, after_json, correlation_id
+            ) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?)
+            """,
+            (
+                event_type,
+                actor,
+                actor_role,
+                target_type,
+                target_id,
+                occurred_at,
+                correlation_id,
+            ),
+        )
+        con.commit()
+        row_id = cur.lastrowid
+        if row_id is None:
+            raise RuntimeError("Failed to insert audit event")
+        return int(row_id)
+    finally:
+        con.close()
+
+
+def _delete_audit_events(correlation_id: str) -> None:
+    con = _connect(MAIN_DB)
+    try:
+        con.execute(
+            "DELETE FROM GovernanceAuditEvents WHERE correlation_id = ?",
+            (correlation_id,),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def test_get_governance_audit_events_returns_empty_list_when_no_match(
+    client: TestClient,
+) -> None:
+    res = client.get(
+        "/governance/audit-events",
+        params={"event_type": "no_such_event_type"},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"] == []
+
+
+def test_get_governance_audit_events_filters_by_event_type_and_target(
+    client: TestClient,
+) -> None:
+    correlation_id = f"audit-filter-{uuid4().hex[:8]}"
+    now = datetime.now(UTC)
+    try:
+        target_id = 22001
+        expected_id = _insert_audit_event(
+            event_type="change_applied",
+            actor="ops-a",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=target_id,
+            occurred_at=now.isoformat(),
+            correlation_id=correlation_id,
+        )
+        _insert_audit_event(
+            event_type="change_approved",
+            actor="ops-b",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=target_id,
+            occurred_at=now.isoformat(),
+            correlation_id=correlation_id,
+        )
+        _insert_audit_event(
+            event_type="change_applied",
+            actor="ops-c",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=22002,
+            occurred_at=now.isoformat(),
+            correlation_id=correlation_id,
+        )
+
+        res = client.get(
+            "/governance/audit-events",
+            params={
+                "event_type": "change_applied",
+                "target_type": "change_request",
+                "target_id": target_id,
+            },
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert [row["id"] for row in body["data"]] == [expected_id]
+    finally:
+        _delete_audit_events(correlation_id)
+
+
+def test_get_governance_audit_events_filters_by_from_to(
+    client: TestClient,
+) -> None:
+    correlation_id = f"audit-time-{uuid4().hex[:8]}"
+    try:
+        _insert_audit_event(
+            event_type="change_requested",
+            actor="ops-a",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=23001,
+            occurred_at="2026-05-01T00:00:00.000Z",
+            correlation_id=correlation_id,
+        )
+        id_mid = _insert_audit_event(
+            event_type="change_approved",
+            actor="ops-b",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=23002,
+            occurred_at="2026-05-02T00:00:00.000Z",
+            correlation_id=correlation_id,
+        )
+        id_new = _insert_audit_event(
+            event_type="change_applied",
+            actor="ops-c",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=23003,
+            occurred_at="2026-05-03T00:00:00.000Z",
+            correlation_id=correlation_id,
+        )
+
+        res = client.get(
+            "/governance/audit-events",
+            params={
+                "from_ts": "2026-05-02T00:00:00Z",
+                "to_ts": "2026-05-03T00:00:00Z",
+            },
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert [row["id"] for row in body["data"] if row["correlation_id"] == correlation_id] == [
+            id_new,
+            id_mid,
+        ]
+    finally:
+        _delete_audit_events(correlation_id)
+
+
+def test_get_governance_audit_events_supports_limit_and_offset(
+    client: TestClient,
+) -> None:
+    correlation_id = f"audit-page-{uuid4().hex[:8]}"
+    event_type = f"page_event_{uuid4().hex[:8]}"
+    try:
+        _insert_audit_event(
+            event_type=event_type,
+            actor="ops-a",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=24001,
+            occurred_at="2026-05-01T00:00:00.000Z",
+            correlation_id=correlation_id,
+        )
+        id_second = _insert_audit_event(
+            event_type=event_type,
+            actor="ops-b",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=24002,
+            occurred_at="2026-05-02T00:00:00.000Z",
+            correlation_id=correlation_id,
+        )
+        _insert_audit_event(
+            event_type=event_type,
+            actor="ops-c",
+            actor_role="ops",
+            target_type="change_request",
+            target_id=24003,
+            occurred_at="2026-05-03T00:00:00.000Z",
+            correlation_id=correlation_id,
+        )
+
+        res = client.get(
+            "/governance/audit-events",
+            params={"event_type": event_type, "limit": 1, "offset": 1},
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert [row["id"] for row in body["data"]] == [id_second]
+    finally:
+        _delete_audit_events(correlation_id)
+
+
+def test_get_governance_audit_events_returns_400_for_naive_from_ts(
+    client: TestClient,
+) -> None:
+    res = client.get(
+        "/governance/audit-events",
+        params={
+            "from_ts": "2026-05-01T00:00:00",
+            "to_ts": "2026-05-02T00:00:00Z",
+        },
+    )
+
+    assert res.status_code == 400
+    assert "timezone" in res.json()["detail"]


### PR DESCRIPTION
## Summary
- Add GET /governance/audit-events as a read-only governance endpoint.
- Support query filters: event_type, 	arget_type, 	arget_id, rom_ts, 	o_ts, limit, offset.
- Return audit events in ok/data envelope and preserve 4xx for query validation errors.
- Add query schema for audit-events endpoint and wire it into the API app.
- Add endpoint tests covering empty results, filters, time range, pagination, and naive datetime rejection.
- Update endpoint catalog status for governance approve/apply/audit-events to implemented.

## Verification
- .venv/Scripts/python.exe -m pytest -v tests/db_api/test_db_api_governance_audit_events_endpoint.py tests/db_api/test_db_api_governance_change_requests_endpoint.py
- Result: 33 passed

## Scope
- Included:
  - src/portfolio_fdc/db_api/app.py
  - src/portfolio_fdc/db_api/schemas.py
  - 	ests/db_api/test_db_api_governance_audit_events_endpoint.py
  - docs/db-api-endpoints.md
- Not included:
  - Emergency change/ratify/retry endpoint implementations
  - AuthN/AuthZ model changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## GET /governance/audit-events エンドポイント追加

- 概要
  - ガバナンス監査イベント取得の read-only エンドポイント GET /governance/audit-events を追加
  - クエリフィルタ: event_type, target_type, target_id, from_ts, to_ts, limit, offset
  - レスポンス形式: {"ok": true, "data": [...]}（4xx は既存のクエリ検証エラーを維持）

- 実装ポイント
  - Pydantic クエリモデル GovernanceAuditEventsQuery を schemas に追加（limit: 1..500, offset >=0 等）
  - app.py にエンドポイントハンドラを追加し、クエリ検証・範囲チェックを適用
  - read-only パターンに従い _connect_readonly(MAIN_DB) で直接 DB 参照（DBTaskRunner は不要）
  - ドキュメント docs/db-api-endpoints.md のエンドポイントカタログを "implemented" に更新
  - コミット修正: occurred_at のフィルタ/ソート比較を「raw string 比較」に変更する修正あり（タイムスタンプ比較の扱いに影響）

- テスト（追加）
  - tests/db_api/test_db_api_governance_audit_events_endpoint.py を追加
  - カバレッジ: 空結果、event_type/target フィルタ、from_ts/to_ts の時間範囲（並び順検証含む）、limit/offset のページネーション、naive datetime (timezone-less) の拒否（400）を検証
  - ローカル検証: 該当テスト群実行済み、テストスイート結果: 33 passed

- リスク
  - AuthN/AuthZ は本PR範囲外 → 権限に基づくレコードレベル制限は未実装（別PRで対応予定）
  - rate limiting やアクセス制御の実装なし
  - 大量データ検索時のパフォーマンス/タイムアウト対策（インデックス/クエリ計画等）の記載・検証がない
  - 監査イベントの「読み取り」操作自体に対する追加監査ログがない（読み取り監査要件がある場合は別途対応）

- テストギャップ（未実装／限定的な検証）
  - 大規模データセットでの性能・スケーリング（例: limit が上限近くや多数のマッチ）に関する負荷テストなし
  - 複合フィルタ（多種条件を同時指定した場合）の網羅的挙動検証は限定的
  - correlation_id 等の異常値・境界ケース（存在しない ID、特殊文字、長大値）に対する境界テスト不足
  - occurred_at の比較が raw string 比較に依存する変更の影響（タイムゾーン混在や文字列フォーマット差異）が本番データで問題とならないか追加確認が必要
  - emergency change / ratify / retry の write 系エンドポイントは除外（planned のまま）

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/199)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->