### PR TITLE
ci: import-linter を GitHub Actions で強制実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           mypy src
 
+      - name: Import Linter
+        run: |
+          python scripts/run_import_linter.py
+
       - name: Pytest
         run: |
           pytest

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -66,7 +66,7 @@
 
 検証方針:
 
-1. import 境界は `import-linter` で pre-commit で機械検出する（CI での強制は未実装・フォローアップ: Issue #108）。
+1. import 境界は `import-linter` で pre-commit と CI の両方で機械検出する（Issue #108 対応）。
 2. endpoint 権限は API スキーマ実装時にテスト（認可・認証）で検証する。
 
 ## Must-Test Cases for API Contract


### PR DESCRIPTION
## What

CI に import-linter の実行ステップを追加し、モジュール境界違反を pull request 時点で自動検知できるようにしました。

- .github/workflows/ci.yml に Import Linter ステップを追加
- docs/db-api-endpoints.md の検証方針を更新（pre-commit + CI 両方で検出）

## Why

これまで import 境界チェックは pre-commit 側のみで、CI 側では未強制でした。
Issue #108 のフォローアップとして CI 側に同等のガードを追加し、環境差分やローカル未実行による見落としを防ぎます。

## How

1. CI workflow 更新
- mypy の後、pytest の前に python scripts/run_import_linter.py を追加

2. ドキュメント更新
- docs/db-api-endpoints.md の「検証方針」を現行運用に合わせて修正

## Validation

- python scripts/run_import_linter.py 実行: contracts 3件すべて KEPT
- pre-commit hooks: pass（yaml check / import-linter 含む）

## Impact

- 既存 API の挙動変更なし
- CI の品質ゲートが1つ追加されるのみ

## Related

- Issue #108
- commit: 1217cf5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容

- **CI ワークフロー追加**: `.github/workflows/ci.yml` に `python scripts/run_import_linter.py` ステップを追加（Mypy後、Pytest前）
- **ドキュメント更新**: `docs/db-api-endpoints.md` の検証方針を更新し、import 境界ルール検出が pre-commit + CI の両方で機械的に行われることを明記

## リスク

- `scripts/run_import_linter.py` で戻り値が常に 0 固定（16行目）のため、import-linter のエラーが CI 失敗として適切に伝播しない可能性がある
- CI 版と pre-commit 版で設定値が乖離すると異なる結果が生じるリスク（現在は両方とも `pyproject.toml` を参照するため大丈夫なはず）
- lint_imports_command のエラーハンドリングが不十分で、違反が黙殺される可能性

## テストギャップ

- モジュール境界違反を検出することを保証するユニット/統合テストが不足（既存 33 テストのうち、明示的な import 契約テストが見当たらない）
- 実際に違反ケース（dashboard → judge import など）が CI で検出される動作確認テストがない

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/202)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->