### PR TITLE
feat: 緊急変更（emergency change）の即時反映と事後追認エンドポイントを追加 (Issue #102)

### DIFF
--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -71,7 +71,7 @@
 
 ## Must-Test Cases for API Contract
 
-しきい値更新 API（planned endpoint）を実装する際、以下のケースを最小必須テストとする。
+しきい値更新 API を実装する際、以下のケースを最小必須テストとする.
 
 ### Normal Update
 
@@ -93,12 +93,24 @@
 1. 同一 `Idempotency-Key` で再送した場合、二重更新しない
 2. `ChartsHistory` が二重記録されない
 
-### Emergency Update
+### Emergency Update Flow
 
-1. emergency 権限なしでは拒否する
-2. emergency 権限ありでは強制更新を許可する
-3. `reason` 必須を検証する
-4. `ChartsHistory` に `is_emergency=true` を記録する
+#### POST /governance/emergency-changes (即時反映)
+
+1. 正常系: `reason` 必須で、即座に ChartsV2 を更新し version を 1 増加させる
+2. 成功時に ChartsHistory に 1 件追加される（`change_source='emergency_manual'`）
+3. AuditEvents に `emergency_changed` タイプのイベントが記録される
+4. NotificationOutbox に `pending` 状態で登録され、通知ポーラー対象になる
+5. 空 payload（`{}`）やタイポのみの payload は 422 を返す
+6. 対象 chart が存在しない場合は 404 を返す
+7. しきい値整合性チェック失敗は 422 を返す
+8. 変更なし更新（同一値送信）は no-op として成功応答を返し、ChartsHistory を追加しない
+
+#### POST /governance/emergency-changes/{request_id}/ratify (事後追認)
+
+1. 正常系: 緊急変更を追認し、`related_issue_or_pr` を GovernanceEmergencyChanges に埋め込む
+2. AuditEvents に `emergency_ratified` タイプのイベントが記録される
+3. 同一 request_id での重複追認は 409 で拒否する
 
 ### Boundary and Edge Cases
 

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -449,14 +449,16 @@ def _parse_result_pk(result_id: str) -> int:
         raise HTTPException(status_code=400, detail="Invalid result_id") from exc
 
 
-def _not_found_error_response(*, message: str, details: dict[str, str]) -> JSONResponse:
-    """契約準拠の 404 error envelope を返す。"""
+def _not_found_error_response(
+    *, code: str = "NOT_FOUND", message: str, details: dict[str, str]
+) -> JSONResponse:
+    """404 error envelope を返す。code を指定可能にする。"""
     return JSONResponse(
         status_code=404,
         content={
             "ok": False,
             "error": {
-                "code": "NOT_FOUND",
+                "code": code,
                 "message": message,
                 "details": details,
             },
@@ -1122,6 +1124,12 @@ def create_governance_emergency_change(payload: EmergencyChangeIn, runner: Runne
             ) = row
 
             patch = _parse_threshold_patch(payload.change_payload)
+            # Reject empty or typo-only patches: at least one threshold key must be present
+            if not any(k in patch for k in ["warn_low", "warn_high", "crit_low", "crit_high"]):
+                raise _GovernanceApplyValidationError(
+                    message="change_payload must contain at least one of: "
+                    "warn_low, warn_high, crit_low, crit_high"
+                )
             new_warn_low = patch.get("warn_low", old_warn_low)
             new_warn_high = patch.get("warn_high", old_warn_high)
             new_crit_low = patch.get("crit_low", old_crit_low)
@@ -1270,7 +1278,7 @@ def create_governance_emergency_change(payload: EmergencyChangeIn, runner: Runne
         data = runner.submit("write", _write)
         return {"ok": True, "data": data}
     except _GovernanceEmergencyChangeChartNotFound:
-        return _bad_request_error_response(
+        return _not_found_error_response(
             code="CHART_NOT_FOUND",
             message="target chart not found",
             details={"chart_id": str(payload.chart_id)},

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -1123,7 +1123,12 @@ def create_governance_emergency_change(payload: EmergencyChangeIn, runner: Runne
                 current_version,
             ) = row
 
-            patch = _parse_threshold_patch(payload.change_payload)
+            try:
+                patch = _parse_threshold_patch(payload.change_payload)
+            except json.JSONDecodeError as e:
+                raise _GovernanceApplyValidationError(
+                    message="change_payload must be valid JSON"
+                ) from e
             # Reject empty or typo-only patches: at least one threshold key must be present
             if not any(k in patch for k in ["warn_low", "warn_high", "crit_low", "crit_high"]):
                 raise _GovernanceApplyValidationError(

--- a/tests/db_api/test_db_api_governance_emergency_changes_endpoint.py
+++ b/tests/db_api/test_db_api_governance_emergency_changes_endpoint.py
@@ -306,7 +306,7 @@ def test_post_emergency_changes_success_updates_chart_and_writes_audit(
     assert _find_notification_outbox_status(ec_id) == ("pending", 0)
 
 
-def test_post_emergency_changes_returns_400_when_chart_not_found(client: TestClient) -> None:
+def test_post_emergency_changes_returns_404_when_chart_not_found(client: TestClient) -> None:
     res = client.post(
         "/governance/emergency-changes",
         json={
@@ -318,7 +318,7 @@ def test_post_emergency_changes_returns_400_when_chart_not_found(client: TestCli
         },
     )
 
-    assert res.status_code == 400
+    assert res.status_code == 404
     body = res.json()
     assert body["ok"] is False
     assert body["error"]["code"] == "CHART_NOT_FOUND"
@@ -345,6 +345,54 @@ def test_post_emergency_changes_returns_422_for_invalid_change_payload(
         res.json(),
         expected_loc_fragment="change_payload",
         expected_message_fragment="valid JSON",
+    )
+
+
+def test_post_emergency_changes_returns_422_for_empty_change_payload(
+    client: TestClient,
+    seeded_emergency_chart: tuple[int, int],
+) -> None:
+    _, chart_id = seeded_emergency_chart
+    res = client.post(
+        "/governance/emergency-changes",
+        json={
+            "chart_id": chart_id,
+            "changed_by": "ops-user",
+            "changed_by_role": "operator",
+            "reason": "incident mitigation",
+            "change_payload": "{}",
+        },
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(
+        res.json(),
+        expected_loc_fragment="change_payload",
+        expected_message_fragment="must contain at least one of",
+    )
+
+
+def test_post_emergency_changes_returns_422_for_typo_only_change_payload(
+    client: TestClient,
+    seeded_emergency_chart: tuple[int, int],
+) -> None:
+    _, chart_id = seeded_emergency_chart
+    res = client.post(
+        "/governance/emergency-changes",
+        json={
+            "chart_id": chart_id,
+            "changed_by": "ops-user",
+            "changed_by_role": "operator",
+            "reason": "incident mitigation",
+            "change_payload": '{"typo_key": 1.5, "invalid_field": 2.0}',
+        },
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(
+        res.json(),
+        expected_loc_fragment="change_payload",
+        expected_message_fragment="must contain at least one of",
     )
 
 

--- a/tests/db_api/test_db_api_governance_emergency_changes_endpoint.py
+++ b/tests/db_api/test_db_api_governance_emergency_changes_endpoint.py
@@ -489,7 +489,7 @@ def test_post_emergency_changes_ratify_returns_409_when_already_ratified(
     assert body["error"]["code"] == "ALREADY_RATIFIED"
 
 
-def test_post_emergency_changes_returns_400_for_invalid_chart_id(
+def test_post_emergency_changes_returns_422_for_invalid_chart_id(
     client: TestClient,
 ) -> None:
     res = client.post(

--- a/tests/db_api/test_db_api_governance_emergency_changes_endpoint.py
+++ b/tests/db_api/test_db_api_governance_emergency_changes_endpoint.py
@@ -411,6 +411,7 @@ def test_post_emergency_changes_ratify_success_updates_related_issue_or_pr(
             "change_payload": '{"warn_high": 1.9, "crit_high": 2.0}',
         },
     )
+    assert create_res.status_code == 200
     ec_id = int(create_res.json()["data"]["request_id"])
 
     res = client.post(
@@ -468,6 +469,7 @@ def test_post_emergency_changes_ratify_returns_409_when_already_ratified(
             "change_payload": '{"warn_high": 1.9, "crit_high": 2.0}',
         },
     )
+    assert create_res.status_code == 200
     ec_id = int(create_res.json()["data"]["request_id"])
 
     first_res = client.post(
@@ -485,3 +487,97 @@ def test_post_emergency_changes_ratify_returns_409_when_already_ratified(
     body = second_res.json()
     assert body["ok"] is False
     assert body["error"]["code"] == "ALREADY_RATIFIED"
+
+
+def test_post_emergency_changes_returns_400_for_invalid_chart_id(
+    client: TestClient,
+) -> None:
+    res = client.post(
+        "/governance/emergency-changes",
+        json={
+            "chart_id": "not-a-number",
+            "changed_by": "ops-user",
+            "changed_by_role": "operator",
+            "reason": "incident mitigation",
+            "change_payload": '{"warn_high": 1.9}',
+        },
+    )
+
+    assert res.status_code == 422
+    body = res.json()
+    assert body["ok"] is False
+    # Verify that chart_id is mentioned in the validation error
+    issues = body.get("error", {}).get("details", {}).get("issues", [])
+    assert any("chart_id" in str(issue.get("loc", [])) for issue in issues)
+
+
+def test_post_emergency_changes_returns_422_for_threshold_consistency(
+    client: TestClient,
+    seeded_emergency_chart: tuple[int, int],
+) -> None:
+    _, chart_id = seeded_emergency_chart
+    # Send payload with warn_low > warn_high, violating consistency rule
+    res = client.post(
+        "/governance/emergency-changes",
+        json={
+            "chart_id": chart_id,
+            "changed_by": "ops-user",
+            "changed_by_role": "operator",
+            "reason": "incident mitigation",
+            "change_payload": '{"warn_low": 3.0, "warn_high": 1.0}',
+        },
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(
+        res.json(),
+        expected_loc_fragment="change_payload",
+        expected_message_fragment="warn_low",
+    )
+
+
+def test_post_emergency_changes_noop_success_does_not_add_history(
+    client: TestClient,
+    seeded_emergency_chart: tuple[int, int],
+) -> None:
+    _, chart_id = seeded_emergency_chart
+
+    # Get initial history count
+    con = _connect(MAIN_DB)
+    try:
+        initial_count = con.execute(
+            "SELECT COUNT(*) FROM ChartsHistory WHERE chart_id = ?",
+            (chart_id,),
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    # Submit a no-op change (same values as current)
+    payload_json = '{"warn_low": 1.0, "warn_high": 2.0, "crit_low": 0.8, "crit_high": 2.2}'
+    res = client.post(
+        "/governance/emergency-changes",
+        json={
+            "chart_id": chart_id,
+            "changed_by": "ops-user",
+            "changed_by_role": "operator",
+            "reason": "incident mitigation",
+            "change_payload": payload_json,
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"]["noop"] is True
+
+    # Verify history count did not increase
+    con = _connect(MAIN_DB)
+    try:
+        final_count = con.execute(
+            "SELECT COUNT(*) FROM ChartsHistory WHERE chart_id = ?",
+            (chart_id,),
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    assert final_count == initial_count


### PR DESCRIPTION
## What

Issue #102 の変更ガバナンス方針に基づき、緊急変更の即時反映と事後追認フローを実装しました。

新規エンドポイント：
- POST /governance/emergency-changes : 緊急変更を即座に適用
- POST /governance/emergency-changes/{request_id}/ratify : 事後追認して関連 Issue/PR を記録

## Why

緊急事案では approve→apply の段階的ガバナンスでは対応が遅すぎるため、以下を実現する必要がありました：

1. **即応性** : 変更検出→即座に適用→通知キューに自動登録
2. **監査可能性** : 事後追認で関連 PR/Issue リンク、追認者・理由を記録
3. **原子性** : ChartsV2 + ChartsHistory + GovernanceEmergencyChanges + AuditEvents + NotificationOutbox を 1 トランザクション内で完結

## How

### 1. スキーマ追加 (src/portfolio_fdc/db_api/schemas.py)

- EmergencyChangeIn : chart_id, changed_by, changed_by_role, reason, change_payload
- EmergencyChangeRatifyIn : ratified_by_role, ratification_comment, related_pr

### 2. エンドポイント実装 (src/portfolio_fdc/db_api/app.py)

- /governance/emergency-changes POST : 1 atomic TX で ChartsV2 UPDATE + ChartsHistory INSERT + GovernanceEmergencyChanges + AuditEvents + NotificationOutbox を完結
- /governance/emergency-changes/{request_id}/ratify POST : related_issue_or_pr 埋め込み＆追認監査イベント記録
- エラー処理 : 404 (chart 未検出) / 400 (存在しない chart_id) / 422 (JSON/しきい値エラー) / 409 (重複追認)

### 3. テスト追加 (tests/db_api/test_db_api_governance_emergency_changes_endpoint.py)

- 成功系 : version bump、history 記録、audit event、notification outbox 検証
- エラーケース : 404 / 400 / 422 / 409
- 追認フロー : related_pr 更新、重複追認ブロック

### 4. ドキュメント更新 (docs/db-api-endpoints.md)

- 両エンドポイントを implemented に更新

## Checklist

- [x] Tests added/updated (6 test cases, 38 total governance tests)
- [x] ruff/mypy/pytest pass locally
- [x] docs/db-api-endpoints.md updated
- [x] docs/decision-log.md referenced (論点8 Emergency TX スコープ)
- [x] TX atomic scope verified

## Related

- Issue #102 : 変更ガバナンス方針
- docs/decision-log.md : 論点8 Emergency TX スコープ
- commit: c668976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 実装内容（要点）
- 緊急変更即時反映（POST /governance/emergency-changes）
  - ChartsV2 UPDATE、ChartsHistory INSERT、GovernanceEmergencyChanges 登録、AuditEvents 発行、NotificationOutbox 登録を単一トランザクションで実行
  - change_payload の検証強化：無効 JSON → 422、空オブジェクト／有効キー（warn_low/high, crit_low/high）未包含 → 422、しきい値整合性チェック、noop 判定（差分小なら version 更新/History 追加抑制）
  - チャート未検出時は 404（error.code="CHART_NOT_FOUND"）を返却
- 事後追認（POST /governance/emergency-changes/{request_id}/ratify）
  - ratified_by_role, ratification_comment, related_pr を保存して既存レコードを更新、監査イベント(emergency_ratified) を発行
  - 既に追認済みの再追認は 409 でブロック
- ヘルパー変更
  - _not_found_error_response に code パラメータを追加（404 応答の error.code を柔軟化）
- ドキュメント
  - docs/db-api-endpoints.md で両エンドポイントを implemented に更新、Tracking を Issue #102 から source: db_api/app.py に差替え、API 契約テスト要件（Emergency Update Flow）を明確化

## テストカバレッジ（変更点）
- 新規/更新テスト計6件（ガバナンス系合計 38 件）
- 正常系：version 更新、ChartsHistory 挿入、監査イベント、notification outbox 登録、noop の扱い検証
- エラー系：404（chart 未発見）、422（無効 JSON / 空オブジェクト / 無効キーのみ / しきい値不整合 等）、409（重複追認）、既存の chart_id 型検証等
- テスト中で 400 → 404 期待値変更を反映（該当テスト名をリネーム）

## リスク
- トランザクション競合
  - SELECT ... FOR UPDATE 等の排他制御が明示されておらず、並行リクエストでの lost update や整合性不整合のリスクあり
- 非同期／副次処理の失敗時挙動
  - runner.submit()/通知送信など外部処理失敗時の部分コミット／ロールバックやリトライロジックのテスト・設計が不足
- 例外ハンドリング網羅性
  - トランザクション中の DB 接続エラーや runner.submit の例外に対する API 応答と監査ログの一貫性が未検証
- 浮動小数点しきい値判定
  - noop 判定で math.isclose(rel_tol=1e-9) を使用しているが、本番での許容誤差が適切か不明

## テストギャップ（推奨追加検証）
- 並行リクエストによるレース条件（楽観ロック／悲観ロックの挙動確認）
- トランザクション内での外部処理失敗時（通知送信など）の完全ロールバック検証
- DB 接続障害や runner.submit の例外発生時の API エラー応答・監査ログ整合性テスト
- 大きな/特殊文字を含む change_payload の境界値・パフォーマンス検証
- 浮動小数点閾値の許容誤差（rel_tol）の検証と運用基準化

（参照：Issue #102、docs/decision-log.md 論点8、参照コミット c668976）

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/201)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->