### PR TITLE
fix: address Issue #142 gaps - complete governance change request apply flow

### DIFF
--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -578,10 +578,18 @@ class _GovernanceApplyChartNotFound(Exception):
 class _GovernanceApplyVersionConflict(Exception):
     """expected_version と current.version が不一致の場合に送出する内部例外。"""
 
-    def __init__(self, *, current_version: int, current_updated_at: str, chart_id: int) -> None:
+    def __init__(
+        self,
+        *,
+        current_version: int,
+        current_updated_at: str,
+        chart_id: int,
+        current_status: str,
+    ) -> None:
         self.current_version = current_version
         self.current_updated_at = current_updated_at
         self.chart_id = chart_id
+        self.current_status = current_status
 
 
 class _GovernanceApplyValidationError(Exception):
@@ -1636,7 +1644,7 @@ def approve_governance_change_request(
 
     try:
         data = runner.submit("write", _write)
-        return {"ok": True, "data": data}
+        return {"ok": True, "data": data, "timestamp": to_utc_millis(datetime.now(UTC).isoformat())}
     except GovernanceNotFoundError:
         return _not_found_error_response(
             message="change request not found",
@@ -1675,164 +1683,182 @@ def apply_governance_change_request(
         con = _connect(MAIN_DB)
         try:
             con.execute("BEGIN")
-            req = _governance_change_request_repository.find_by_id(con, request_id)
-            if req.status != "approved":
-                raise _GovernanceApplyInvalidState
+            try:
+                req = _governance_change_request_repository.find_by_id(con, request_id)
+                if req.status != "approved":
+                    raise _GovernanceApplyInvalidState
 
-            chart_row = con.execute(
-                """
-                SELECT
-                    id, chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                    step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
-                    version, updated_at
-                FROM ChartsV2
-                WHERE id = ?
-                """,
-                (req.chart_id,),
-            ).fetchone()
-            if chart_row is None:
-                raise _GovernanceApplyChartNotFound
-
-            (
-                chart_id,
-                chart_set_id,
-                tool_id,
-                chamber_id,
-                recipe_id,
-                parameter,
-                step_no,
-                feature_type,
-                old_warn_low,
-                old_warn_high,
-                old_crit_low,
-                old_crit_high,
-                current_version,
-                current_updated_at,
-            ) = chart_row
-
-            if int(current_version) != int(req.expected_version):
-                raise _GovernanceApplyVersionConflict(
-                    current_version=int(current_version),
-                    current_updated_at=str(current_updated_at),
-                    chart_id=int(chart_id),
-                )
-
-            patch = _parse_threshold_patch(req.change_payload)
-            new_warn_low = patch.get("warn_low", old_warn_low)
-            new_warn_high = patch.get("warn_high", old_warn_high)
-            new_crit_low = patch.get("crit_low", old_crit_low)
-            new_crit_high = patch.get("crit_high", old_crit_high)
-
-            _validate_threshold_consistency(
-                warn_low=new_warn_low,
-                warn_high=new_warn_high,
-                crit_low=new_crit_low,
-                crit_high=new_crit_high,
-            )
-
-            def _thresh_eq(a: float | None, b: float | None) -> bool:
-                if a is None and b is None:
-                    return True
-                if a is None or b is None:
-                    return False
-                return math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-12)
-
-            is_noop = (
-                _thresh_eq(old_warn_low, new_warn_low)
-                and _thresh_eq(old_warn_high, new_warn_high)
-                and _thresh_eq(old_crit_low, new_crit_low)
-                and _thresh_eq(old_crit_high, new_crit_high)
-            )
-
-            resulting_version = int(current_version)
-            if not is_noop:
-                resulting_version = int(current_version) + 1
-                con.execute(
+                chart_row = con.execute(
                     """
-                    UPDATE ChartsV2
-                    SET warn_low = ?, warn_high = ?, crit_low = ?, crit_high = ?,
-                        version = ?, updated_at = ?, updated_by = ?,
-                        update_reason = ?, update_source = ?
+                    SELECT
+                        id, chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                        step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                        version, updated_at
+                    FROM ChartsV2
                     WHERE id = ?
                     """,
-                    (
-                        new_warn_low,
-                        new_warn_high,
-                        new_crit_low,
-                        new_crit_high,
-                        resulting_version,
-                        applied_at,
-                        payload.applied_by,
-                        payload.reason,
-                        "governance_apply",
-                        chart_id,
-                    ),
-                )
-                con.execute(
-                    """
-                    INSERT INTO ChartsHistory(
-                        chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                        step_no, feature_type,
-                        old_warn_low, old_warn_high, old_crit_low, old_crit_high,
-                        new_warn_low, new_warn_high, new_crit_low, new_crit_high,
-                        changed_at, changed_by, change_reason, change_source, chart_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        chart_set_id,
-                        tool_id,
-                        chamber_id,
-                        recipe_id,
-                        parameter,
-                        step_no,
-                        feature_type,
-                        old_warn_low,
-                        old_warn_high,
-                        old_crit_low,
-                        old_crit_high,
-                        new_warn_low,
-                        new_warn_high,
-                        new_crit_low,
-                        new_crit_high,
-                        applied_at,
-                        payload.applied_by,
-                        payload.reason,
-                        "governance_apply",
-                        chart_id,
-                    ),
+                    (req.chart_id,),
+                ).fetchone()
+                if chart_row is None:
+                    raise _GovernanceApplyChartNotFound
+
+                (
+                    chart_id,
+                    chart_set_id,
+                    tool_id,
+                    chamber_id,
+                    recipe_id,
+                    parameter,
+                    step_no,
+                    feature_type,
+                    old_warn_low,
+                    old_warn_high,
+                    old_crit_low,
+                    old_crit_high,
+                    current_version,
+                    current_updated_at,
+                ) = chart_row
+
+                if int(current_version) != int(req.expected_version):
+                    raise _GovernanceApplyVersionConflict(
+                        current_version=int(current_version),
+                        current_updated_at=str(current_updated_at),
+                        chart_id=int(chart_id),
+                        current_status="unknown",
+                    )
+
+                patch = _parse_threshold_patch(req.change_payload)
+                new_warn_low = patch.get("warn_low", old_warn_low)
+                new_warn_high = patch.get("warn_high", old_warn_high)
+                new_crit_low = patch.get("crit_low", old_crit_low)
+                new_crit_high = patch.get("crit_high", old_crit_high)
+
+                _validate_threshold_consistency(
+                    warn_low=new_warn_low,
+                    warn_high=new_warn_high,
+                    crit_low=new_crit_low,
+                    crit_high=new_crit_high,
                 )
 
-            con.execute(
-                """
-                INSERT OR REPLACE INTO GovernanceApplyResults(
-                    request_id, applied_at, success, resulting_version,
-                    error_code, error_message
-                ) VALUES (?, ?, 1, ?, NULL, NULL)
-                """,
-                (request_id, applied_at, resulting_version),
-            )
-            _governance_change_request_repository.update_status(
-                con,
-                record_id=request_id,
-                new_status="applied",
-            )
-            _audit_event_writer.write(
-                con,
-                event_type="change_applied",
-                actor=payload.applied_by,
-                actor_role=payload.applied_by_role,
-                target_type="change_request",
-                target_id=request_id,
-                occurred_at=applied_at,
-                correlation_id=f"request:{request_id}",
-            )
-            con.commit()
-            return {
-                "request_id": request_id,
-                "status": "applied",
-                "resulting_version": resulting_version,
-                "noop": is_noop,
-            }
+                def _thresh_eq(a: float | None, b: float | None) -> bool:
+                    if a is None and b is None:
+                        return True
+                    if a is None or b is None:
+                        return False
+                    return math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-12)
+
+                is_noop = (
+                    _thresh_eq(old_warn_low, new_warn_low)
+                    and _thresh_eq(old_warn_high, new_warn_high)
+                    and _thresh_eq(old_crit_low, new_crit_low)
+                    and _thresh_eq(old_crit_high, new_crit_high)
+                )
+
+                resulting_version = int(current_version)
+                if not is_noop:
+                    resulting_version = int(current_version) + 1
+                    con.execute(
+                        """
+                        UPDATE ChartsV2
+                        SET warn_low = ?, warn_high = ?, crit_low = ?, crit_high = ?,
+                            version = ?, updated_at = ?, updated_by = ?,
+                            update_reason = ?, update_source = ?
+                        WHERE id = ?
+                        """,
+                        (
+                            new_warn_low,
+                            new_warn_high,
+                            new_crit_low,
+                            new_crit_high,
+                            resulting_version,
+                            applied_at,
+                            payload.applied_by,
+                            payload.reason,
+                            "governance_apply",
+                            chart_id,
+                        ),
+                    )
+                    con.execute(
+                        """
+                        INSERT INTO ChartsHistory(
+                            chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                            step_no, feature_type,
+                            old_warn_low, old_warn_high, old_crit_low, old_crit_high,
+                            new_warn_low, new_warn_high, new_crit_low, new_crit_high,
+                            changed_at, changed_by, change_reason, change_source, chart_id
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            chart_set_id,
+                            tool_id,
+                            chamber_id,
+                            recipe_id,
+                            parameter,
+                            step_no,
+                            feature_type,
+                            old_warn_low,
+                            old_warn_high,
+                            old_crit_low,
+                            old_crit_high,
+                            new_warn_low,
+                            new_warn_high,
+                            new_crit_low,
+                            new_crit_high,
+                            applied_at,
+                            payload.applied_by,
+                            payload.reason,
+                            "governance_apply",
+                            chart_id,
+                        ),
+                    )
+
+                con.execute(
+                    """
+                    INSERT OR REPLACE INTO GovernanceApplyResults(
+                        request_id, applied_at, success, resulting_version,
+                        error_code, error_message
+                    ) VALUES (?, ?, 1, ?, NULL, NULL)
+                    """,
+                    (request_id, applied_at, resulting_version),
+                )
+                _governance_change_request_repository.update_status(
+                    con,
+                    record_id=request_id,
+                    new_status="applied",
+                )
+                _audit_event_writer.write(
+                    con,
+                    event_type="change_applied",
+                    actor=payload.applied_by,
+                    actor_role=payload.applied_by_role,
+                    target_type="change_request",
+                    target_id=request_id,
+                    occurred_at=applied_at,
+                    correlation_id=f"request:{request_id}",
+                )
+                con.commit()
+                return {
+                    "request_id": request_id,
+                    "status": "applied",
+                    "resulting_version": resulting_version,
+                    "noop": is_noop,
+                }
+            except (
+                _GovernanceApplyInvalidState,
+                _GovernanceApplyValidationError,
+                _GovernanceApplyVersionConflict,
+            ):
+                _audit_event_writer.write(
+                    con,
+                    event_type="change_apply_failed",
+                    actor=payload.applied_by,
+                    actor_role=payload.applied_by_role,
+                    target_type="change_request",
+                    target_id=request_id,
+                    occurred_at=applied_at,
+                    correlation_id=f"request:{request_id}",
+                )
+                raise
         except Exception:
             con.rollback()
             raise
@@ -1841,7 +1867,7 @@ def apply_governance_change_request(
 
     try:
         data = runner.submit("write", _write)
-        return {"ok": True, "data": data}
+        return {"ok": True, "data": data, "timestamp": to_utc_millis(datetime.now(UTC).isoformat())}
     except GovernanceNotFoundError:
         return _not_found_error_response(
             message="change request not found",
@@ -1873,6 +1899,7 @@ def apply_governance_change_request(
                             "chart_id": e.chart_id,
                             "version": e.current_version,
                             "updated_at": e.current_updated_at,
+                            "status": e.current_status,
                         },
                     },
                 },

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -1724,7 +1724,7 @@ def apply_governance_change_request(
                         current_version=int(current_version),
                         current_updated_at=str(current_updated_at),
                         chart_id=int(chart_id),
-                        current_status="unknown",
+                        current_status=str(getattr(req, "status", "unknown") or "unknown"),
                     )
 
                 patch = _parse_threshold_patch(req.change_payload)
@@ -1858,6 +1858,7 @@ def apply_governance_change_request(
                     occurred_at=applied_at,
                     correlation_id=f"request:{request_id}",
                 )
+                con.commit()
                 raise
         except Exception:
             con.rollback()

--- a/tests/db_api/test_db_api_governance_change_requests_endpoint.py
+++ b/tests/db_api/test_db_api_governance_change_requests_endpoint.py
@@ -595,6 +595,40 @@ def test_post_approve_change_requests_returns_409_for_duplicate_approval(
     assert body["error"]["details"]["request_id"] == str(request_id)
 
 
+def test_post_approve_change_requests_success_envelope_contract(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    idempotency_key = f"approve-envelope-{uuid4().hex[:12]}"
+
+    request_id = _insert_change_request(
+        chart_id=seeded.chart_2_id,
+        proposed_by="ops",
+        proposed_at="2026-05-04T00:00:00.000Z",
+        idempotency_key=idempotency_key,
+        change_payload="{}",
+        expected_version=1,
+    )
+    try:
+        res = client.post(
+            f"/governance/change-requests/{request_id}/approve",
+            json={
+                "approved_by": "tester",
+                "approved_by_role": "ops",
+                "comment": "test approve contract",
+            },
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert "data" in body
+        assert "timestamp" in body
+    finally:
+        _delete_change_request_by_idempotency(idempotency_key)
+
+
 def test_post_apply_change_requests_success_noop_does_not_add_history(
     client: TestClient,
     seeded_change_requests_context: SeededChangeRequestsContext,
@@ -718,6 +752,7 @@ def test_post_apply_change_requests_returns_409_for_stale_expected_version(
 ) -> None:
     seeded = seeded_change_requests_context
     _update_chart_version(seeded.chart_1_id, 3)
+    before_history = _count_chart_history(seeded.chart_1_id)
 
     request_id = seeded.request_approved_chart_1
     res = client.post(
@@ -735,6 +770,7 @@ def test_post_apply_change_requests_returns_409_for_stale_expected_version(
     current = body["error"]["details"]["current"]
     assert current["chart_id"] == seeded.chart_1_id
     assert current["version"] == 3
+    assert _count_chart_history(seeded.chart_1_id) == before_history
 
 
 def test_post_apply_change_requests_returns_422_for_invalid_threshold_consistency(
@@ -800,6 +836,40 @@ def test_post_apply_change_requests_returns_400_when_chart_missing(
     body = res.json()
     assert body["ok"] is False
     assert body["error"]["code"] == "CHART_NOT_FOUND"
+
+
+def test_post_apply_change_requests_success_envelope_contract(
+    client: TestClient,
+    seeded_change_requests_context: SeededChangeRequestsContext,
+) -> None:
+    seeded = seeded_change_requests_context
+    idempotency_key = f"apply-envelope-{uuid4().hex[:12]}"
+
+    request_id = _insert_change_request(
+        chart_id=seeded.chart_1_id,
+        proposed_by="ops",
+        proposed_at="2026-05-04T00:00:00.000Z",
+        idempotency_key=idempotency_key,
+        change_payload='{"warn_low": 1.0}',
+        expected_version=1,
+    )
+    _update_change_request_status(request_id, "approved")
+    try:
+        res = client.post(
+            f"/governance/change-requests/{request_id}/apply",
+            json={
+                "applied_by": "tester",
+                "applied_by_role": "ops",
+            },
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["ok"] is True
+        assert "data" in body
+        assert "timestamp" in body
+    finally:
+        _delete_change_request_by_idempotency(idempotency_key)
 
 
 def test_post_change_requests_success_envelope_contract(


### PR DESCRIPTION
## What

Issue #142 の ガバナンス変更申請の実装ギャップ 4 件を修正しました。

### 修正内容

1. **409 レスポンスに \status\ フィールド追加**（ギャップ 1）
   - _GovernanceApplyVersionConflict に current_status フィールドを追加
   - 409 レスポンスの details.current に status を含める

2. **apply 失敗時の監査イベント記録**（ギャップ 2）
   - _write 関数内で apply 失敗時（InvalidState / ValidationError / VersionConflict）に audit event を記録
   - change_apply_failed イベント型で監査可能性を確保

3. **競合時の履歴テスト確認追加**（ギャップ 3）
   - test_post_apply_change_requests_returns_409_for_stale_expected_version に before/after 履歴数確認を追加
   - 版競合時に履歴が増加しないことを検証

4. **approve/apply 用の契約テスト 2 件追加**（ギャップ 4）
   - test_post_approve_change_requests_success_envelope_contract：approve 成功時の envelope / timestamp 契約
   - test_post_apply_change_requests_success_envelope_contract：apply 成功時の envelope / timestamp 契約

### 検証

- ✅ pytest: 30 テスト全て合格（approve 4, apply 11, POST change-requests 15）
- ✅ ruff チェック：合格
- ✅ pre-commit hook：全て合格（mypy / import-linter 含む）

## Related

- Issue #142: approve/apply エンドポイント実装
- docs/db-api-endpoints.md: 既に実装済みとして記載

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更概要

ガバナンス変更申請の apply フローの未実装ギャップ（Issue #142）を4点修正し、approve/apply のレスポンス契約とエラー処理を強化。

## 主要な変更（簡潔）
- 409レスポンスにステータスを含める: `_GovernanceApplyVersionConflict` に `current_status` を追加し、409の `details.current.status` に含める（実装では現在 `"unknown"` とハードコード）。
- apply 失敗時の監査記録: `_write` 内で InvalidState / ValidationError / VersionConflict の発生時に `change_apply_failed` イベントを記録してから例外再送出。
- レスポンスにタイムスタンプ追加: approve/apply 成功レスポンスに UTC ミリ秒の `timestamp` を追加。
- 履歴カウント検証の強化: 競合（409）テストで before/after の履歴カウントを確認し、履歴が増えていないことを検証。
- 契約テスト追加: approve と apply 成功時のレスポンスエンベロープ（`data` と `timestamp`）を検証する API 契約テストを追加。

## リスク・テストギャップ（短く明示）
- current_status がハードコード（"unknown"）: 実際のチャート状態を反映しておらず、将来の利用に不十分。
- 監査イベントの書き込みを検証するテストがない: `change_apply_failed` が実際に永続化されるか（失敗ケースで監査可能性が担保されるか）を確認するテストが欠落。
- 新規契約テストはレスポンス構造のみ検証: 副作用（履歴更新や監査イベント）まではカバーしていない。
- ステータス遷移チェックの限定性: 申請ステータス検査が `"approved"` のみを見ている箇所があり（将来的な状態名拡張やメッセージとの齟齬リスク）。

## 検証状況
- pytest: 30テスト合格（approve 4、apply 11、POST change-requests 15）
- ruff / pre-commit（mypy, import-linter 等）: 全通過

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/203)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->