### PR TITLE
feat(db_api): implement governance notifications retry endpoint

### DIFF
--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -34,7 +34,7 @@
 | `POST`   | `/governance/emergency-changes/{request_id}/ratify` | governance     | planned     | ops             | Issue #102              | 緊急変更の事後追認                           |
 | `GET`    | `/governance/change-requests`                       | governance     | implemented | ops/audit       | source: `db_api/app.py` | 変更申請の検索                               |
 | `GET`    | `/governance/audit-events`                          | governance     | implemented | ops/audit       | source: `db_api/app.py` | 監査イベントの検索                           |
-| `POST`   | `/governance/notifications/{event_id}/retry`        | governance     | planned     | ops             | Issue #102              | 通知失敗時の再送                             |
+| `POST`   | `/governance/notifications/{event_id}/retry`        | governance     | implemented | ops             | source: `db_api/app.py` | 通知失敗時の再送                             |
 
 ## Notes
 

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -15,7 +15,7 @@ import sqlite3
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import asdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
 from threading import Lock
 from typing import Annotated, NoReturn, cast
@@ -89,6 +89,8 @@ CHARTS_FILTER_MAX_LENGTH = 128
 CHART_ID_PATTERN = r"^CHART_[0-9]+$"
 JUDGE_LEVEL_PATTERN = r"^(OK|WARN|NG)$"
 RESULT_ID_PATTERN = r"^JR_[0-9]+$"
+MAX_NOTIFICATION_RETRY_COUNT = 3
+NOTIFICATION_RETRY_BACKOFF_MINUTES = {1: 1, 2: 5, 3: 30}
 
 
 def _legacy_delete_headers(process_id: str | None) -> dict[str, str]:
@@ -573,6 +575,30 @@ class _GovernanceApplyValidationError(Exception):
         self.message = message
 
 
+class _GovernanceNotificationNotFound(Exception):
+    """notification outbox が存在しない場合に送出する内部例外。"""
+
+
+class _GovernanceNotificationInvalidState(Exception):
+    """retry 対象の status が failed 以外の場合に送出する内部例外。"""
+
+    def __init__(self, *, status: str) -> None:
+        self.status = status
+
+
+class _GovernanceNotificationRetryLimitExceeded(Exception):
+    """retry_count が上限に達している場合に送出する内部例外。"""
+
+    def __init__(self, *, retry_count: int) -> None:
+        self.retry_count = retry_count
+
+
+def _compute_notification_next_retry_at(*, base_time: datetime, retry_count: int) -> str:
+    """retry_count に応じた次回試行時刻を UTC ミリ秒 ISO 文字列で返す。"""
+    minutes = NOTIFICATION_RETRY_BACKOFF_MINUTES[retry_count]
+    return to_utc_millis((base_time + timedelta(minutes=minutes)).isoformat())
+
+
 def _parse_threshold_patch(change_payload: str) -> dict[str, float | None]:
     """change_payload からしきい値更新パッチを抽出する。"""
     payload = json.loads(change_payload)
@@ -1021,6 +1047,107 @@ def get_governance_audit_events(
         _raise_api_error(operation="GET /governance/audit-events", error=e)
     finally:
         con.close()
+
+
+@app.post("/governance/notifications/{event_id}/retry")
+def retry_governance_notification(
+    runner: RunnerDep,
+    event_id: int = Path(ge=1),
+):
+    """通知 outbox の failed レコードを再送キューへ戻す。"""
+
+    def _write() -> dict[str, object]:
+        con = _connect(MAIN_DB)
+        try:
+            con.execute("BEGIN")
+            row = con.execute(
+                """
+                SELECT id, status, retry_count
+                FROM GovernanceNotificationOutbox
+                WHERE event_id = ?
+                """,
+                (event_id,),
+            ).fetchone()
+            if row is None:
+                raise _GovernanceNotificationNotFound
+
+            outbox_id = int(row[0])
+            status = str(row[1])
+            retry_count = int(row[2])
+
+            if status != "failed":
+                raise _GovernanceNotificationInvalidState(status=status)
+            if retry_count >= MAX_NOTIFICATION_RETRY_COUNT:
+                raise _GovernanceNotificationRetryLimitExceeded(retry_count=retry_count)
+
+            now = datetime.now(UTC)
+            now_iso = to_utc_millis(now.isoformat())
+            next_retry_at = _compute_notification_next_retry_at(
+                base_time=now,
+                retry_count=retry_count + 1,
+            )
+
+            con.execute(
+                """
+                UPDATE GovernanceNotificationOutbox
+                SET status = 'pending',
+                    retry_count = ?,
+                    next_retry_at = ?,
+                    last_attempt_at = ?,
+                    last_error = NULL
+                WHERE id = ?
+                """,
+                (retry_count + 1, next_retry_at, now_iso, outbox_id),
+            )
+            _audit_event_writer.write(
+                con,
+                event_type="notification_queued",
+                actor="ops",
+                actor_role="ops",
+                target_type="notification",
+                target_id=outbox_id,
+                occurred_at=now_iso,
+                correlation_id=f"event:{event_id}",
+            )
+            con.commit()
+            return {
+                "event_id": event_id,
+                "status": "pending",
+                "retry_count": retry_count + 1,
+                "next_retry_at": next_retry_at,
+            }
+        except Exception:
+            con.rollback()
+            raise
+        finally:
+            con.close()
+
+    try:
+        data = runner.submit("write", _write)
+        return {"ok": True, "data": data}
+    except _GovernanceNotificationNotFound:
+        return _not_found_error_response(
+            message="notification outbox not found",
+            details={"event_id": str(event_id)},
+        )
+    except _GovernanceNotificationInvalidState as e:
+        return _bad_request_error_response(
+            code="INVALID_RETRY_TARGET",
+            message="only failed notification can be retried",
+            details={"event_id": str(event_id), "current_status": e.status},
+        )
+    except _GovernanceNotificationRetryLimitExceeded as e:
+        return _conflict_error_response(
+            code="RETRY_LIMIT_EXCEEDED",
+            message="retry_count has reached the maximum",
+            details={
+                "event_id": str(event_id),
+                "retry_count": str(e.retry_count),
+                "max_retry_count": str(MAX_NOTIFICATION_RETRY_COUNT),
+            },
+        )
+    except Exception as e:
+        _raise_api_error(operation="POST /governance/notifications/{event_id}/retry", error=e)
 
 
 @app.post("/governance/change-requests")

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -598,7 +598,10 @@ class _GovernanceNotificationConcurrentModification(Exception):
 
 def _compute_notification_next_retry_at(*, base_time: datetime, retry_count: int) -> str:
     """retry_count に応じた次回試行時刻を UTC ミリ秒 ISO 文字列で返す。"""
-    minutes = NOTIFICATION_RETRY_BACKOFF_MINUTES[retry_count]
+    minutes = NOTIFICATION_RETRY_BACKOFF_MINUTES.get(retry_count)
+    if minutes is None:
+        max_retries = len(NOTIFICATION_RETRY_BACKOFF_MINUTES)
+        raise ValueError(f"retry_count must be between 1 and {max_retries}")
     return to_utc_millis((base_time + timedelta(minutes=minutes)).isoformat())
 
 

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -1060,7 +1060,7 @@ def retry_governance_notification(
 ):
     """通知 outbox の failed レコードを再送キューへ戻す。"""
 
-    def _write() -> dict[str, object]:
+    def _retry_failed_notification_outbox() -> dict[str, object]:
         con = _connect(MAIN_DB)
         try:
             con.execute("BEGIN")
@@ -1149,7 +1149,7 @@ def retry_governance_notification(
             con.close()
 
     try:
-        data = runner.submit("write", _write)
+        data = runner.submit("write", _retry_failed_notification_outbox)
         return {"ok": True, "data": data}
     except _GovernanceNotificationNotFound:
         return _not_found_error_response(

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -89,7 +89,6 @@ CHARTS_FILTER_MAX_LENGTH = 128
 CHART_ID_PATTERN = r"^CHART_[0-9]+$"
 JUDGE_LEVEL_PATTERN = r"^(OK|WARN|NG)$"
 RESULT_ID_PATTERN = r"^JR_[0-9]+$"
-MAX_NOTIFICATION_RETRY_COUNT = 3
 NOTIFICATION_RETRY_BACKOFF_MINUTES = {1: 1, 2: 5, 3: 30}
 
 
@@ -1081,7 +1080,7 @@ def retry_governance_notification(
 
             if status != "failed":
                 raise _GovernanceNotificationInvalidState(status=status)
-            if retry_count >= MAX_NOTIFICATION_RETRY_COUNT:
+            if retry_count >= len(NOTIFICATION_RETRY_BACKOFF_MINUTES):
                 raise _GovernanceNotificationRetryLimitExceeded(retry_count=retry_count)
 
             now = datetime.now(UTC)
@@ -1121,7 +1120,7 @@ def retry_governance_notification(
                 latest_retry_count = int(latest[1])
                 if latest_status != "failed":
                     raise _GovernanceNotificationInvalidState(status=latest_status)
-                if latest_retry_count >= MAX_NOTIFICATION_RETRY_COUNT:
+                if latest_retry_count >= len(NOTIFICATION_RETRY_BACKOFF_MINUTES):
                     raise _GovernanceNotificationRetryLimitExceeded(retry_count=latest_retry_count)
                 raise _GovernanceNotificationConcurrentModification
 
@@ -1169,7 +1168,7 @@ def retry_governance_notification(
             details={
                 "event_id": str(event_id),
                 "retry_count": str(e.retry_count),
-                "max_retry_count": str(MAX_NOTIFICATION_RETRY_COUNT),
+                "max_retry_count": str(len(NOTIFICATION_RETRY_BACKOFF_MINUTES)),
             },
         )
     except _GovernanceNotificationConcurrentModification:

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -593,6 +593,10 @@ class _GovernanceNotificationRetryLimitExceeded(Exception):
         self.retry_count = retry_count
 
 
+class _GovernanceNotificationConcurrentModification(Exception):
+    """conditional UPDATE が 0 件更新になった場合に送出する内部例外。"""
+
+
 def _compute_notification_next_retry_at(*, base_time: datetime, retry_count: int) -> str:
     """retry_count に応じた次回試行時刻を UTC ミリ秒 ISO 文字列で返す。"""
     minutes = NOTIFICATION_RETRY_BACKOFF_MINUTES[retry_count]
@@ -1087,18 +1091,40 @@ def retry_governance_notification(
                 retry_count=retry_count + 1,
             )
 
-            con.execute(
+            update_cur = con.execute(
                 """
                 UPDATE GovernanceNotificationOutbox
                 SET status = 'pending',
-                    retry_count = ?,
+                    retry_count = retry_count + 1,
                     next_retry_at = ?,
                     last_attempt_at = ?,
                     last_error = NULL
                 WHERE id = ?
+                  AND status = 'failed'
+                  AND retry_count = ?
                 """,
-                (retry_count + 1, next_retry_at, now_iso, outbox_id),
+                (next_retry_at, now_iso, outbox_id, retry_count),
             )
+            if update_cur.rowcount == 0:
+                latest = con.execute(
+                    """
+                    SELECT status, retry_count
+                    FROM GovernanceNotificationOutbox
+                    WHERE id = ?
+                    """,
+                    (outbox_id,),
+                ).fetchone()
+                if latest is None:
+                    raise _GovernanceNotificationNotFound
+
+                latest_status = str(latest[0])
+                latest_retry_count = int(latest[1])
+                if latest_status != "failed":
+                    raise _GovernanceNotificationInvalidState(status=latest_status)
+                if latest_retry_count >= MAX_NOTIFICATION_RETRY_COUNT:
+                    raise _GovernanceNotificationRetryLimitExceeded(retry_count=latest_retry_count)
+                raise _GovernanceNotificationConcurrentModification
+
             _audit_event_writer.write(
                 con,
                 event_type="notification_queued",
@@ -1145,6 +1171,12 @@ def retry_governance_notification(
                 "retry_count": str(e.retry_count),
                 "max_retry_count": str(MAX_NOTIFICATION_RETRY_COUNT),
             },
+        )
+    except _GovernanceNotificationConcurrentModification:
+        return _conflict_error_response(
+            code="CONCURRENT_MODIFICATION",
+            message="notification outbox was modified concurrently",
+            details={"event_id": str(event_id)},
         )
     except Exception as e:
         _raise_api_error(operation="POST /governance/notifications/{event_id}/retry", error=e)

--- a/tests/db_api/test_db_api_governance_notifications_retry_endpoint.py
+++ b/tests/db_api/test_db_api_governance_notifications_retry_endpoint.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
+from portfolio_fdc.db_api.app import _compute_notification_next_retry_at
 from portfolio_fdc.db_api.db import MAIN_DB, _connect
 
 
@@ -131,6 +132,17 @@ def _count_notification_queued_events(event_id: int) -> int:
 
 def _parse_utc_millis(ts: str) -> datetime:
     return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def test_compute_notification_next_retry_at_rejects_invalid_retry_count() -> None:
+    base_time = datetime(2026, 5, 10, 0, 0, tzinfo=UTC)
+
+    try:
+        _compute_notification_next_retry_at(base_time=base_time, retry_count=4)
+    except ValueError as exc:
+        assert "retry_count must be between 1 and 3" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
 
 
 def test_post_notifications_retry_success_updates_failed_to_pending(

--- a/tests/db_api/test_db_api_governance_notifications_retry_endpoint.py
+++ b/tests/db_api/test_db_api_governance_notifications_retry_endpoint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
@@ -108,6 +109,30 @@ def _delete_seeded_notification_records(event_id: int, correlation_id: str) -> N
         con.close()
 
 
+def _count_notification_queued_events(event_id: int) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        row = con.execute(
+            """
+                        SELECT COUNT(*)
+                        FROM GovernanceAuditEvents AS ae
+                        JOIN GovernanceNotificationOutbox AS outbox
+                            ON outbox.id = ae.target_id
+                        WHERE outbox.event_id = ?
+                            AND ae.target_type = 'notification'
+                            AND ae.event_type = 'notification_queued'
+                        """,
+            (event_id,),
+        ).fetchone()
+        return int(row[0])
+    finally:
+        con.close()
+
+
+def _parse_utc_millis(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
 def test_post_notifications_retry_success_updates_failed_to_pending(
     client: TestClient,
 ) -> None:
@@ -116,7 +141,10 @@ def test_post_notifications_retry_success_updates_failed_to_pending(
     _insert_outbox(event_id=event_id, status="failed", retry_count=1, last_error="smtp timeout")
 
     try:
+        before_call = datetime.now(UTC)
+        before_audit_count = _count_notification_queued_events(event_id)
         res = client.post(f"/governance/notifications/{event_id}/retry")
+        after_call = datetime.now(UTC)
 
         assert res.status_code == 200
         body = res.json()
@@ -131,6 +159,12 @@ def test_post_notifications_retry_success_updates_failed_to_pending(
         assert retry_count == 2
         assert next_retry_at == body["data"]["next_retry_at"]
         assert last_error is None
+
+        actual_next_retry_at = _parse_utc_millis(body["data"]["next_retry_at"])
+        lower_bound = before_call + timedelta(minutes=5) - timedelta(seconds=2)
+        upper_bound = after_call + timedelta(minutes=5) + timedelta(seconds=2)
+        assert lower_bound <= actual_next_retry_at <= upper_bound
+        assert _count_notification_queued_events(event_id) == before_audit_count + 1
     finally:
         _delete_seeded_notification_records(event_id, correlation_id)
 
@@ -154,6 +188,7 @@ def test_post_notifications_retry_returns_400_when_status_is_pending(
     _insert_outbox(event_id=event_id, status="pending", retry_count=1)
 
     try:
+        seeded_status, seeded_retry_count, _, _ = _find_outbox_by_event_id(event_id)
         res = client.post(f"/governance/notifications/{event_id}/retry")
 
         assert res.status_code == 400
@@ -161,6 +196,9 @@ def test_post_notifications_retry_returns_400_when_status_is_pending(
         assert body["ok"] is False
         assert body["error"]["code"] == "INVALID_RETRY_TARGET"
         assert body["error"]["details"]["current_status"] == "pending"
+        status, retry_count, _, _ = _find_outbox_by_event_id(event_id)
+        assert status == seeded_status
+        assert retry_count == seeded_retry_count
     finally:
         _delete_seeded_notification_records(event_id, correlation_id)
 
@@ -173,6 +211,7 @@ def test_post_notifications_retry_returns_400_when_status_is_sent(
     _insert_outbox(event_id=event_id, status="sent", retry_count=1)
 
     try:
+        seeded_status, seeded_retry_count, _, _ = _find_outbox_by_event_id(event_id)
         res = client.post(f"/governance/notifications/{event_id}/retry")
 
         assert res.status_code == 400
@@ -180,6 +219,9 @@ def test_post_notifications_retry_returns_400_when_status_is_sent(
         assert body["ok"] is False
         assert body["error"]["code"] == "INVALID_RETRY_TARGET"
         assert body["error"]["details"]["current_status"] == "sent"
+        status, retry_count, _, _ = _find_outbox_by_event_id(event_id)
+        assert status == seeded_status
+        assert retry_count == seeded_retry_count
     finally:
         _delete_seeded_notification_records(event_id, correlation_id)
 
@@ -192,6 +234,7 @@ def test_post_notifications_retry_returns_409_when_retry_limit_exceeded(
     _insert_outbox(event_id=event_id, status="failed", retry_count=3)
 
     try:
+        seeded_status, seeded_retry_count, _, _ = _find_outbox_by_event_id(event_id)
         res = client.post(f"/governance/notifications/{event_id}/retry")
 
         assert res.status_code == 409
@@ -199,5 +242,8 @@ def test_post_notifications_retry_returns_409_when_retry_limit_exceeded(
         assert body["ok"] is False
         assert body["error"]["code"] == "RETRY_LIMIT_EXCEEDED"
         assert body["error"]["details"]["retry_count"] == "3"
+        status, retry_count, _, _ = _find_outbox_by_event_id(event_id)
+        assert status == seeded_status
+        assert retry_count == seeded_retry_count
     finally:
         _delete_seeded_notification_records(event_id, correlation_id)

--- a/tests/db_api/test_db_api_governance_notifications_retry_endpoint.py
+++ b/tests/db_api/test_db_api_governance_notifications_retry_endpoint.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from portfolio_fdc.db_api.db import MAIN_DB, _connect
+
+
+def _insert_audit_event_for_outbox(correlation_id: str) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceAuditEvents(
+                event_type, actor, actor_role, target_type, target_id,
+                occurred_at, before_json, after_json, correlation_id
+            ) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?)
+            """,
+            (
+                "notification_emitted",
+                "system",
+                "system",
+                "change_request",
+                1,
+                "2026-05-10T00:00:00.000Z",
+                correlation_id,
+            ),
+        )
+        con.commit()
+        row_id = cur.lastrowid
+        if row_id is None:
+            raise RuntimeError("Failed to insert audit event")
+        return int(row_id)
+    finally:
+        con.close()
+
+
+def _insert_outbox(
+    *, event_id: int, status: str, retry_count: int, last_error: str | None = None
+) -> int:
+    con = _connect(MAIN_DB)
+    try:
+        cur = con.execute(
+            """
+            INSERT INTO GovernanceNotificationOutbox(
+                event_id, status, retry_count, next_retry_at,
+                last_attempt_at, last_error, delivered_at
+            ) VALUES (?, ?, ?, ?, ?, ?, NULL)
+            """,
+            (
+                event_id,
+                status,
+                retry_count,
+                "2026-05-10T00:01:00.000Z",
+                "2026-05-10T00:00:00.000Z",
+                last_error,
+            ),
+        )
+        con.commit()
+        row_id = cur.lastrowid
+        if row_id is None:
+            raise RuntimeError("Failed to insert notification outbox")
+        return int(row_id)
+    finally:
+        con.close()
+
+
+def _find_outbox_by_event_id(event_id: int) -> tuple[str, int, str | None, str | None]:
+    con = _connect(MAIN_DB)
+    try:
+        row = con.execute(
+            """
+            SELECT status, retry_count, next_retry_at, last_error
+            FROM GovernanceNotificationOutbox
+            WHERE event_id = ?
+            """,
+            (event_id,),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("outbox not found")
+        return (str(row[0]), int(row[1]), row[2], row[3])
+    finally:
+        con.close()
+
+
+def _delete_seeded_notification_records(event_id: int, correlation_id: str) -> None:
+    con = _connect(MAIN_DB)
+    try:
+        con.execute(
+            "DELETE FROM GovernanceNotificationOutbox WHERE event_id = ?",
+            (event_id,),
+        )
+        con.execute(
+            "DELETE FROM GovernanceAuditEvents WHERE id = ?",
+            (event_id,),
+        )
+        con.execute(
+            "DELETE FROM GovernanceAuditEvents WHERE correlation_id = ?",
+            (correlation_id,),
+        )
+        con.execute(
+            "DELETE FROM GovernanceAuditEvents WHERE correlation_id = ?",
+            (f"event:{event_id}",),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def test_post_notifications_retry_success_updates_failed_to_pending(
+    client: TestClient,
+) -> None:
+    correlation_id = f"notif-retry-success-{uuid4().hex[:8]}"
+    event_id = _insert_audit_event_for_outbox(correlation_id)
+    _insert_outbox(event_id=event_id, status="failed", retry_count=1, last_error="smtp timeout")
+
+    try:
+        res = client.post(f"/governance/notifications/{event_id}/retry")
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert body["data"]["event_id"] == event_id
+        assert body["data"]["status"] == "pending"
+        assert body["data"]["retry_count"] == 2
+        assert body["data"]["next_retry_at"] is not None
+
+        status, retry_count, next_retry_at, last_error = _find_outbox_by_event_id(event_id)
+        assert status == "pending"
+        assert retry_count == 2
+        assert next_retry_at == body["data"]["next_retry_at"]
+        assert last_error is None
+    finally:
+        _delete_seeded_notification_records(event_id, correlation_id)
+
+
+def test_post_notifications_retry_returns_404_when_event_not_found(
+    client: TestClient,
+) -> None:
+    res = client.post("/governance/notifications/9223372036854775807/retry")
+
+    assert res.status_code == 404
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "NOT_FOUND"
+
+
+def test_post_notifications_retry_returns_400_when_status_is_pending(
+    client: TestClient,
+) -> None:
+    correlation_id = f"notif-retry-pending-{uuid4().hex[:8]}"
+    event_id = _insert_audit_event_for_outbox(correlation_id)
+    _insert_outbox(event_id=event_id, status="pending", retry_count=1)
+
+    try:
+        res = client.post(f"/governance/notifications/{event_id}/retry")
+
+        assert res.status_code == 400
+        body = res.json()
+        assert body["ok"] is False
+        assert body["error"]["code"] == "INVALID_RETRY_TARGET"
+        assert body["error"]["details"]["current_status"] == "pending"
+    finally:
+        _delete_seeded_notification_records(event_id, correlation_id)
+
+
+def test_post_notifications_retry_returns_400_when_status_is_sent(
+    client: TestClient,
+) -> None:
+    correlation_id = f"notif-retry-sent-{uuid4().hex[:8]}"
+    event_id = _insert_audit_event_for_outbox(correlation_id)
+    _insert_outbox(event_id=event_id, status="sent", retry_count=1)
+
+    try:
+        res = client.post(f"/governance/notifications/{event_id}/retry")
+
+        assert res.status_code == 400
+        body = res.json()
+        assert body["ok"] is False
+        assert body["error"]["code"] == "INVALID_RETRY_TARGET"
+        assert body["error"]["details"]["current_status"] == "sent"
+    finally:
+        _delete_seeded_notification_records(event_id, correlation_id)
+
+
+def test_post_notifications_retry_returns_409_when_retry_limit_exceeded(
+    client: TestClient,
+) -> None:
+    correlation_id = f"notif-retry-limit-{uuid4().hex[:8]}"
+    event_id = _insert_audit_event_for_outbox(correlation_id)
+    _insert_outbox(event_id=event_id, status="failed", retry_count=3)
+
+    try:
+        res = client.post(f"/governance/notifications/{event_id}/retry")
+
+        assert res.status_code == 409
+        body = res.json()
+        assert body["ok"] is False
+        assert body["error"]["code"] == "RETRY_LIMIT_EXCEEDED"
+        assert body["error"]["details"]["retry_count"] == "3"
+    finally:
+        _delete_seeded_notification_records(event_id, correlation_id)


### PR DESCRIPTION
## Summary
- Add POST /governance/notifications/{event_id}/retry endpoint.
- Retry target is limited to status = failed; return 400 INVALID_RETRY_TARGET for pending/sent.
- Enforce retry upper bound with 409 RETRY_LIMIT_EXCEEDED when etry_count has reached max.
- On successful retry request, transition outbox row to pending, increment etry_count, compute 
ext_retry_at using backoff (1/5/30 minutes), clear last_error, and record 
otification_queued audit event.
- Update endpoint catalog to mark notifications retry endpoint as implemented.
- Add endpoint tests for success, not-found, invalid-target, and retry-limit scenarios.

## Verification
- .venv/Scripts/python.exe -m pytest -v tests/db_api/test_db_api_governance_notifications_retry_endpoint.py tests/db_api/test_db_api_governance_change_requests_endpoint.py tests/db_api/test_db_api_governance_audit_events_endpoint.py
- Result: 38 passed

## Scope
- Included:
  - src/portfolio_fdc/db_api/app.py
  - 	ests/db_api/test_db_api_governance_notifications_retry_endpoint.py
  - docs/db-api-endpoints.md
- Not included:
  - emergency-changes / ratify endpoint implementations
  - notification delivery worker/background polling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 実装概要（更新済み）

- POST /governance/notifications/{event_id}/retry を実装
  - status='failed' の通知のみ再送キュー（pending）へ遷移可能。pending/sent に対するリクエストは 400 INVALID_RETRY_TARGET を返す。
  - リトライ上限はバックオフ間隔設定 NOTIFICATION_RETRY_BACKOFF_MINUTES = {1:1, 2:5, 3:30} の長さから導出。上限到達時は 409 RETRY_LIMIT_EXCEEDED を返す。
  - 成功時の副作用：outbox.status → "pending"、retry_count++、next_retry_at をバックオフで算出（UTCミリ秒文字列）、last_attempt_at 更新、last_error をクリア、notification_queued 監査イベントを記録。
  - 実装は DBTaskRunner キュー内でトランザクション的に実行。条件付き UPDATE（期待する status/retry_count）で競合を検出し、0 行更新時は再読込して 404/400/409 等へマッピング。
  - docs/db-api-endpoints.md を planned → implemented に更新。
  - 変更ファイル（主要）：src/portfolio_fdc/db_api/app.py、tests/db_api/test_db_api_governance_notifications_retry_endpoint.py、docs/db-api-endpoints.md

検証結果
- 関連テスト実行済み：テスト群（38件）すべてパス
- 追加ユニットテスト：_compute_notification_next_retry_at の境界チェック（辞書外 retry_count は ValueError）

重要な修正
- backoff 参照時の防御を追加（guard notification retry backoff lookup） — 辞書外参照を防ぐガードを導入

リスク・テストギャップ（短く）
- バックオフ辞書外の運用値に対するフォールバックやより詳細なログが不足（現在は ValueError が発生するテストあり）
- 高負荷・並行環境での競合状況の実運用検証が未実施（条件付き UPDATE はあるが負荷下での挙動・再試行戦略の負荷試験なし）
- DB 障害／トランザクション失敗時の副作用（監査イベントの重複・欠落、ロールバック挙動）を検証する統合テストがない
- 監査イベントのペイロード（actor, correlation_id 等）の詳細な検証が限定的
- 境界ケースの追加カバレッジ不足（retry_count が上限直前から上限到達する遷移、負の／不正な event_id 等）
- 再送ワーカーとの並行処理に伴う二重キューイングや順序整合性の検証がない

テストカバレッジ（要点）
- カバー済み：正常系（failed→pending）、404（未存在）、400（status が pending／sent）、409（リトライ上限超過）
- 欠如：並行競合の統合負荷試験、DB障害時の副作用テスト、監査イベント内容のより詳細なアサーション、追加境界値ケース

コミット要旨
- リトライ上限をバックオフ配列長から導出するリファクタ（旧 MAX 定数除去）
- エンドポイント本体・ヘルパー・テスト群を追加し、ドキュメントに実装状態を反映
- backoff 参照の防御処理を追加（不正な retry_count 参照のガード）

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/200)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->