### PR TITLE
refactor: db_api/app.py をOOPルーター分割でスリム化

### DIFF
--- a/src/portfolio_fdc/db_api/api_common.py
+++ b/src/portfolio_fdc/db_api/api_common.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import json
+import logging
+import math
+import sqlite3
+from datetime import datetime, timedelta
+from typing import NoReturn
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+from .datetime_util import to_utc_millis
+from .schemas import validate_timestamp_range
+
+logger = logging.getLogger("portfolio_fdc.db_api.app")
+
+CHARTS_FILTER_PATTERN = r"^[A-Za-z0-9_./:-]+$"
+CHARTS_FILTER_MAX_LENGTH = 128
+CHART_ID_PATTERN = r"^CHART_[0-9]+$"
+JUDGE_LEVEL_PATTERN = r"^(OK|WARN|NG)$"
+RESULT_ID_PATTERN = r"^JR_[0-9]+$"
+NOTIFICATION_RETRY_BACKOFF_MINUTES = {1: 1, 2: 5, 3: 30}
+
+
+class GovernanceApplyValidationError(Exception):
+    """apply payload がしきい値整合性を満たさない場合に送出する内部例外。"""
+
+    def __init__(self, *, message: str) -> None:
+        self.message = message
+
+
+def is_runner_unavailable_error(error: Exception) -> bool:
+    """DBTaskRunner 停止/タイムアウト起因の一時的障害かを判定する。"""
+    if isinstance(error, TimeoutError):
+        return True
+    if not isinstance(error, RuntimeError):
+        return False
+    return str(error).startswith("DBTaskRunner")
+
+
+def is_transient_operational_error(error: sqlite3.OperationalError) -> bool:
+    """OperationalError が一時的な DB 障害かどうかを判定する。"""
+    message = str(error).lower()
+
+    non_transient_markers = (
+        "no such table",
+        "no such column",
+        "syntax error",
+        "malformed",
+    )
+    if any(marker in message for marker in non_transient_markers):
+        return False
+
+    transient_markers = (
+        "database is locked",
+        "database is busy",
+        "busy",
+        "unable to open database file",
+        "disk i/o error",
+        "readonly database",
+    )
+    return any(marker in message for marker in transient_markers)
+
+
+def raise_api_error(
+    *,
+    operation: str,
+    error: Exception,
+    headers: dict[str, str] | None = None,
+) -> NoReturn:
+    """内部例外をログに残しつつ、クライアント向けには安全なエラーを返す。"""
+    logger.exception("%s failed: %s", operation, type(error).__name__)
+
+    if is_runner_unavailable_error(error):
+        raise HTTPException(
+            status_code=503,
+            detail="Service temporarily unavailable",
+            headers=headers,
+        ) from error
+
+    if isinstance(error, sqlite3.OperationalError):
+        if is_transient_operational_error(error):
+            raise HTTPException(
+                status_code=503,
+                detail="Database temporarily unavailable",
+                headers=headers,
+            ) from error
+        raise HTTPException(
+            status_code=500,
+            detail="Database operation failed",
+            headers=headers,
+        ) from error
+
+    if isinstance(error, sqlite3.DatabaseError):
+        raise HTTPException(
+            status_code=500,
+            detail="Database operation failed",
+            headers=headers,
+        ) from error
+
+    raise HTTPException(
+        status_code=500,
+        detail="Internal server error",
+        headers=headers,
+    ) from error
+
+
+def normalize_query_datetime(raw: datetime | None) -> str | None:
+    """履歴検索用の datetime クエリを SQLite 比較用 ISO 文字列へ変換する。"""
+    if raw is None:
+        return None
+    if raw.tzinfo is None:
+        raise HTTPException(
+            status_code=400,
+            detail="from_ts and to_ts must be timezone-aware datetimes",
+        )
+    return to_utc_millis(raw.isoformat())
+
+
+def validate_query_datetime_range(
+    from_ts: datetime | None,
+    to_ts: datetime | None,
+    *,
+    require_pair: bool,
+) -> None:
+    """from_ts/to_ts の指定整合と範囲整合を検証する。"""
+    if require_pair and (from_ts is None) != (to_ts is None):
+        raise HTTPException(
+            status_code=400,
+            detail="from_ts and to_ts must be specified together",
+        )
+
+    if from_ts is not None and to_ts is None:
+        if from_ts.tzinfo is None:
+            raise HTTPException(
+                status_code=400,
+                detail="from_ts and to_ts must be timezone-aware datetimes",
+            )
+        return
+
+    if to_ts is not None and from_ts is None:
+        if to_ts.tzinfo is None:
+            raise HTTPException(
+                status_code=400,
+                detail="from_ts and to_ts must be timezone-aware datetimes",
+            )
+        return
+
+    if from_ts is None or to_ts is None:
+        return
+
+    try:
+        validate_timestamp_range(from_ts, to_ts)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def parse_chart_pk(chart_id: str | None) -> int | None:
+    """CHART_<id> 形式の chart_id を int PK へ変換する。"""
+    if chart_id is None:
+        return None
+
+    try:
+        numeric_part = chart_id.split("_", maxsplit=1)[1]
+        if not numeric_part.isdigit():
+            raise ValueError("chart_id numeric part must contain only digits")
+        chart_pk = int(numeric_part)
+        if chart_pk < 1:
+            raise ValueError("chart_id must be greater than or equal to 1")
+        if not (-(2**63) <= chart_pk <= 2**63 - 1):
+            raise ValueError("chart_id out of int64 range")
+        return chart_pk
+    except (ValueError, OverflowError, IndexError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid chart_id") from exc
+
+
+def parse_result_pk(result_id: str) -> int:
+    """JR_<id> 形式の result_id を int PK へ変換する。"""
+    try:
+        numeric_part = result_id.split("_", maxsplit=1)[1]
+        if not numeric_part.isdigit():
+            raise ValueError("result_id numeric part must contain only digits")
+        result_pk = int(numeric_part)
+        if result_pk < 1:
+            raise ValueError("result_id must be greater than or equal to 1")
+        if not (-(2**63) <= result_pk <= 2**63 - 1):
+            raise ValueError("result_id out of int64 range")
+        return result_pk
+    except (ValueError, OverflowError, IndexError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid result_id") from exc
+
+
+def not_found_error_response(
+    *, code: str = "NOT_FOUND", message: str, details: dict[str, str]
+) -> JSONResponse:
+    """404 error envelope を返す。"""
+    return JSONResponse(
+        status_code=404,
+        content={
+            "ok": False,
+            "error": {
+                "code": code,
+                "message": message,
+                "details": details,
+            },
+        },
+    )
+
+
+def duplicate_idempotency_error_response(*, idempotency_key: str) -> JSONResponse:
+    """重複 idempotency_key への 409 error envelope を返す。"""
+    return JSONResponse(
+        status_code=409,
+        content={
+            "ok": False,
+            "error": {
+                "code": "DUPLICATE_IDEMPOTENCY_KEY",
+                "message": "idempotency_key already exists",
+                "details": {"idempotency_key": idempotency_key},
+            },
+        },
+    )
+
+
+def conflict_error_response(*, code: str, message: str, details: dict[str, str]) -> JSONResponse:
+    """契約準拠の 409 error envelope を返す。"""
+    return JSONResponse(
+        status_code=409,
+        content={
+            "ok": False,
+            "error": {
+                "code": code,
+                "message": message,
+                "details": details,
+            },
+        },
+    )
+
+
+def bad_request_error_response(*, code: str, message: str, details: dict[str, str]) -> JSONResponse:
+    """契約準拠の 400 error envelope を返す。"""
+    return JSONResponse(
+        status_code=400,
+        content={
+            "ok": False,
+            "error": {
+                "code": code,
+                "message": message,
+                "details": details,
+            },
+        },
+    )
+
+
+def validation_error_response(*, issues: list[dict[str, object]]) -> JSONResponse:
+    """契約準拠の 422 validation error envelope を返す。"""
+    return JSONResponse(
+        status_code=422,
+        content={
+            "ok": False,
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "Validation error",
+                "details": {"issues": issues},
+            },
+        },
+    )
+
+
+def compute_notification_next_retry_at(*, base_time: datetime, retry_count: int) -> str:
+    """retry_count に応じた次回試行時刻を UTC ミリ秒 ISO 文字列で返す。"""
+    minutes = NOTIFICATION_RETRY_BACKOFF_MINUTES.get(retry_count)
+    if minutes is None:
+        max_retries = len(NOTIFICATION_RETRY_BACKOFF_MINUTES)
+        raise ValueError(f"retry_count must be between 1 and {max_retries}")
+    return to_utc_millis((base_time + timedelta(minutes=minutes)).isoformat())
+
+
+def parse_threshold_patch(change_payload: str) -> dict[str, float | None]:
+    """change_payload からしきい値更新パッチを抽出する。"""
+    payload = json.loads(change_payload)
+    if not isinstance(payload, dict):
+        raise GovernanceApplyValidationError(message="change_payload must be an object")
+
+    aliases = {
+        "warn_low": "warn_low",
+        "warning_lcl": "warn_low",
+        "warn_high": "warn_high",
+        "warning_ucl": "warn_high",
+        "crit_low": "crit_low",
+        "critical_lcl": "crit_low",
+        "crit_high": "crit_high",
+        "critical_ucl": "crit_high",
+    }
+    patch: dict[str, float | None] = {}
+    for key, value in payload.items():
+        mapped = aliases.get(str(key))
+        if mapped is None:
+            continue
+        if value is None:
+            patch[mapped] = None
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise GovernanceApplyValidationError(message=f"{key} must be a number or null")
+        numeric = float(value)
+        if numeric != numeric or numeric in (float("inf"), float("-inf")):
+            raise GovernanceApplyValidationError(message=f"{key} must be finite")
+        patch[mapped] = numeric
+    return patch
+
+
+def validate_threshold_consistency(
+    *,
+    warn_low: float | None,
+    warn_high: float | None,
+    crit_low: float | None,
+    crit_high: float | None,
+) -> None:
+    """しきい値の大小関係を検証する。"""
+    if warn_low is not None and warn_high is not None and warn_low > warn_high:
+        raise GovernanceApplyValidationError(
+            message="warn_low must be less than or equal to warn_high"
+        )
+    if crit_low is not None and crit_high is not None and crit_low > crit_high:
+        raise GovernanceApplyValidationError(
+            message="crit_low must be less than or equal to crit_high"
+        )
+    if crit_low is not None and warn_low is not None and crit_low > warn_low:
+        raise GovernanceApplyValidationError(
+            message="crit_low must be less than or equal to warn_low"
+        )
+    if warn_high is not None and crit_high is not None and warn_high > crit_high:
+        raise GovernanceApplyValidationError(
+            message="warn_high must be less than or equal to crit_high"
+        )
+    if crit_low is not None and warn_high is not None and crit_low > warn_high:
+        raise GovernanceApplyValidationError(
+            message="crit_low must be less than or equal to warn_high"
+        )
+
+
+def thresholds_equal(a: float | None, b: float | None) -> bool:
+    """閾値の同値判定。None 同士は等値、数値は許容誤差で比較する。"""
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    return math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-12)

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -1,83 +1,56 @@
-"""FastAPI ベースの DB API エントリポイント。
-
-集約結果の書き込み系エンドポイントを提供し、アプリ単位で
-`DBTaskRunner` を初期化・再利用・停止する。
-"""
+"""FastAPI ベースの DB API エントリポイント。"""
 
 from __future__ import annotations
 
-import json
 import logging
-import math
 import os as _os
 import pathlib
-import sqlite3
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from dataclasses import asdict
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from email.utils import format_datetime
 from threading import Lock
-from typing import Annotated, NoReturn, cast
+from typing import cast
 from urllib.parse import quote
 
-from fastapi import Depends, FastAPI, HTTPException, Path, Query, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
-from .aggregate_repository import (
-    delete_process,
-    write_aggregate_atomic,
-    write_parameters_bulk,
-    write_process,
-    write_step_windows_bulk,
+from .api_common import (
+    compute_notification_next_retry_at,
+    parse_chart_pk,
+    raise_api_error,
 )
 from .audit_event_writer import AuditEventWriter
-from .chart_repository import (
-    ActiveChartsQueryCriteria,
-    ChartRepository,
-    ChartsHistoryQueryCriteria,
-    ChartsQueryCriteria,
-)
-from .datetime_util import to_utc_millis
-from .db import MAIN_DB, TEMP_DB, _connect, _connect_readonly, _init_schema
+from .chart_repository import ChartRepository
+from .db import MAIN_DB, TEMP_DB, _connect_readonly, _init_schema
 from .governance_repository import (
     GovernanceApprovalsRepository,
     GovernanceChangeRequestRepository,
     GovernanceEmergencyChangesRepository,
-    GovernanceNotFoundError,
     GovernanceRatificationsRepository,
 )
-from .judge_repository import (
-    JudgeDataCorruptionError,
-    JudgeRepository,
-    JudgeResultsQueryCriteria,
-)
-from .schemas import (
-    AggregateWriteIn,
-    ChangeRequestApplyIn,
-    ChangeRequestApproveIn,
-    ChangeRequestIn,
-    ChangeRequestsQuery,
-    EmergencyChangeIn,
-    EmergencyChangeRatifyIn,
-    GovernanceAuditEventsQuery,
-    ParameterIn,
-    ProcessDeleteIn,
-    ProcessInfoIn,
-    StepWindowIn,
-    validate_timestamp_range,
-)
+from .judge_repository import JudgeRepository
+from .routers.governance_router import GovernanceRouter
+from .routers.ingest_router import IngestRouter
+from .routers.query_router import QueryRouter
 from .task_runner import DBTaskRunner
 
 logger = logging.getLogger(__name__)
 _runner_lock = Lock()
 DATA_ROOT = "DATA_ROOT"
 
+LEGACY_DELETE_PROCESSES_SUNSET_AT = datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC)
+LEGACY_DELETE_PROCESSES_SUNSET = format_datetime(LEGACY_DELETE_PROCESSES_SUNSET_AT, usegmt=True)
 
-# パストラバーサル対策: raw CSV ファイルの許可ベースディレクトリ
-# 環境変数 DATA_ROOT で指定可能（未設定時はカレントワーキングディレクトリ）
+
+# Backward-compatible alias for tests importing from this module.
+_compute_notification_next_retry_at = compute_notification_next_retry_at
+_parse_chart_pk = parse_chart_pk
+
+
 def _get_allowed_base_dirs() -> list[pathlib.Path]:
     """許可されたベースディレクトリリストを取得。"""
     data_root = _os.environ.get(DATA_ROOT)
@@ -86,14 +59,113 @@ def _get_allowed_base_dirs() -> list[pathlib.Path]:
     return [pathlib.Path.cwd().resolve()]
 
 
-LEGACY_DELETE_PROCESSES_SUNSET_AT = datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC)
-LEGACY_DELETE_PROCESSES_SUNSET = format_datetime(LEGACY_DELETE_PROCESSES_SUNSET_AT, usegmt=True)
-CHARTS_FILTER_PATTERN = r"^[A-Za-z0-9_./:-]+$"
-CHARTS_FILTER_MAX_LENGTH = 128
-CHART_ID_PATTERN = r"^CHART_[0-9]+$"
-JUDGE_LEVEL_PATTERN = r"^(OK|WARN|NG)$"
-RESULT_ID_PATTERN = r"^JR_[0-9]+$"
-NOTIFICATION_RETRY_BACKOFF_MINUTES = {1: 1, 2: 5, 3: 30}
+def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
+    """ProcessInfo.raw_csv_path からドリルダウン表示用の波形プレビューを返す。"""
+    con = _connect_readonly(MAIN_DB)
+    try:
+        row = con.execute(
+            "SELECT raw_csv_path FROM ProcessInfo WHERE process_id = ?",
+            (process_id,),
+        ).fetchone()
+    finally:
+        con.close()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="process not found")
+
+    raw_path = row[0]
+    if raw_path is None:
+        return {"process_id": process_id, "source_path": None, "points": []}
+
+    src = pathlib.Path(str(raw_path))
+    if not src.is_absolute():
+        src = pathlib.Path.cwd() / src
+
+    src_resolved = src.resolve()
+    allowed_base_dirs = _get_allowed_base_dirs()
+    is_allowed = any(
+        src_resolved == allowed_dir or str(src_resolved).startswith(str(allowed_dir) + _os.sep)
+        for allowed_dir in allowed_base_dirs
+    )
+    if not is_allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Access to files outside the allowed base directories is forbidden: "
+                f"process_id={process_id}, file={src_resolved.name}"
+            ),
+        )
+
+    if not src_resolved.exists():
+        return {
+            "process_id": process_id,
+            "source_path": src_resolved.as_posix(),
+            "points": [],
+        }
+
+    try:
+        import pandas as pd
+
+        with src_resolved.open("r", encoding="utf-8", errors="ignore") as f:
+            start_row = 0
+            for idx, line in enumerate(f):
+                if idx >= 200:
+                    break
+                if line.strip().upper().startswith("DATA"):
+                    start_row = idx + 1
+                    break
+            f.seek(0)
+            for _ in range(start_row):
+                next(f)
+            try:
+                frame = pd.read_csv(f)
+            except pd.errors.ParserError:
+                return {
+                    "process_id": process_id,
+                    "source_path": src_resolved.as_posix(),
+                    "points": [],
+                }
+        if frame.empty:
+            return {
+                "process_id": process_id,
+                "source_path": src_resolved.as_posix(),
+                "points": [],
+            }
+
+        x_col = frame.columns[0]
+        y_col = None
+        for col in frame.columns[1:]:
+            if pd.api.types.is_numeric_dtype(frame[col]):
+                y_col = col
+                break
+        if y_col is None:
+            return {
+                "process_id": process_id,
+                "source_path": src_resolved.as_posix(),
+                "points": [],
+            }
+
+        sample = frame[[x_col, y_col]].tail(limit)
+        points = [
+            {"x": str(x), "y": None if pd.isna(y) else float(y)}
+            for x, y in sample.to_records(index=False)
+        ]
+        return {
+            "process_id": process_id,
+            "source_path": src_resolved.as_posix(),
+            "points": points,
+        }
+    except Exception:
+        logger.exception(
+            "Failed to build waveform preview for process_id=%s source_path=%s",
+            process_id,
+            src_resolved.as_posix(),
+        )
+        return {
+            "process_id": process_id,
+            "source_path": src_resolved.as_posix(),
+            "points": [],
+        }
 
 
 def _legacy_delete_headers(process_id: str | None) -> dict[str, str]:
@@ -186,89 +258,7 @@ def _runner_from_request(request: Request) -> DBTaskRunner:
     return _get_or_create_runner(request.app)
 
 
-def get_runner(request: Request) -> DBTaskRunner:
-    """FastAPI Depends 経由で遅延初期化された DBTaskRunner を提供する。"""
-    return _runner_from_request(request)
-
-
-def _is_runner_unavailable_error(error: Exception) -> bool:
-    """DBTaskRunner 停止/タイムアウト起因の一時的障害かを判定する。"""
-    if isinstance(error, TimeoutError):
-        return True
-    if not isinstance(error, RuntimeError):
-        return False
-    return str(error).startswith("DBTaskRunner")
-
-
-def _is_transient_operational_error(error: sqlite3.OperationalError) -> bool:
-    """OperationalError が一時的な DB 障害かどうかを判定する。"""
-    message = str(error).lower()
-
-    # 恒久的な設定/SQL 不整合は 500 として扱う。
-    non_transient_markers = (
-        "no such table",
-        "no such column",
-        "syntax error",
-        "malformed",
-    )
-    if any(marker in message for marker in non_transient_markers):
-        return False
-
-    transient_markers = (
-        "database is locked",
-        "database is busy",
-        "busy",
-        "unable to open database file",
-        "disk i/o error",
-        "readonly database",
-    )
-    return any(marker in message for marker in transient_markers)
-
-
-def _raise_api_error(
-    *,
-    operation: str,
-    error: Exception,
-    headers: dict[str, str] | None = None,
-) -> NoReturn:
-    """内部例外をログに残しつつ、クライアント向けには安全なエラーを返す。"""
-    logger.exception("%s failed: %s", operation, type(error).__name__)
-
-    if _is_runner_unavailable_error(error):
-        raise HTTPException(
-            status_code=503,
-            detail="Service temporarily unavailable",
-            headers=headers,
-        ) from error
-
-    if isinstance(error, sqlite3.OperationalError):
-        if _is_transient_operational_error(error):
-            raise HTTPException(
-                status_code=503,
-                detail="Database temporarily unavailable",
-                headers=headers,
-            ) from error
-        raise HTTPException(
-            status_code=500,
-            detail="Database operation failed",
-            headers=headers,
-        ) from error
-
-    if isinstance(error, sqlite3.DatabaseError):
-        raise HTTPException(
-            status_code=500,
-            detail="Database operation failed",
-            headers=headers,
-        ) from error
-
-    raise HTTPException(
-        status_code=500,
-        detail="Internal server error",
-        headers=headers,
-    ) from error
-
-
-RunnerDep = Annotated[DBTaskRunner, Depends(get_runner)]
+# Repository singletons are shared across routers.
 _chart_repository = ChartRepository()
 _judge_repository = JudgeRepository()
 _governance_change_request_repository = GovernanceChangeRequestRepository()
@@ -277,1713 +267,33 @@ _governance_emergency_changes_repository = GovernanceEmergencyChangesRepository(
 _governance_ratifications_repository = GovernanceRatificationsRepository()
 _audit_event_writer = AuditEventWriter()
 
-
-@app.get("/charts")
-def get_charts(
-    tool_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    chamber_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    recipe_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    parameter: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    step_no: int | None = Query(default=None, ge=0),
-    feature_type: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    active_only: bool = False,
-):
-    """Chart 定義一覧を返す。"""
-    criteria = ChartsQueryCriteria(
-        tool_id=tool_id,
-        chamber_id=chamber_id,
-        recipe_id=recipe_id,
-        parameter=parameter,
-        step_no=step_no,
-        feature_type=feature_type,
-        active_only=active_only,
-    )
-    try:
-        rows = _chart_repository.find_charts(criteria)
-        return {"ok": True, "data": [asdict(row) for row in rows]}
-    except Exception as e:
-        _raise_api_error(operation="GET /charts", error=e)
-
-
-@app.get("/charts/active")
-def get_active_charts(
-    tool_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    chamber_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    recipe_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-):
-    """active chart set と有効閾値一覧を返す。"""
-    criteria = ActiveChartsQueryCriteria(
-        tool_id=tool_id,
-        chamber_id=chamber_id,
-        recipe_id=recipe_id,
-    )
-    try:
-        data = _chart_repository.find_active_chart_set(criteria)
-        return {"ok": True, "data": asdict(data)}
-    except Exception as e:
-        _raise_api_error(operation="GET /charts/active", error=e)
-
-
-def _normalize_query_datetime(raw: datetime | None) -> str | None:
-    """履歴検索用の datetime クエリを SQLite 比較用 ISO 文字列へ変換する。"""
-    if raw is None:
-        return None
-    if raw.tzinfo is None:
-        raise HTTPException(
-            status_code=400,
-            detail="from_ts and to_ts must be timezone-aware datetimes",
-        )
-    return to_utc_millis(raw.isoformat())
-
-
-def _validate_query_datetime_range(
-    from_ts: datetime | None,
-    to_ts: datetime | None,
-    *,
-    require_pair: bool,
-) -> None:
-    """from_ts/to_ts の指定整合と範囲整合を検証する。"""
-    if require_pair and (from_ts is None) != (to_ts is None):
-        raise HTTPException(
-            status_code=400,
-            detail="from_ts and to_ts must be specified together",
-        )
-
-    if from_ts is not None and to_ts is None:
-        if from_ts.tzinfo is None:
-            raise HTTPException(
-                status_code=400,
-                detail="from_ts and to_ts must be timezone-aware datetimes",
-            )
-        return
-
-    if to_ts is not None and from_ts is None:
-        if to_ts.tzinfo is None:
-            raise HTTPException(
-                status_code=400,
-                detail="from_ts and to_ts must be timezone-aware datetimes",
-            )
-        return
-
-    if from_ts is None or to_ts is None:
-        return
-
-    try:
-        validate_timestamp_range(from_ts, to_ts)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-
-def _parse_chart_pk(chart_id: str | None) -> int | None:
-    """`CHART_<id>` 形式の chart_id を int PK へ変換する。"""
-    if chart_id is None:
-        return None
-
-    try:
-        numeric_part = chart_id.split("_", maxsplit=1)[1]
-        if not numeric_part.isdigit():
-            raise ValueError("chart_id numeric part must contain only digits")
-        chart_pk = int(numeric_part)
-        if chart_pk < 1:
-            raise ValueError("chart_id must be greater than or equal to 1")
-        if not (-(2**63) <= chart_pk <= 2**63 - 1):
-            raise ValueError("chart_id out of int64 range")
-        return chart_pk
-    except (ValueError, OverflowError, IndexError) as exc:
-        raise HTTPException(status_code=400, detail="Invalid chart_id") from exc
-
-
-def _parse_result_pk(result_id: str) -> int:
-    """`JR_<id>` 形式の result_id を int PK へ変換する。"""
-    try:
-        numeric_part = result_id.split("_", maxsplit=1)[1]
-        if not numeric_part.isdigit():
-            raise ValueError("result_id numeric part must contain only digits")
-        result_pk = int(numeric_part)
-        if result_pk < 1:
-            raise ValueError("result_id must be greater than or equal to 1")
-        if not (-(2**63) <= result_pk <= 2**63 - 1):
-            raise ValueError("result_id out of int64 range")
-        return result_pk
-    except (ValueError, OverflowError, IndexError) as exc:
-        raise HTTPException(status_code=400, detail="Invalid result_id") from exc
-
-
-def _not_found_error_response(
-    *, code: str = "NOT_FOUND", message: str, details: dict[str, str]
-) -> JSONResponse:
-    """404 error envelope を返す。code を指定可能にする。"""
-    return JSONResponse(
-        status_code=404,
-        content={
-            "ok": False,
-            "error": {
-                "code": code,
-                "message": message,
-                "details": details,
-            },
-        },
-    )
-
-
-def _duplicate_idempotency_error_response(*, idempotency_key: str) -> JSONResponse:
-    """重複 idempotency_key への 409 error envelope を返す。"""
-    return JSONResponse(
-        status_code=409,
-        content={
-            "ok": False,
-            "error": {
-                "code": "DUPLICATE_IDEMPOTENCY_KEY",
-                "message": "idempotency_key already exists",
-                "details": {"idempotency_key": idempotency_key},
-            },
-        },
-    )
-
-
-def _conflict_error_response(*, code: str, message: str, details: dict[str, str]) -> JSONResponse:
-    """契約準拠の 409 error envelope を返す。"""
-    return JSONResponse(
-        status_code=409,
-        content={
-            "ok": False,
-            "error": {
-                "code": code,
-                "message": message,
-                "details": details,
-            },
-        },
-    )
-
-
-def _bad_request_error_response(
-    *, code: str, message: str, details: dict[str, str]
-) -> JSONResponse:
-    """契約準拠の 400 error envelope を返す。"""
-    return JSONResponse(
-        status_code=400,
-        content={
-            "ok": False,
-            "error": {
-                "code": code,
-                "message": message,
-                "details": details,
-            },
-        },
-    )
-
-
-def _validation_error_response(*, issues: list[dict[str, object]]) -> JSONResponse:
-    """契約準拠の 422 validation error envelope を返す。"""
-    return JSONResponse(
-        status_code=422,
-        content={
-            "ok": False,
-            "error": {
-                "code": "VALIDATION_ERROR",
-                "message": "Validation error",
-                "details": {"issues": issues},
-            },
-        },
-    )
-
-
-def _is_duplicate_change_request_idempotency_error(error: sqlite3.IntegrityError) -> bool:
-    """GovernanceChangeRequests.idempotency_key の UNIQUE 違反かを判定する。"""
-    message = str(error)
-    return (
-        "GovernanceChangeRequests.idempotency_key" in message
-        or "idx_change_requests_idempotency" in message
-    )
-
-
-def _is_governance_change_request_chart_fk_error(error: sqlite3.IntegrityError) -> bool:
-    """GovernanceChangeRequests.chart_id の外部キー制約違反かを判定する。"""
-    return "foreign key constraint failed" in str(error).lower()
-
-
-def _is_governance_ratification_ec_unique_error(error: sqlite3.IntegrityError) -> bool:
-    """GovernanceRatifications.ec_id の UNIQUE 違反かを判定する。"""
-    message = str(error)
-    return (
-        "GovernanceRatifications.ec_id" in message
-        or "UNIQUE constraint failed: GovernanceRatifications.ec_id" in message
-    )
-
-
-class _GovernanceChangeRequestIdempotencyConflict(Exception):
-    """change-request 作成時の重複 idempotency_key を表す内部例外。"""
-
-
-class _GovernanceChangeRequestChartFkViolation(Exception):
-    """change-request 作成時の chart_id 外部キー違反を表す内部例外。"""
-
-
-class _GovernanceApproveAlreadyApproved(Exception):
-    """approve 対象が既に approved の場合に送出する内部例外。"""
-
-
-class _GovernanceApproveInvalidState(Exception):
-    """approve 対象の status が pending 以外の場合に送出する内部例外。"""
-
-
-class _GovernanceApplyInvalidState(Exception):
-    """apply 対象の status が approved 以外の場合に送出する内部例外。"""
-
-
-class _GovernanceApplyChartNotFound(Exception):
-    """apply 対象 chart が存在しない場合に送出する内部例外。"""
-
-
-class _GovernanceApplyVersionConflict(Exception):
-    """expected_version と current.version が不一致の場合に送出する内部例外。"""
-
-    def __init__(
-        self,
-        *,
-        current_version: int,
-        current_updated_at: str,
-        chart_id: int,
-        current_status: str,
-    ) -> None:
-        self.current_version = current_version
-        self.current_updated_at = current_updated_at
-        self.chart_id = chart_id
-        self.current_status = current_status
-
-
-class _GovernanceApplyValidationError(Exception):
-    """apply payload がしきい値整合性を満たさない場合に送出する内部例外。"""
-
-    def __init__(self, *, message: str) -> None:
-        self.message = message
-
-
-class _GovernanceNotificationNotFound(Exception):
-    """notification outbox が存在しない場合に送出する内部例外。"""
-
-
-class _GovernanceNotificationInvalidState(Exception):
-    """retry 対象の status が failed 以外の場合に送出する内部例外。"""
-
-    def __init__(self, *, status: str) -> None:
-        self.status = status
-
-
-class _GovernanceNotificationRetryLimitExceeded(Exception):
-    """retry_count が上限に達している場合に送出する内部例外。"""
-
-    def __init__(self, *, retry_count: int) -> None:
-        self.retry_count = retry_count
-
-
-class _GovernanceNotificationConcurrentModification(Exception):
-    """conditional UPDATE が 0 件更新になった場合に送出する内部例外。"""
-
-
-class _GovernanceEmergencyChangeChartNotFound(Exception):
-    """emergency change 対象 chart が存在しない場合に送出する内部例外。"""
-
-
-class _GovernanceEmergencyRatificationConflict(Exception):
-    """emergency change が既に追認済みの場合に送出する内部例外。"""
-
-    def __init__(self, *, ec_id: int) -> None:
-        self.ec_id = ec_id
-
-
-def _compute_notification_next_retry_at(*, base_time: datetime, retry_count: int) -> str:
-    """retry_count に応じた次回試行時刻を UTC ミリ秒 ISO 文字列で返す。"""
-    minutes = NOTIFICATION_RETRY_BACKOFF_MINUTES.get(retry_count)
-    if minutes is None:
-        max_retries = len(NOTIFICATION_RETRY_BACKOFF_MINUTES)
-        raise ValueError(f"retry_count must be between 1 and {max_retries}")
-    return to_utc_millis((base_time + timedelta(minutes=minutes)).isoformat())
-
-
-def _parse_threshold_patch(change_payload: str) -> dict[str, float | None]:
-    """change_payload からしきい値更新パッチを抽出する。"""
-    payload = json.loads(change_payload)
-    if not isinstance(payload, dict):
-        raise _GovernanceApplyValidationError(message="change_payload must be an object")
-
-    aliases = {
-        "warn_low": "warn_low",
-        "warning_lcl": "warn_low",
-        "warn_high": "warn_high",
-        "warning_ucl": "warn_high",
-        "crit_low": "crit_low",
-        "critical_lcl": "crit_low",
-        "crit_high": "crit_high",
-        "critical_ucl": "crit_high",
-    }
-    patch: dict[str, float | None] = {}
-    for key, value in payload.items():
-        mapped = aliases.get(str(key))
-        if mapped is None:
-            continue
-        if value is None:
-            patch[mapped] = None
-            continue
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise _GovernanceApplyValidationError(message=f"{key} must be a number or null")
-        numeric = float(value)
-        if numeric != numeric or numeric in (float("inf"), float("-inf")):
-            raise _GovernanceApplyValidationError(message=f"{key} must be finite")
-        patch[mapped] = numeric
-    return patch
-
-
-def _validate_threshold_consistency(
-    *,
-    warn_low: float | None,
-    warn_high: float | None,
-    crit_low: float | None,
-    crit_high: float | None,
-) -> None:
-    """しきい値の大小関係を検証する。"""
-    if warn_low is not None and warn_high is not None and warn_low > warn_high:
-        raise _GovernanceApplyValidationError(
-            message="warn_low must be less than or equal to warn_high"
-        )
-    if crit_low is not None and crit_high is not None and crit_low > crit_high:
-        raise _GovernanceApplyValidationError(
-            message="crit_low must be less than or equal to crit_high"
-        )
-    if crit_low is not None and warn_low is not None and crit_low > warn_low:
-        raise _GovernanceApplyValidationError(
-            message="crit_low must be less than or equal to warn_low"
-        )
-    if warn_high is not None and crit_high is not None and warn_high > crit_high:
-        raise _GovernanceApplyValidationError(
-            message="warn_high must be less than or equal to crit_high"
-        )
-    if crit_low is not None and warn_high is not None and crit_low > warn_high:
-        raise _GovernanceApplyValidationError(
-            message="crit_low must be less than or equal to warn_high"
-        )
-
-
-def _build_waveform_preview(process_id: str, limit: int) -> dict[str, object]:
-    """ProcessInfo.raw_csv_path からドリルダウン表示用の波形プレビューを返す。
-
-    READ-ONLY 接続を使用することで、書き込み作業中の lock 競合を回避する。
-    """
-    con = _connect_readonly(MAIN_DB)
-    try:
-        row = con.execute(
-            "SELECT raw_csv_path FROM ProcessInfo WHERE process_id = ?",
-            (process_id,),
-        ).fetchone()
-    finally:
-        con.close()
-
-    if row is None:
-        raise HTTPException(status_code=404, detail="process not found")
-
-    raw_path = row[0]
-    if raw_path is None:
-        return {
-            "process_id": process_id,
-            "source_path": None,
-            "points": [],
-        }
-
-    src = pathlib.Path(str(raw_path))
-    if not src.is_absolute():
-        src = pathlib.Path.cwd() / src
-
-    # パストラバーサル対策: ベースディレクトリ外のアクセスを拒否
-    src_resolved = src.resolve()
-    allowed_base_dirs = _get_allowed_base_dirs()
-    is_allowed = any(
-        src_resolved == allowed_dir or str(src_resolved).startswith(str(allowed_dir) + _os.sep)
-        for allowed_dir in allowed_base_dirs
-    )
-    if not is_allowed:
-        src_name = src_resolved.name
-        logger.warning(
-            "Access attempt outside allowed directories: process_id=%s, path=%s, allowed_dirs=%s",
-            process_id,
-            src_resolved.as_posix(),
-            ", ".join(d.as_posix() for d in allowed_base_dirs),
-        )
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                "Access to files outside the allowed base directories is forbidden: "
-                f"process_id={process_id}, file={src_name}"
-            ),
-        )
-
-    if not src_resolved.exists():
-        return {
-            "process_id": process_id,
-            "source_path": src_resolved.as_posix(),
-            "points": [],
-        }
-
-    try:
-        import pandas as pd  # Local import to avoid global import cost.
-
-        with src_resolved.open("r", encoding="utf-8", errors="ignore") as f:
-            start_row = 0
-            for idx, line in enumerate(f):
-                if idx >= 200:
-                    break
-                if line.strip().upper().startswith("DATA"):
-                    start_row = idx + 1
-                    break
-            # DATA行の直後からpandasで読み込む
-            f.seek(0)
-            for _ in range(start_row):
-                next(f)
-            try:
-                frame = pd.read_csv(f)
-            except pd.errors.ParserError as e:
-                logger.error(
-                    "CSV parse error in waveform preview for process_id=%s source_path=%s: %s",
-                    process_id,
-                    src_resolved.as_posix(),
-                    str(e),
-                )
-                return {
-                    "process_id": process_id,
-                    "source_path": src_resolved.as_posix(),
-                    "points": [],
-                }
-        if frame.empty:
-            return {
-                "process_id": process_id,
-                "source_path": src_resolved.as_posix(),
-                "points": [],
-            }
-
-        x_col = frame.columns[0]
-        y_col = None
-        for col in frame.columns[1:]:
-            if pd.api.types.is_numeric_dtype(frame[col]):
-                y_col = col
-                break
-        if y_col is None:
-            return {
-                "process_id": process_id,
-                "source_path": src_resolved.as_posix(),
-                "points": [],
-            }
-
-        sample = frame[[x_col, y_col]].tail(limit)
-        points = [
-            {
-                "x": str(x),
-                "y": None if pd.isna(y) else float(y),
-            }
-            for x, y in sample.to_records(index=False)
-        ]
-        return {
-            "process_id": process_id,
-            "source_path": src_resolved.as_posix(),
-            "points": points,
-        }
-    except Exception:
-        logger.exception(
-            "Failed to build waveform preview for process_id=%s source_path=%s",
-            process_id,
-            src_resolved.as_posix(),
-        )
-        return {
-            "process_id": process_id,
-            "source_path": src_resolved.as_posix(),
-            "points": [],
-        }
-
-
-@app.get("/charts/history")
-def get_charts_history(
-    chart_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=64,
-        pattern=CHART_ID_PATTERN,
-    ),
-    chart_set_id: int | None = Query(default=None, ge=1),
-    change_source: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    from_ts: Annotated[datetime | None, Query()] = None,
-    to_ts: Annotated[datetime | None, Query()] = None,
-    limit: int = Query(default=100, ge=1, le=500),
-    offset: int = Query(default=0, ge=0),
-):
-    """Chart 閾値変更履歴を返す。"""
-    _validate_query_datetime_range(from_ts, to_ts, require_pair=False)
-
-    chart_pk = _parse_chart_pk(chart_id)
-    criteria = ChartsHistoryQueryCriteria(
-        chart_pk=chart_pk,
-        chart_set_id=chart_set_id,
-        change_source=change_source,
-        from_ts=_normalize_query_datetime(from_ts),
-        to_ts=_normalize_query_datetime(to_ts),
-        limit=limit,
-        offset=offset,
-    )
-
-    try:
-        rows = _chart_repository.find_chart_history(criteria)
-        return {"ok": True, "data": [asdict(row) for row in rows]}
-    except Exception as e:
-        _raise_api_error(operation="GET /charts/history", error=e)
-
-
-@app.get("/charts/{chart_id}/points")
-def get_chart_points(
-    chart_id: str = Path(
-        min_length=1,
-        max_length=64,
-        pattern=CHART_ID_PATTERN,
-    ),
-    limit: int = Query(default=50, ge=1, le=500),
-):
-    """指定 chart に対応する最新特徴量点を返す。"""
-    chart_pk = _parse_chart_pk(chart_id)
-    if chart_pk is None:
-        raise HTTPException(status_code=400, detail="Invalid chart_id")
-
-    try:
-        rows = _chart_repository.find_chart_points(chart_pk, limit)
-        return {"ok": True, "data": [asdict(row) for row in rows]}
-    except Exception as e:
-        _raise_api_error(operation="GET /charts/{chart_id}/points", error=e)
-
-
-@app.get("/processes/{process_id}/waveform-preview")
-def get_process_waveform_preview(
-    process_id: str = Path(
-        min_length=1, max_length=CHARTS_FILTER_MAX_LENGTH, pattern=CHARTS_FILTER_PATTERN
-    ),
-    limit: int = Query(default=300, ge=10, le=2000),
-):
-    """process_id に紐づく元波形（raw_csv_path）のプレビューを返す。"""
-    try:
-        data = _build_waveform_preview(process_id, limit)
-        return {"ok": True, "data": data}
-    except HTTPException:
-        raise
-    except Exception as e:
-        _raise_api_error(operation="GET /processes/{process_id}/waveform-preview", error=e)
-
-
-@app.get("/judge/results")
-def get_judge_results(
-    chart_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=64,
-        pattern=CHART_ID_PATTERN,
-    ),
-    process_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    lot_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    recipe_id: str | None = Query(
-        default=None,
-        min_length=1,
-        max_length=CHARTS_FILTER_MAX_LENGTH,
-        pattern=CHARTS_FILTER_PATTERN,
-    ),
-    level: str | None = Query(default=None, pattern=JUDGE_LEVEL_PATTERN),
-    from_ts: Annotated[datetime | None, Query()] = None,
-    to_ts: Annotated[datetime | None, Query()] = None,
-    limit: int = Query(default=200, ge=1, le=1000),
-    offset: int = Query(default=0, ge=0),
-):
-    """判定結果一覧を返す。"""
-    _validate_query_datetime_range(from_ts, to_ts, require_pair=True)
-
-    criteria = JudgeResultsQueryCriteria(
-        chart_id=chart_id,
-        process_id=process_id,
-        lot_id=lot_id,
-        recipe_id=recipe_id,
-        level=level,
-        from_ts=_normalize_query_datetime(from_ts),
-        to_ts=_normalize_query_datetime(to_ts),
-        limit=limit,
-        offset=offset,
-    )
-
-    try:
-        rows = _judge_repository.find_results(criteria)
-        return {"ok": True, "data": [asdict(row) for row in rows]}
-    except Exception as e:
-        _raise_api_error(operation="GET /judge/results", error=e)
-
-
-@app.get("/judge/results/{result_id}")
-def get_judge_result_by_id(
-    result_id: str = Path(
-        min_length=1,
-        max_length=64,
-        pattern=RESULT_ID_PATTERN,
-    ),
-):
-    """判定結果詳細を返す。"""
-    result_pk = _parse_result_pk(result_id)
-
-    try:
-        row = _judge_repository.find_result_by_id(result_pk)
-        if row is None:
-            return _not_found_error_response(
-                message="judge result not found",
-                details={"result_id": result_id},
-            )
-        return {"ok": True, "data": asdict(row)}
-    except JudgeDataCorruptionError as e:
-        logger.error(
-            "JUDGE_DATA_CORRUPTION: GET /judge/results/{result_id} failed "
-            "(requested_result_id=%s, result_pk=%s)",
-            result_id,
-            result_pk,
-            exc_info=True,
-        )
-        raise HTTPException(status_code=500, detail="Internal server error") from e
-    except Exception as e:
-        _raise_api_error(operation="GET /judge/results/{result_id}", error=e)
-
-
-@app.get("/governance/change-requests")
-def get_governance_change_requests(
-    query: Annotated[ChangeRequestsQuery, Depends()],
-):
-    """ガバナンス変更申請一覧を返す。"""
-    con = _connect_readonly(MAIN_DB)
-    try:
-        rows = _governance_change_request_repository.list(
-            con,
-            status=query.status,
-            chart_id=query.chart_id,
-            from_ts=_normalize_query_datetime(query.from_ts),
-            to_ts=_normalize_query_datetime(query.to_ts),
-            limit=query.limit,
-            offset=query.offset,
-        )
-        return {"ok": True, "data": [asdict(row) for row in rows]}
-    except Exception as e:
-        _raise_api_error(operation="GET /governance/change-requests", error=e)
-    finally:
-        con.close()
-
-
-@app.get("/governance/audit-events")
-def get_governance_audit_events(
-    query: Annotated[GovernanceAuditEventsQuery, Depends()],
-):
-    """ガバナンス監査イベント一覧を返す。"""
-    con = _connect_readonly(MAIN_DB)
-    try:
-        _validate_query_datetime_range(query.from_ts, query.to_ts, require_pair=False)
-
-        sql = """
-            SELECT
-                id, event_type, actor, actor_role, target_type, target_id,
-                occurred_at, before_json, after_json, correlation_id
-            FROM GovernanceAuditEvents
-        """
-        where_clauses: list[str] = []
-        params: list[object] = []
-
-        if query.event_type is not None:
-            where_clauses.append("event_type = ?")
-            params.append(query.event_type)
-        if query.target_type is not None:
-            where_clauses.append("target_type = ?")
-            params.append(query.target_type)
-        if query.target_id is not None:
-            where_clauses.append("target_id = ?")
-            params.append(query.target_id)
-        if query.from_ts is not None:
-            where_clauses.append("occurred_at >= ?")
-            params.append(_normalize_query_datetime(query.from_ts))
-        if query.to_ts is not None:
-            where_clauses.append("occurred_at <= ?")
-            params.append(_normalize_query_datetime(query.to_ts))
-
-        if where_clauses:
-            sql += " WHERE " + " AND ".join(where_clauses)
-
-        sql += " ORDER BY occurred_at DESC, id DESC LIMIT ? OFFSET ?"
-        params.extend((query.limit, query.offset))
-
-        rows = con.execute(sql, params).fetchall()
-        data = [
-            {
-                "id": int(row[0]),
-                "event_type": str(row[1]),
-                "actor": str(row[2]),
-                "actor_role": str(row[3]),
-                "target_type": str(row[4]),
-                "target_id": int(row[5]),
-                "occurred_at": str(row[6]),
-                "before_json": row[7],
-                "after_json": row[8],
-                "correlation_id": row[9],
-            }
-            for row in rows
-        ]
-        return {"ok": True, "data": data}
-    except HTTPException:
-        raise
-    except Exception as e:
-        _raise_api_error(operation="GET /governance/audit-events", error=e)
-    finally:
-        con.close()
-
-
-@app.post("/governance/emergency-changes")
-def create_governance_emergency_change(payload: EmergencyChangeIn, runner: RunnerDep):
-    """緊急変更を即時反映する。"""
-
-    changed_at = to_utc_millis(datetime.now(UTC).isoformat())
-
-    def _write() -> dict[str, object]:
-        con = _connect(MAIN_DB)
-        try:
-            con.execute("BEGIN")
-            row = con.execute(
-                """
-                SELECT
-                    id, chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                    step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
-                    version
-                FROM ChartsV2
-                WHERE id = ?
-                """,
-                (payload.chart_id,),
-            ).fetchone()
-            if row is None:
-                raise _GovernanceEmergencyChangeChartNotFound
-
-            (
-                chart_id,
-                chart_set_id,
-                tool_id,
-                chamber_id,
-                recipe_id,
-                parameter,
-                step_no,
-                feature_type,
-                old_warn_low,
-                old_warn_high,
-                old_crit_low,
-                old_crit_high,
-                current_version,
-            ) = row
-
-            try:
-                patch = _parse_threshold_patch(payload.change_payload)
-            except json.JSONDecodeError as e:
-                raise _GovernanceApplyValidationError(
-                    message="change_payload must be valid JSON"
-                ) from e
-            # Reject empty or typo-only patches: at least one threshold key must be present
-            if not any(k in patch for k in ["warn_low", "warn_high", "crit_low", "crit_high"]):
-                raise _GovernanceApplyValidationError(
-                    message="change_payload must contain at least one of: "
-                    "warn_low, warn_high, crit_low, crit_high"
-                )
-            new_warn_low = patch.get("warn_low", old_warn_low)
-            new_warn_high = patch.get("warn_high", old_warn_high)
-            new_crit_low = patch.get("crit_low", old_crit_low)
-            new_crit_high = patch.get("crit_high", old_crit_high)
-
-            _validate_threshold_consistency(
-                warn_low=new_warn_low,
-                warn_high=new_warn_high,
-                crit_low=new_crit_low,
-                crit_high=new_crit_high,
-            )
-
-            def _thresh_eq(a: float | None, b: float | None) -> bool:
-                if a is None and b is None:
-                    return True
-                if a is None or b is None:
-                    return False
-                return math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-12)
-
-            is_noop = (
-                _thresh_eq(old_warn_low, new_warn_low)
-                and _thresh_eq(old_warn_high, new_warn_high)
-                and _thresh_eq(old_crit_low, new_crit_low)
-                and _thresh_eq(old_crit_high, new_crit_high)
-            )
-
-            resulting_version = int(current_version)
-            before_json = json.dumps(
-                {
-                    "warn_low": old_warn_low,
-                    "warn_high": old_warn_high,
-                    "crit_low": old_crit_low,
-                    "crit_high": old_crit_high,
-                }
-            )
-            after_json = json.dumps(
-                {
-                    "warn_low": new_warn_low,
-                    "warn_high": new_warn_high,
-                    "crit_low": new_crit_low,
-                    "crit_high": new_crit_high,
-                }
-            )
-            if not is_noop:
-                resulting_version = int(current_version) + 1
-                con.execute(
-                    """
-                    UPDATE ChartsV2
-                    SET warn_low = ?, warn_high = ?, crit_low = ?, crit_high = ?,
-                        version = ?, updated_at = ?, updated_by = ?,
-                        update_reason = ?, update_source = ?
-                    WHERE id = ?
-                    """,
-                    (
-                        new_warn_low,
-                        new_warn_high,
-                        new_crit_low,
-                        new_crit_high,
-                        resulting_version,
-                        changed_at,
-                        payload.changed_by,
-                        payload.reason,
-                        "emergency_manual",
-                        chart_id,
-                    ),
-                )
-                con.execute(
-                    """
-                    INSERT INTO ChartsHistory(
-                        chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                        step_no, feature_type,
-                        old_warn_low, old_warn_high, old_crit_low, old_crit_high,
-                        new_warn_low, new_warn_high, new_crit_low, new_crit_high,
-                        changed_at, changed_by, change_reason, change_source, chart_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        chart_set_id,
-                        tool_id,
-                        chamber_id,
-                        recipe_id,
-                        parameter,
-                        step_no,
-                        feature_type,
-                        old_warn_low,
-                        old_warn_high,
-                        old_crit_low,
-                        old_crit_high,
-                        new_warn_low,
-                        new_warn_high,
-                        new_crit_low,
-                        new_crit_high,
-                        changed_at,
-                        payload.changed_by,
-                        payload.reason,
-                        "emergency_manual",
-                        chart_id,
-                    ),
-                )
-
-            emergency_change_id = _governance_emergency_changes_repository.create(
-                con,
-                chart_id=int(chart_id),
-                changed_by=payload.changed_by,
-                changed_by_role=payload.changed_by_role,
-                changed_at=changed_at,
-                reason=payload.reason,
-                before_json=before_json,
-                after_json=after_json,
-                resulting_version=resulting_version,
-                related_issue_or_pr=None,
-            )
-            audit_event_id = _audit_event_writer.write(
-                con,
-                event_type="emergency_changed",
-                actor=payload.changed_by,
-                actor_role=payload.changed_by_role,
-                target_type="emergency_change",
-                target_id=emergency_change_id,
-                occurred_at=changed_at,
-                before_json=before_json,
-                after_json=after_json,
-                correlation_id=f"emergency:{emergency_change_id}",
-            )
-            con.execute(
-                """
-                INSERT INTO GovernanceNotificationOutbox(event_id, status)
-                VALUES (?, 'pending')
-                """,
-                (audit_event_id,),
-            )
-            con.commit()
-            return {
-                "request_id": emergency_change_id,
-                "status": "applied",
-                "resulting_version": resulting_version,
-                "noop": is_noop,
-            }
-        except Exception:
-            con.rollback()
-            raise
-        finally:
-            con.close()
-
-    try:
-        data = runner.submit("write", _write)
-        return {"ok": True, "data": data}
-    except _GovernanceEmergencyChangeChartNotFound:
-        return _not_found_error_response(
-            code="CHART_NOT_FOUND",
-            message="target chart not found",
-            details={"chart_id": str(payload.chart_id)},
-        )
-    except _GovernanceApplyValidationError as e:
-        return _validation_error_response(
-            issues=[
-                {
-                    "loc": ["body", "change_payload"],
-                    "msg": e.message,
-                    "type": "value_error",
-                }
-            ]
-        )
-    except Exception as e:
-        _raise_api_error(operation="POST /governance/emergency-changes", error=e)
-
-
-@app.post("/governance/emergency-changes/{request_id}/ratify")
-def ratify_governance_emergency_change(
-    payload: EmergencyChangeRatifyIn,
-    runner: RunnerDep,
-    request_id: int = Path(ge=1),
-):
-    """緊急変更を事後追認する。"""
-
-    ratified_at = to_utc_millis(datetime.now(UTC).isoformat())
-
-    def _write() -> dict[str, object]:
-        con = _connect(MAIN_DB)
-        try:
-            con.execute("BEGIN")
-            _governance_emergency_changes_repository.find_by_id(con, request_id)
-
-            try:
-                _governance_ratifications_repository.create(
-                    con,
-                    ec_id=request_id,
-                    ratified_by_role=payload.ratified_by_role,
-                    ratified_at=ratified_at,
-                    ratification_comment=payload.ratification_comment,
-                    related_pr=payload.related_pr,
-                )
-            except sqlite3.IntegrityError as e:
-                if _is_governance_ratification_ec_unique_error(e):
-                    raise _GovernanceEmergencyRatificationConflict(ec_id=request_id) from e
-                if "foreign key constraint failed" in str(e).lower():
-                    raise GovernanceNotFoundError(
-                        f"GovernanceEmergencyChanges id={request_id} not found"
-                    ) from e
-                raise
-
-            if payload.related_pr is not None:
-                con.execute(
-                    """
-                    UPDATE GovernanceEmergencyChanges
-                    SET related_issue_or_pr = ?
-                    WHERE id = ?
-                    """,
-                    (payload.related_pr, request_id),
-                )
-
-            _audit_event_writer.write(
-                con,
-                event_type="emergency_ratified",
-                actor="ops",
-                actor_role=payload.ratified_by_role,
-                target_type="emergency_change",
-                target_id=request_id,
-                occurred_at=ratified_at,
-                correlation_id=f"emergency:{request_id}",
-            )
-            con.commit()
-            return {"request_id": request_id, "status": "ratified"}
-        except Exception:
-            con.rollback()
-            raise
-        finally:
-            con.close()
-
-    try:
-        data = runner.submit("write", _write)
-        return {"ok": True, "data": data}
-    except GovernanceNotFoundError:
-        return _not_found_error_response(
-            message="emergency change not found",
-            details={"request_id": str(request_id)},
-        )
-    except _GovernanceEmergencyRatificationConflict:
-        return _conflict_error_response(
-            code="ALREADY_RATIFIED",
-            message="emergency change is already ratified",
-            details={"request_id": str(request_id)},
-        )
-    except Exception as e:
-        _raise_api_error(
-            operation="POST /governance/emergency-changes/{request_id}/ratify",
-            error=e,
-        )
-
-
-@app.post("/governance/notifications/{event_id}/retry")
-def retry_governance_notification(
-    runner: RunnerDep,
-    event_id: int = Path(ge=1),
-):
-    """通知 outbox の failed レコードを再送キューへ戻す。"""
-
-    def _retry_failed_notification_outbox() -> dict[str, object]:
-        con = _connect(MAIN_DB)
-        try:
-            con.execute("BEGIN")
-            row = con.execute(
-                """
-                SELECT id, status, retry_count
-                FROM GovernanceNotificationOutbox
-                WHERE event_id = ?
-                """,
-                (event_id,),
-            ).fetchone()
-            if row is None:
-                raise _GovernanceNotificationNotFound
-
-            outbox_id = int(row[0])
-            status = str(row[1])
-            retry_count = int(row[2])
-
-            if status != "failed":
-                raise _GovernanceNotificationInvalidState(status=status)
-            if retry_count >= len(NOTIFICATION_RETRY_BACKOFF_MINUTES):
-                raise _GovernanceNotificationRetryLimitExceeded(retry_count=retry_count)
-
-            now = datetime.now(UTC)
-            now_iso = to_utc_millis(now.isoformat())
-            next_retry_at = _compute_notification_next_retry_at(
-                base_time=now,
-                retry_count=retry_count + 1,
-            )
-
-            update_cur = con.execute(
-                """
-                UPDATE GovernanceNotificationOutbox
-                SET status = 'pending',
-                    retry_count = retry_count + 1,
-                    next_retry_at = ?,
-                    last_attempt_at = ?,
-                    last_error = NULL
-                WHERE id = ?
-                  AND status = 'failed'
-                  AND retry_count = ?
-                """,
-                (next_retry_at, now_iso, outbox_id, retry_count),
-            )
-            if update_cur.rowcount == 0:
-                latest = con.execute(
-                    """
-                    SELECT status, retry_count
-                    FROM GovernanceNotificationOutbox
-                    WHERE id = ?
-                    """,
-                    (outbox_id,),
-                ).fetchone()
-                if latest is None:
-                    raise _GovernanceNotificationNotFound
-
-                latest_status = str(latest[0])
-                latest_retry_count = int(latest[1])
-                if latest_status != "failed":
-                    raise _GovernanceNotificationInvalidState(status=latest_status)
-                if latest_retry_count >= len(NOTIFICATION_RETRY_BACKOFF_MINUTES):
-                    raise _GovernanceNotificationRetryLimitExceeded(retry_count=latest_retry_count)
-                raise _GovernanceNotificationConcurrentModification
-
-            _audit_event_writer.write(
-                con,
-                event_type="notification_queued",
-                actor="ops",
-                actor_role="ops",
-                target_type="notification",
-                target_id=outbox_id,
-                occurred_at=now_iso,
-                correlation_id=f"event:{event_id}",
-            )
-            con.commit()
-            return {
-                "event_id": event_id,
-                "status": "pending",
-                "retry_count": retry_count + 1,
-                "next_retry_at": next_retry_at,
-            }
-        except Exception:
-            con.rollback()
-            raise
-        finally:
-            con.close()
-
-    try:
-        data = runner.submit("write", _retry_failed_notification_outbox)
-        return {"ok": True, "data": data}
-    except _GovernanceNotificationNotFound:
-        return _not_found_error_response(
-            message="notification outbox not found",
-            details={"event_id": str(event_id)},
-        )
-    except _GovernanceNotificationInvalidState as e:
-        return _bad_request_error_response(
-            code="INVALID_RETRY_TARGET",
-            message="only failed notification can be retried",
-            details={"event_id": str(event_id), "current_status": e.status},
-        )
-    except _GovernanceNotificationRetryLimitExceeded as e:
-        return _conflict_error_response(
-            code="RETRY_LIMIT_EXCEEDED",
-            message="retry_count has reached the maximum",
-            details={
-                "event_id": str(event_id),
-                "retry_count": str(e.retry_count),
-                "max_retry_count": str(len(NOTIFICATION_RETRY_BACKOFF_MINUTES)),
-            },
-        )
-    except _GovernanceNotificationConcurrentModification:
-        return _conflict_error_response(
-            code="CONCURRENT_MODIFICATION",
-            message="notification outbox was modified concurrently",
-            details={"event_id": str(event_id)},
-        )
-    except Exception as e:
-        _raise_api_error(operation="POST /governance/notifications/{event_id}/retry", error=e)
-
-
-@app.post("/governance/change-requests")
-def create_governance_change_request(payload: ChangeRequestIn, runner: RunnerDep):
-    """ガバナンス変更申請を作成する。"""
-
-    proposed_at = to_utc_millis(datetime.now(UTC).isoformat())
-
-    def _write() -> dict[str, int | str]:
-        con = _connect(MAIN_DB)
-        try:
-            con.execute("BEGIN")
-            try:
-                request_id = _governance_change_request_repository.create(
-                    con,
-                    chart_id=payload.chart_id,
-                    proposed_by=payload.proposed_by,
-                    proposed_at=proposed_at,
-                    change_payload=payload.change_payload,
-                    expected_version=payload.expected_version,
-                    idempotency_key=payload.idempotency_key,
-                )
-            except sqlite3.IntegrityError as e:
-                if _is_duplicate_change_request_idempotency_error(e):
-                    raise _GovernanceChangeRequestIdempotencyConflict from e
-                if _is_governance_change_request_chart_fk_error(e):
-                    raise _GovernanceChangeRequestChartFkViolation from e
-                raise
-
-            _audit_event_writer.write(
-                con,
-                event_type="change_requested",
-                actor=payload.proposed_by,
-                actor_role="requester",
-                target_type="change_request",
-                target_id=request_id,
-                occurred_at=proposed_at,
-                correlation_id=payload.idempotency_key,
-            )
-
-            row = _governance_change_request_repository.find_by_id(con, request_id)
-            con.commit()
-            return {"request_id": request_id, "status": row.status}
-        except Exception:
-            con.rollback()
-            raise
-        finally:
-            con.close()
-
-    try:
-        data = runner.submit("write", _write)
-        return {"ok": True, "data": data}
-    except _GovernanceChangeRequestIdempotencyConflict:
-        return _duplicate_idempotency_error_response(
-            idempotency_key=payload.idempotency_key,
-        )
-    except _GovernanceChangeRequestChartFkViolation:
-        return _validation_error_response(
-            issues=[
-                {
-                    "loc": ["body", "chart_id"],
-                    "msg": "chart_id must reference an existing chart",
-                    "type": "value_error",
-                }
-            ]
-        )
-    except Exception as e:
-        _raise_api_error(operation="POST /governance/change-requests", error=e)
-
-
-@app.post("/governance/change-requests/{request_id}/approve")
-def approve_governance_change_request(
-    payload: ChangeRequestApproveIn,
-    runner: RunnerDep,
-    request_id: int = Path(ge=1),
-):
-    """ガバナンス変更申請を承認する。"""
-
-    approved_at = to_utc_millis(datetime.now(UTC).isoformat())
-
-    def _write() -> dict[str, int | str]:
-        con = _connect(MAIN_DB)
-        try:
-            con.execute("BEGIN")
-            row = _governance_change_request_repository.find_by_id(con, request_id)
-
-            if row.status == "approved":
-                raise _GovernanceApproveAlreadyApproved
-            if row.status != "pending":
-                raise _GovernanceApproveInvalidState
-
-            _governance_approvals_repository.create(
-                con,
-                request_id=request_id,
-                approved_by=payload.approved_by,
-                approved_by_role=payload.approved_by_role,
-                approved_at=approved_at,
-                comment=payload.comment,
-            )
-            _governance_change_request_repository.update_status(
-                con,
-                record_id=request_id,
-                new_status="approved",
-            )
-            _audit_event_writer.write(
-                con,
-                event_type="change_approved",
-                actor=payload.approved_by,
-                actor_role=payload.approved_by_role,
-                target_type="change_request",
-                target_id=request_id,
-                occurred_at=approved_at,
-                correlation_id=f"request:{request_id}",
-            )
-            con.commit()
-            return {"request_id": request_id, "status": "approved"}
-        except Exception:
-            con.rollback()
-            raise
-        finally:
-            con.close()
-
-    try:
-        data = runner.submit("write", _write)
-        return {"ok": True, "data": data, "timestamp": to_utc_millis(datetime.now(UTC).isoformat())}
-    except GovernanceNotFoundError:
-        return _not_found_error_response(
-            message="change request not found",
-            details={"request_id": str(request_id)},
-        )
-    except _GovernanceApproveAlreadyApproved:
-        return _conflict_error_response(
-            code="ALREADY_APPROVED",
-            message="change request is already approved",
-            details={"request_id": str(request_id)},
-        )
-    except _GovernanceApproveInvalidState:
-        return _conflict_error_response(
-            code="INVALID_STATUS_TRANSITION",
-            message="only pending change request can be approved",
-            details={"request_id": str(request_id)},
-        )
-    except Exception as e:
-        _raise_api_error(
-            operation="POST /governance/change-requests/{request_id}/approve",
-            error=e,
-        )
-
-
-@app.post("/governance/change-requests/{request_id}/apply")
-def apply_governance_change_request(
-    payload: ChangeRequestApplyIn,
-    runner: RunnerDep,
-    request_id: int = Path(ge=1),
-):
-    """承認済みのガバナンス変更申請を反映する。"""
-
-    applied_at = to_utc_millis(datetime.now(UTC).isoformat())
-
-    def _write() -> dict[str, object]:
-        con = _connect(MAIN_DB)
-        try:
-            con.execute("BEGIN")
-            try:
-                req = _governance_change_request_repository.find_by_id(con, request_id)
-                if req.status != "approved":
-                    raise _GovernanceApplyInvalidState
-
-                chart_row = con.execute(
-                    """
-                    SELECT
-                        id, chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                        step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
-                        version, updated_at
-                    FROM ChartsV2
-                    WHERE id = ?
-                    """,
-                    (req.chart_id,),
-                ).fetchone()
-                if chart_row is None:
-                    raise _GovernanceApplyChartNotFound
-
-                (
-                    chart_id,
-                    chart_set_id,
-                    tool_id,
-                    chamber_id,
-                    recipe_id,
-                    parameter,
-                    step_no,
-                    feature_type,
-                    old_warn_low,
-                    old_warn_high,
-                    old_crit_low,
-                    old_crit_high,
-                    current_version,
-                    current_updated_at,
-                ) = chart_row
-
-                if int(current_version) != int(req.expected_version):
-                    raise _GovernanceApplyVersionConflict(
-                        current_version=int(current_version),
-                        current_updated_at=str(current_updated_at),
-                        chart_id=int(chart_id),
-                        current_status=str(getattr(req, "status", "unknown") or "unknown"),
-                    )
-
-                patch = _parse_threshold_patch(req.change_payload)
-                new_warn_low = patch.get("warn_low", old_warn_low)
-                new_warn_high = patch.get("warn_high", old_warn_high)
-                new_crit_low = patch.get("crit_low", old_crit_low)
-                new_crit_high = patch.get("crit_high", old_crit_high)
-
-                _validate_threshold_consistency(
-                    warn_low=new_warn_low,
-                    warn_high=new_warn_high,
-                    crit_low=new_crit_low,
-                    crit_high=new_crit_high,
-                )
-
-                def _thresh_eq(a: float | None, b: float | None) -> bool:
-                    if a is None and b is None:
-                        return True
-                    if a is None or b is None:
-                        return False
-                    return math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-12)
-
-                is_noop = (
-                    _thresh_eq(old_warn_low, new_warn_low)
-                    and _thresh_eq(old_warn_high, new_warn_high)
-                    and _thresh_eq(old_crit_low, new_crit_low)
-                    and _thresh_eq(old_crit_high, new_crit_high)
-                )
-
-                resulting_version = int(current_version)
-                if not is_noop:
-                    resulting_version = int(current_version) + 1
-                    con.execute(
-                        """
-                        UPDATE ChartsV2
-                        SET warn_low = ?, warn_high = ?, crit_low = ?, crit_high = ?,
-                            version = ?, updated_at = ?, updated_by = ?,
-                            update_reason = ?, update_source = ?
-                        WHERE id = ?
-                        """,
-                        (
-                            new_warn_low,
-                            new_warn_high,
-                            new_crit_low,
-                            new_crit_high,
-                            resulting_version,
-                            applied_at,
-                            payload.applied_by,
-                            payload.reason,
-                            "governance_apply",
-                            chart_id,
-                        ),
-                    )
-                    con.execute(
-                        """
-                        INSERT INTO ChartsHistory(
-                            chart_set_id, tool_id, chamber_id, recipe_id, parameter,
-                            step_no, feature_type,
-                            old_warn_low, old_warn_high, old_crit_low, old_crit_high,
-                            new_warn_low, new_warn_high, new_crit_low, new_crit_high,
-                            changed_at, changed_by, change_reason, change_source, chart_id
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            chart_set_id,
-                            tool_id,
-                            chamber_id,
-                            recipe_id,
-                            parameter,
-                            step_no,
-                            feature_type,
-                            old_warn_low,
-                            old_warn_high,
-                            old_crit_low,
-                            old_crit_high,
-                            new_warn_low,
-                            new_warn_high,
-                            new_crit_low,
-                            new_crit_high,
-                            applied_at,
-                            payload.applied_by,
-                            payload.reason,
-                            "governance_apply",
-                            chart_id,
-                        ),
-                    )
-
-                con.execute(
-                    """
-                    INSERT OR REPLACE INTO GovernanceApplyResults(
-                        request_id, applied_at, success, resulting_version,
-                        error_code, error_message
-                    ) VALUES (?, ?, 1, ?, NULL, NULL)
-                    """,
-                    (request_id, applied_at, resulting_version),
-                )
-                _governance_change_request_repository.update_status(
-                    con,
-                    record_id=request_id,
-                    new_status="applied",
-                )
-                _audit_event_writer.write(
-                    con,
-                    event_type="change_applied",
-                    actor=payload.applied_by,
-                    actor_role=payload.applied_by_role,
-                    target_type="change_request",
-                    target_id=request_id,
-                    occurred_at=applied_at,
-                    correlation_id=f"request:{request_id}",
-                )
-                con.commit()
-                return {
-                    "request_id": request_id,
-                    "status": "applied",
-                    "resulting_version": resulting_version,
-                    "noop": is_noop,
-                }
-            except (
-                _GovernanceApplyInvalidState,
-                _GovernanceApplyValidationError,
-                _GovernanceApplyVersionConflict,
-            ):
-                _audit_event_writer.write(
-                    con,
-                    event_type="change_apply_failed",
-                    actor=payload.applied_by,
-                    actor_role=payload.applied_by_role,
-                    target_type="change_request",
-                    target_id=request_id,
-                    occurred_at=applied_at,
-                    correlation_id=f"request:{request_id}",
-                )
-                con.commit()
-                raise
-        except Exception:
-            con.rollback()
-            raise
-        finally:
-            con.close()
-
-    try:
-        data = runner.submit("write", _write)
-        return {"ok": True, "data": data, "timestamp": to_utc_millis(datetime.now(UTC).isoformat())}
-    except GovernanceNotFoundError:
-        return _not_found_error_response(
-            message="change request not found",
-            details={"request_id": str(request_id)},
-        )
-    except _GovernanceApplyInvalidState:
-        return _conflict_error_response(
-            code="INVALID_STATUS_TRANSITION",
-            message="only approved change request can be applied",
-            details={"request_id": str(request_id)},
-        )
-    except _GovernanceApplyChartNotFound:
-        return _bad_request_error_response(
-            code="CHART_NOT_FOUND",
-            message="target chart not found",
-            details={"request_id": str(request_id)},
-        )
-    except _GovernanceApplyVersionConflict as e:
-        return JSONResponse(
-            status_code=409,
-            content={
-                "ok": False,
-                "error": {
-                    "code": "STALE_EXPECTED_VERSION",
-                    "message": "expected_version does not match current version",
-                    "details": {
-                        "request_id": str(request_id),
-                        "current": {
-                            "chart_id": e.chart_id,
-                            "version": e.current_version,
-                            "updated_at": e.current_updated_at,
-                            "status": e.current_status,
-                        },
-                    },
-                },
-            },
-        )
-    except _GovernanceApplyValidationError as e:
-        return _validation_error_response(
-            issues=[
-                {
-                    "loc": ["body", "change_payload"],
-                    "msg": e.message,
-                    "type": "value_error",
-                }
-            ]
-        )
-    except Exception as e:
-        _raise_api_error(
-            operation="POST /governance/change-requests/{request_id}/apply",
-            error=e,
-        )
-
-
-@app.post("/processes")
-def create_process(p: ProcessInfoIn, runner: RunnerDep):
-    """1 件の ProcessInfo をキュー経由で保存する。"""
-    try:
-        runner.submit("write", lambda: write_process(p))
-        return {"ok": True}
-    except Exception as e:
-        _raise_api_error(operation="POST /processes", error=e)
-
-
-@app.delete("/processes/{process_id:path}")
-def remove_process_by_path(process_id: str, runner: RunnerDep):
-    """指定 process_id の ProcessInfo を削除する（推奨エンドポイント）。"""
-    try:
-        deleted = runner.submit("write", lambda: delete_process(process_id))
-        return {"ok": True, "deleted": deleted}
-    except Exception as e:
-        _raise_api_error(operation="DELETE /processes/{process_id}", error=e)
-
-
-@app.delete("/processes")
-def remove_process_legacy(
-    request: Request,
-    req: ProcessDeleteIn,
-    runner: RunnerDep,
-):
-    """互換用の旧削除 API。廃止予定日まで `/processes/{process_id}` と併存する。"""
-    request.state.legacy_delete_process_id = req.process_id
-    headers = _legacy_delete_headers(req.process_id)
-    try:
-        deleted = runner.submit("write", lambda: delete_process(req.process_id))
-        return {"ok": True, "deleted": deleted}
-    except Exception as e:
-        _raise_api_error(operation="DELETE /processes", error=e, headers=headers)
-
-
-@app.post("/step_windows/bulk")
-def create_step_windows_bulk(items: list[StepWindowIn], runner: RunnerDep):
-    """StepWindow レコードをまとめて保存する。"""
-    try:
-        inserted = runner.submit("write", lambda: write_step_windows_bulk(items))
-        return {"ok": True, "inserted": inserted}
-    except Exception as e:
-        _raise_api_error(operation="POST /step_windows/bulk", error=e)
-
-
-@app.post("/parameters/bulk")
-def create_parameters_bulk(params: list[ParameterIn], runner: RunnerDep):
-    """Parameter レコードをまとめて保存する。"""
-    try:
-        n = runner.submit("write", lambda: write_parameters_bulk(params))
-        return {"ok": True, "inserted": n}
-    except Exception as e:
-        _raise_api_error(operation="POST /parameters/bulk", error=e)
-
-
-@app.post("/aggregate/write")
-def create_aggregate_write(payload: AggregateWriteIn, runner: RunnerDep):
-    """Process/StepWindow/Parameter を 1 API・1 トランザクションで保存する。"""
-    try:
-        result = runner.submit("write", lambda: write_aggregate_atomic(payload))
-        return result
-    except Exception as e:
-        _raise_api_error(operation="POST /aggregate/write", error=e)
+query_router = QueryRouter(
+    chart_repository=_chart_repository,
+    judge_repository=_judge_repository,
+    governance_change_request_repository=_governance_change_request_repository,
+    get_runner=_runner_from_request,
+    build_waveform_preview=lambda process_id, limit: _build_waveform_preview(process_id, limit),
+)
+
+governance_router = GovernanceRouter(
+    governance_change_request_repository=_governance_change_request_repository,
+    governance_approvals_repository=_governance_approvals_repository,
+    governance_emergency_changes_repository=_governance_emergency_changes_repository,
+    governance_ratifications_repository=_governance_ratifications_repository,
+    audit_event_writer=_audit_event_writer,
+    get_runner=_runner_from_request,
+)
+
+ingest_router = IngestRouter(
+    get_runner=_runner_from_request,
+    legacy_headers=_legacy_delete_headers,
+)
+
+app.include_router(query_router.router)
+app.include_router(governance_router.router)
+app.include_router(ingest_router.router)
+
+
+def _raise_api_error(*, operation: str, error: Exception, headers: dict[str, str] | None = None):
+    """後方互換のため app モジュールからも共通エラーハンドラを公開する。"""
+    raise_api_error(operation=operation, error=error, headers=headers)

--- a/src/portfolio_fdc/db_api/app.py
+++ b/src/portfolio_fdc/db_api/app.py
@@ -18,6 +18,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
+from .aggregate_repository import delete_process, write_aggregate_atomic
 from .api_common import (
     compute_notification_next_retry_at,
     parse_chart_pk,
@@ -287,6 +288,8 @@ governance_router = GovernanceRouter(
 ingest_router = IngestRouter(
     get_runner=_runner_from_request,
     legacy_headers=_legacy_delete_headers,
+    delete_process=lambda *args, **kwargs: delete_process(*args, **kwargs),
+    write_aggregate_atomic=lambda *args, **kwargs: write_aggregate_atomic(*args, **kwargs),
 )
 
 app.include_router(query_router.router)

--- a/src/portfolio_fdc/db_api/routers/__init__.py
+++ b/src/portfolio_fdc/db_api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""db_api APIRouter 集約モジュール。"""

--- a/src/portfolio_fdc/db_api/routers/governance_router.py
+++ b/src/portfolio_fdc/db_api/routers/governance_router.py
@@ -1,0 +1,972 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Path, Request
+from fastapi.responses import JSONResponse
+
+from ..api_common import (
+    NOTIFICATION_RETRY_BACKOFF_MINUTES,
+    GovernanceApplyValidationError,
+    bad_request_error_response,
+    compute_notification_next_retry_at,
+    conflict_error_response,
+    duplicate_idempotency_error_response,
+    not_found_error_response,
+    parse_threshold_patch,
+    raise_api_error,
+    thresholds_equal,
+    validate_threshold_consistency,
+    validation_error_response,
+)
+from ..audit_event_writer import AuditEventWriter
+from ..datetime_util import to_utc_millis
+from ..db import MAIN_DB, _connect
+from ..governance_repository import (
+    GovernanceApprovalsRepository,
+    GovernanceChangeRequestRepository,
+    GovernanceEmergencyChangesRepository,
+    GovernanceNotFoundError,
+    GovernanceRatificationsRepository,
+)
+from ..schemas import (
+    ChangeRequestApplyIn,
+    ChangeRequestApproveIn,
+    ChangeRequestIn,
+    EmergencyChangeIn,
+    EmergencyChangeRatifyIn,
+)
+from ..task_runner import DBTaskRunner
+
+
+class _GovernanceChangeRequestIdempotencyConflict(Exception):
+    pass
+
+
+class _GovernanceChangeRequestChartFkViolation(Exception):
+    pass
+
+
+class _GovernanceApproveAlreadyApproved(Exception):
+    pass
+
+
+class _GovernanceApproveInvalidState(Exception):
+    pass
+
+
+class _GovernanceApplyInvalidState(Exception):
+    pass
+
+
+class _GovernanceApplyChartNotFound(Exception):
+    pass
+
+
+class _GovernanceApplyVersionConflict(Exception):
+    def __init__(
+        self,
+        *,
+        current_version: int,
+        current_updated_at: str,
+        chart_id: int,
+        current_status: str,
+    ) -> None:
+        self.current_version = current_version
+        self.current_updated_at = current_updated_at
+        self.chart_id = chart_id
+        self.current_status = current_status
+
+
+class _GovernanceNotificationNotFound(Exception):
+    pass
+
+
+class _GovernanceNotificationInvalidState(Exception):
+    def __init__(self, *, status: str) -> None:
+        self.status = status
+
+
+class _GovernanceNotificationRetryLimitExceeded(Exception):
+    def __init__(self, *, retry_count: int) -> None:
+        self.retry_count = retry_count
+
+
+class _GovernanceNotificationConcurrentModification(Exception):
+    pass
+
+
+class _GovernanceEmergencyChangeChartNotFound(Exception):
+    pass
+
+
+class _GovernanceEmergencyRatificationConflict(Exception):
+    def __init__(self, *, ec_id: int) -> None:
+        self.ec_id = ec_id
+
+
+def _is_duplicate_change_request_idempotency_error(error: sqlite3.IntegrityError) -> bool:
+    message = str(error)
+    return (
+        "GovernanceChangeRequests.idempotency_key" in message
+        or "idx_change_requests_idempotency" in message
+    )
+
+
+def _is_governance_change_request_chart_fk_error(error: sqlite3.IntegrityError) -> bool:
+    return "foreign key constraint failed" in str(error).lower()
+
+
+def _is_governance_ratification_ec_unique_error(error: sqlite3.IntegrityError) -> bool:
+    message = str(error)
+    return (
+        "GovernanceRatifications.ec_id" in message
+        or "UNIQUE constraint failed: GovernanceRatifications.ec_id" in message
+    )
+
+
+class GovernanceRouter:
+    """ガバナンス書き込み系エンドポイントをまとめるルータークラス。"""
+
+    def __init__(
+        self,
+        *,
+        governance_change_request_repository: GovernanceChangeRequestRepository,
+        governance_approvals_repository: GovernanceApprovalsRepository,
+        governance_emergency_changes_repository: GovernanceEmergencyChangesRepository,
+        governance_ratifications_repository: GovernanceRatificationsRepository,
+        audit_event_writer: AuditEventWriter,
+        get_runner: Callable[[Request], DBTaskRunner],
+    ) -> None:
+        self._governance_change_request_repository = governance_change_request_repository
+        self._governance_approvals_repository = governance_approvals_repository
+        self._governance_emergency_changes_repository = governance_emergency_changes_repository
+        self._governance_ratifications_repository = governance_ratifications_repository
+        self._audit_event_writer = audit_event_writer
+        self._get_runner = get_runner
+        self.router = APIRouter()
+        self._register_routes()
+
+    def _register_routes(self) -> None:
+        @self.router.post("/governance/emergency-changes")
+        def create_governance_emergency_change(payload: EmergencyChangeIn, request: Request):
+            changed_at = to_utc_millis(datetime.now(UTC).isoformat())
+            runner = self._get_runner(request)
+
+            def _write() -> dict[str, object]:
+                con = _connect(MAIN_DB)
+                try:
+                    con.execute("BEGIN")
+                    row = con.execute(
+                        """
+                        SELECT
+                            id, chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                            step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                            version
+                        FROM ChartsV2
+                        WHERE id = ?
+                        """,
+                        (payload.chart_id,),
+                    ).fetchone()
+                    if row is None:
+                        raise _GovernanceEmergencyChangeChartNotFound
+
+                    (
+                        chart_id,
+                        chart_set_id,
+                        tool_id,
+                        chamber_id,
+                        recipe_id,
+                        parameter,
+                        step_no,
+                        feature_type,
+                        old_warn_low,
+                        old_warn_high,
+                        old_crit_low,
+                        old_crit_high,
+                        current_version,
+                    ) = row
+
+                    try:
+                        patch = parse_threshold_patch(payload.change_payload)
+                    except json.JSONDecodeError as e:
+                        raise GovernanceApplyValidationError(
+                            message="change_payload must be valid JSON"
+                        ) from e
+                    if not any(
+                        k in patch for k in ["warn_low", "warn_high", "crit_low", "crit_high"]
+                    ):
+                        raise GovernanceApplyValidationError(
+                            message="change_payload must contain at least one of: "
+                            "warn_low, warn_high, crit_low, crit_high"
+                        )
+
+                    new_warn_low = patch.get("warn_low", old_warn_low)
+                    new_warn_high = patch.get("warn_high", old_warn_high)
+                    new_crit_low = patch.get("crit_low", old_crit_low)
+                    new_crit_high = patch.get("crit_high", old_crit_high)
+
+                    validate_threshold_consistency(
+                        warn_low=new_warn_low,
+                        warn_high=new_warn_high,
+                        crit_low=new_crit_low,
+                        crit_high=new_crit_high,
+                    )
+
+                    is_noop = (
+                        thresholds_equal(old_warn_low, new_warn_low)
+                        and thresholds_equal(old_warn_high, new_warn_high)
+                        and thresholds_equal(old_crit_low, new_crit_low)
+                        and thresholds_equal(old_crit_high, new_crit_high)
+                    )
+
+                    resulting_version = int(current_version)
+                    before_json = json.dumps(
+                        {
+                            "warn_low": old_warn_low,
+                            "warn_high": old_warn_high,
+                            "crit_low": old_crit_low,
+                            "crit_high": old_crit_high,
+                        }
+                    )
+                    after_json = json.dumps(
+                        {
+                            "warn_low": new_warn_low,
+                            "warn_high": new_warn_high,
+                            "crit_low": new_crit_low,
+                            "crit_high": new_crit_high,
+                        }
+                    )
+
+                    if not is_noop:
+                        resulting_version = int(current_version) + 1
+                        con.execute(
+                            """
+                            UPDATE ChartsV2
+                            SET warn_low = ?, warn_high = ?, crit_low = ?, crit_high = ?,
+                                version = ?, updated_at = ?, updated_by = ?,
+                                update_reason = ?, update_source = ?
+                            WHERE id = ?
+                            """,
+                            (
+                                new_warn_low,
+                                new_warn_high,
+                                new_crit_low,
+                                new_crit_high,
+                                resulting_version,
+                                changed_at,
+                                payload.changed_by,
+                                payload.reason,
+                                "emergency_manual",
+                                chart_id,
+                            ),
+                        )
+                        con.execute(
+                            """
+                            INSERT INTO ChartsHistory(
+                                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                                step_no, feature_type,
+                                old_warn_low, old_warn_high, old_crit_low, old_crit_high,
+                                new_warn_low, new_warn_high, new_crit_low, new_crit_high,
+                                changed_at, changed_by, change_reason, change_source, chart_id
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                            (
+                                chart_set_id,
+                                tool_id,
+                                chamber_id,
+                                recipe_id,
+                                parameter,
+                                step_no,
+                                feature_type,
+                                old_warn_low,
+                                old_warn_high,
+                                old_crit_low,
+                                old_crit_high,
+                                new_warn_low,
+                                new_warn_high,
+                                new_crit_low,
+                                new_crit_high,
+                                changed_at,
+                                payload.changed_by,
+                                payload.reason,
+                                "emergency_manual",
+                                chart_id,
+                            ),
+                        )
+
+                    emergency_change_id = self._governance_emergency_changes_repository.create(
+                        con,
+                        chart_id=int(chart_id),
+                        changed_by=payload.changed_by,
+                        changed_by_role=payload.changed_by_role,
+                        changed_at=changed_at,
+                        reason=payload.reason,
+                        before_json=before_json,
+                        after_json=after_json,
+                        resulting_version=resulting_version,
+                        related_issue_or_pr=None,
+                    )
+                    audit_event_id = self._audit_event_writer.write(
+                        con,
+                        event_type="emergency_changed",
+                        actor=payload.changed_by,
+                        actor_role=payload.changed_by_role,
+                        target_type="emergency_change",
+                        target_id=emergency_change_id,
+                        occurred_at=changed_at,
+                        before_json=before_json,
+                        after_json=after_json,
+                        correlation_id=f"emergency:{emergency_change_id}",
+                    )
+                    con.execute(
+                        """
+                        INSERT INTO GovernanceNotificationOutbox(event_id, status)
+                        VALUES (?, 'pending')
+                        """,
+                        (audit_event_id,),
+                    )
+                    con.commit()
+                    return {
+                        "request_id": emergency_change_id,
+                        "status": "applied",
+                        "resulting_version": resulting_version,
+                        "noop": is_noop,
+                    }
+                except Exception:
+                    con.rollback()
+                    raise
+                finally:
+                    con.close()
+
+            try:
+                data = runner.submit("write", _write)
+                return {"ok": True, "data": data}
+            except _GovernanceEmergencyChangeChartNotFound:
+                return not_found_error_response(
+                    code="CHART_NOT_FOUND",
+                    message="target chart not found",
+                    details={"chart_id": str(payload.chart_id)},
+                )
+            except GovernanceApplyValidationError as e:
+                return validation_error_response(
+                    issues=[
+                        {
+                            "loc": ["body", "change_payload"],
+                            "msg": e.message,
+                            "type": "value_error",
+                        }
+                    ]
+                )
+            except Exception as e:
+                raise_api_error(operation="POST /governance/emergency-changes", error=e)
+
+        @self.router.post("/governance/emergency-changes/{request_id}/ratify")
+        def ratify_governance_emergency_change(
+            payload: EmergencyChangeRatifyIn,
+            request: Request,
+            request_id: int = Path(ge=1),
+        ):
+            ratified_at = to_utc_millis(datetime.now(UTC).isoformat())
+            runner = self._get_runner(request)
+
+            def _write() -> dict[str, object]:
+                con = _connect(MAIN_DB)
+                try:
+                    con.execute("BEGIN")
+                    self._governance_emergency_changes_repository.find_by_id(con, request_id)
+
+                    try:
+                        self._governance_ratifications_repository.create(
+                            con,
+                            ec_id=request_id,
+                            ratified_by_role=payload.ratified_by_role,
+                            ratified_at=ratified_at,
+                            ratification_comment=payload.ratification_comment,
+                            related_pr=payload.related_pr,
+                        )
+                    except sqlite3.IntegrityError as e:
+                        if _is_governance_ratification_ec_unique_error(e):
+                            raise _GovernanceEmergencyRatificationConflict(ec_id=request_id) from e
+                        if "foreign key constraint failed" in str(e).lower():
+                            raise GovernanceNotFoundError(
+                                f"GovernanceEmergencyChanges id={request_id} not found"
+                            ) from e
+                        raise
+
+                    if payload.related_pr is not None:
+                        con.execute(
+                            """
+                            UPDATE GovernanceEmergencyChanges
+                            SET related_issue_or_pr = ?
+                            WHERE id = ?
+                            """,
+                            (payload.related_pr, request_id),
+                        )
+
+                    self._audit_event_writer.write(
+                        con,
+                        event_type="emergency_ratified",
+                        actor="ops",
+                        actor_role=payload.ratified_by_role,
+                        target_type="emergency_change",
+                        target_id=request_id,
+                        occurred_at=ratified_at,
+                        correlation_id=f"emergency:{request_id}",
+                    )
+                    con.commit()
+                    return {"request_id": request_id, "status": "ratified"}
+                except Exception:
+                    con.rollback()
+                    raise
+                finally:
+                    con.close()
+
+            try:
+                data = runner.submit("write", _write)
+                return {"ok": True, "data": data}
+            except GovernanceNotFoundError:
+                return not_found_error_response(
+                    message="emergency change not found",
+                    details={"request_id": str(request_id)},
+                )
+            except _GovernanceEmergencyRatificationConflict:
+                return conflict_error_response(
+                    code="ALREADY_RATIFIED",
+                    message="emergency change is already ratified",
+                    details={"request_id": str(request_id)},
+                )
+            except Exception as e:
+                raise_api_error(
+                    operation="POST /governance/emergency-changes/{request_id}/ratify",
+                    error=e,
+                )
+
+        @self.router.post("/governance/notifications/{event_id}/retry")
+        def retry_governance_notification(request: Request, event_id: int = Path(ge=1)):
+            runner = self._get_runner(request)
+
+            def _retry_failed_notification_outbox() -> dict[str, object]:
+                con = _connect(MAIN_DB)
+                try:
+                    con.execute("BEGIN")
+                    row = con.execute(
+                        """
+                        SELECT id, status, retry_count
+                        FROM GovernanceNotificationOutbox
+                        WHERE event_id = ?
+                        """,
+                        (event_id,),
+                    ).fetchone()
+                    if row is None:
+                        raise _GovernanceNotificationNotFound
+
+                    outbox_id = int(row[0])
+                    status = str(row[1])
+                    retry_count = int(row[2])
+
+                    if status != "failed":
+                        raise _GovernanceNotificationInvalidState(status=status)
+                    if retry_count >= len(NOTIFICATION_RETRY_BACKOFF_MINUTES):
+                        raise _GovernanceNotificationRetryLimitExceeded(retry_count=retry_count)
+
+                    now = datetime.now(UTC)
+                    now_iso = to_utc_millis(now.isoformat())
+                    next_retry_at = compute_notification_next_retry_at(
+                        base_time=now,
+                        retry_count=retry_count + 1,
+                    )
+
+                    update_cur = con.execute(
+                        """
+                        UPDATE GovernanceNotificationOutbox
+                        SET status = 'pending',
+                            retry_count = retry_count + 1,
+                            next_retry_at = ?,
+                            last_attempt_at = ?,
+                            last_error = NULL
+                        WHERE id = ?
+                          AND status = 'failed'
+                          AND retry_count = ?
+                        """,
+                        (next_retry_at, now_iso, outbox_id, retry_count),
+                    )
+                    if update_cur.rowcount == 0:
+                        latest = con.execute(
+                            """
+                            SELECT status, retry_count
+                            FROM GovernanceNotificationOutbox
+                            WHERE id = ?
+                            """,
+                            (outbox_id,),
+                        ).fetchone()
+                        if latest is None:
+                            raise _GovernanceNotificationNotFound
+
+                        latest_status = str(latest[0])
+                        latest_retry_count = int(latest[1])
+                        if latest_status != "failed":
+                            raise _GovernanceNotificationInvalidState(status=latest_status)
+                        if latest_retry_count >= len(NOTIFICATION_RETRY_BACKOFF_MINUTES):
+                            raise _GovernanceNotificationRetryLimitExceeded(
+                                retry_count=latest_retry_count
+                            )
+                        raise _GovernanceNotificationConcurrentModification
+
+                    self._audit_event_writer.write(
+                        con,
+                        event_type="notification_queued",
+                        actor="ops",
+                        actor_role="ops",
+                        target_type="notification",
+                        target_id=outbox_id,
+                        occurred_at=now_iso,
+                        correlation_id=f"event:{event_id}",
+                    )
+                    con.commit()
+                    return {
+                        "event_id": event_id,
+                        "status": "pending",
+                        "retry_count": retry_count + 1,
+                        "next_retry_at": next_retry_at,
+                    }
+                except Exception:
+                    con.rollback()
+                    raise
+                finally:
+                    con.close()
+
+            try:
+                data = runner.submit("write", _retry_failed_notification_outbox)
+                return {"ok": True, "data": data}
+            except _GovernanceNotificationNotFound:
+                return not_found_error_response(
+                    message="notification outbox not found",
+                    details={"event_id": str(event_id)},
+                )
+            except _GovernanceNotificationInvalidState as e:
+                return bad_request_error_response(
+                    code="INVALID_RETRY_TARGET",
+                    message="only failed notification can be retried",
+                    details={"event_id": str(event_id), "current_status": e.status},
+                )
+            except _GovernanceNotificationRetryLimitExceeded as e:
+                return conflict_error_response(
+                    code="RETRY_LIMIT_EXCEEDED",
+                    message="retry_count has reached the maximum",
+                    details={
+                        "event_id": str(event_id),
+                        "retry_count": str(e.retry_count),
+                        "max_retry_count": str(len(NOTIFICATION_RETRY_BACKOFF_MINUTES)),
+                    },
+                )
+            except _GovernanceNotificationConcurrentModification:
+                return conflict_error_response(
+                    code="CONCURRENT_MODIFICATION",
+                    message="notification outbox was modified concurrently",
+                    details={"event_id": str(event_id)},
+                )
+            except Exception as e:
+                raise_api_error(
+                    operation="POST /governance/notifications/{event_id}/retry", error=e
+                )
+
+        @self.router.post("/governance/change-requests")
+        def create_governance_change_request(payload: ChangeRequestIn, request: Request):
+            proposed_at = to_utc_millis(datetime.now(UTC).isoformat())
+            runner = self._get_runner(request)
+
+            def _write() -> dict[str, int | str]:
+                con = _connect(MAIN_DB)
+                try:
+                    con.execute("BEGIN")
+                    try:
+                        request_id = self._governance_change_request_repository.create(
+                            con,
+                            chart_id=payload.chart_id,
+                            proposed_by=payload.proposed_by,
+                            proposed_at=proposed_at,
+                            change_payload=payload.change_payload,
+                            expected_version=payload.expected_version,
+                            idempotency_key=payload.idempotency_key,
+                        )
+                    except sqlite3.IntegrityError as e:
+                        if _is_duplicate_change_request_idempotency_error(e):
+                            raise _GovernanceChangeRequestIdempotencyConflict from e
+                        if _is_governance_change_request_chart_fk_error(e):
+                            raise _GovernanceChangeRequestChartFkViolation from e
+                        raise
+
+                    self._audit_event_writer.write(
+                        con,
+                        event_type="change_requested",
+                        actor=payload.proposed_by,
+                        actor_role="requester",
+                        target_type="change_request",
+                        target_id=request_id,
+                        occurred_at=proposed_at,
+                        correlation_id=payload.idempotency_key,
+                    )
+
+                    row = self._governance_change_request_repository.find_by_id(con, request_id)
+                    con.commit()
+                    return {"request_id": request_id, "status": row.status}
+                except Exception:
+                    con.rollback()
+                    raise
+                finally:
+                    con.close()
+
+            try:
+                data = runner.submit("write", _write)
+                return {"ok": True, "data": data}
+            except _GovernanceChangeRequestIdempotencyConflict:
+                return duplicate_idempotency_error_response(idempotency_key=payload.idempotency_key)
+            except _GovernanceChangeRequestChartFkViolation:
+                return validation_error_response(
+                    issues=[
+                        {
+                            "loc": ["body", "chart_id"],
+                            "msg": "chart_id must reference an existing chart",
+                            "type": "value_error",
+                        }
+                    ]
+                )
+            except Exception as e:
+                raise_api_error(operation="POST /governance/change-requests", error=e)
+
+        @self.router.post("/governance/change-requests/{request_id}/approve")
+        def approve_governance_change_request(
+            payload: ChangeRequestApproveIn,
+            request: Request,
+            request_id: int = Path(ge=1),
+        ):
+            approved_at = to_utc_millis(datetime.now(UTC).isoformat())
+            runner = self._get_runner(request)
+
+            def _write() -> dict[str, int | str]:
+                con = _connect(MAIN_DB)
+                try:
+                    con.execute("BEGIN")
+                    row = self._governance_change_request_repository.find_by_id(con, request_id)
+
+                    if row.status == "approved":
+                        raise _GovernanceApproveAlreadyApproved
+                    if row.status != "pending":
+                        raise _GovernanceApproveInvalidState
+
+                    self._governance_approvals_repository.create(
+                        con,
+                        request_id=request_id,
+                        approved_by=payload.approved_by,
+                        approved_by_role=payload.approved_by_role,
+                        approved_at=approved_at,
+                        comment=payload.comment,
+                    )
+                    self._governance_change_request_repository.update_status(
+                        con,
+                        record_id=request_id,
+                        new_status="approved",
+                    )
+                    self._audit_event_writer.write(
+                        con,
+                        event_type="change_approved",
+                        actor=payload.approved_by,
+                        actor_role=payload.approved_by_role,
+                        target_type="change_request",
+                        target_id=request_id,
+                        occurred_at=approved_at,
+                        correlation_id=f"request:{request_id}",
+                    )
+                    con.commit()
+                    return {"request_id": request_id, "status": "approved"}
+                except Exception:
+                    con.rollback()
+                    raise
+                finally:
+                    con.close()
+
+            try:
+                data = runner.submit("write", _write)
+                return {
+                    "ok": True,
+                    "data": data,
+                    "timestamp": to_utc_millis(datetime.now(UTC).isoformat()),
+                }
+            except GovernanceNotFoundError:
+                return not_found_error_response(
+                    message="change request not found",
+                    details={"request_id": str(request_id)},
+                )
+            except _GovernanceApproveAlreadyApproved:
+                return conflict_error_response(
+                    code="ALREADY_APPROVED",
+                    message="change request is already approved",
+                    details={"request_id": str(request_id)},
+                )
+            except _GovernanceApproveInvalidState:
+                return conflict_error_response(
+                    code="INVALID_STATUS_TRANSITION",
+                    message="only pending change request can be approved",
+                    details={"request_id": str(request_id)},
+                )
+            except Exception as e:
+                raise_api_error(
+                    operation="POST /governance/change-requests/{request_id}/approve",
+                    error=e,
+                )
+
+        @self.router.post("/governance/change-requests/{request_id}/apply")
+        def apply_governance_change_request(
+            payload: ChangeRequestApplyIn,
+            request: Request,
+            request_id: int = Path(ge=1),
+        ):
+            applied_at = to_utc_millis(datetime.now(UTC).isoformat())
+            runner = self._get_runner(request)
+
+            def _write() -> dict[str, object]:
+                con = _connect(MAIN_DB)
+                try:
+                    con.execute("BEGIN")
+                    try:
+                        req = self._governance_change_request_repository.find_by_id(con, request_id)
+                        if req.status != "approved":
+                            raise _GovernanceApplyInvalidState
+
+                        chart_row = con.execute(
+                            """
+                            SELECT
+                                id, chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                                version, updated_at
+                            FROM ChartsV2
+                            WHERE id = ?
+                            """,
+                            (req.chart_id,),
+                        ).fetchone()
+                        if chart_row is None:
+                            raise _GovernanceApplyChartNotFound
+
+                        (
+                            chart_id,
+                            chart_set_id,
+                            tool_id,
+                            chamber_id,
+                            recipe_id,
+                            parameter,
+                            step_no,
+                            feature_type,
+                            old_warn_low,
+                            old_warn_high,
+                            old_crit_low,
+                            old_crit_high,
+                            current_version,
+                            current_updated_at,
+                        ) = chart_row
+
+                        if int(current_version) != int(req.expected_version):
+                            raise _GovernanceApplyVersionConflict(
+                                current_version=int(current_version),
+                                current_updated_at=str(current_updated_at),
+                                chart_id=int(chart_id),
+                                current_status=str(getattr(req, "status", "unknown") or "unknown"),
+                            )
+
+                        patch = parse_threshold_patch(req.change_payload)
+                        new_warn_low = patch.get("warn_low", old_warn_low)
+                        new_warn_high = patch.get("warn_high", old_warn_high)
+                        new_crit_low = patch.get("crit_low", old_crit_low)
+                        new_crit_high = patch.get("crit_high", old_crit_high)
+
+                        validate_threshold_consistency(
+                            warn_low=new_warn_low,
+                            warn_high=new_warn_high,
+                            crit_low=new_crit_low,
+                            crit_high=new_crit_high,
+                        )
+
+                        is_noop = (
+                            thresholds_equal(old_warn_low, new_warn_low)
+                            and thresholds_equal(old_warn_high, new_warn_high)
+                            and thresholds_equal(old_crit_low, new_crit_low)
+                            and thresholds_equal(old_crit_high, new_crit_high)
+                        )
+
+                        resulting_version = int(current_version)
+                        if not is_noop:
+                            resulting_version = int(current_version) + 1
+                            con.execute(
+                                """
+                                UPDATE ChartsV2
+                                SET warn_low = ?, warn_high = ?, crit_low = ?, crit_high = ?,
+                                    version = ?, updated_at = ?, updated_by = ?,
+                                    update_reason = ?, update_source = ?
+                                WHERE id = ?
+                                """,
+                                (
+                                    new_warn_low,
+                                    new_warn_high,
+                                    new_crit_low,
+                                    new_crit_high,
+                                    resulting_version,
+                                    applied_at,
+                                    payload.applied_by,
+                                    payload.reason,
+                                    "governance_apply",
+                                    chart_id,
+                                ),
+                            )
+                            con.execute(
+                                """
+                                INSERT INTO ChartsHistory(
+                                    chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                                    step_no, feature_type,
+                                    old_warn_low, old_warn_high, old_crit_low, old_crit_high,
+                                    new_warn_low, new_warn_high, new_crit_low, new_crit_high,
+                                    changed_at, changed_by, change_reason, change_source, chart_id
+                                ) VALUES (
+                                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                                )
+                                """,
+                                (
+                                    chart_set_id,
+                                    tool_id,
+                                    chamber_id,
+                                    recipe_id,
+                                    parameter,
+                                    step_no,
+                                    feature_type,
+                                    old_warn_low,
+                                    old_warn_high,
+                                    old_crit_low,
+                                    old_crit_high,
+                                    new_warn_low,
+                                    new_warn_high,
+                                    new_crit_low,
+                                    new_crit_high,
+                                    applied_at,
+                                    payload.applied_by,
+                                    payload.reason,
+                                    "governance_apply",
+                                    chart_id,
+                                ),
+                            )
+
+                        con.execute(
+                            """
+                            INSERT OR REPLACE INTO GovernanceApplyResults(
+                                request_id, applied_at, success, resulting_version,
+                                error_code, error_message
+                            ) VALUES (?, ?, 1, ?, NULL, NULL)
+                            """,
+                            (request_id, applied_at, resulting_version),
+                        )
+                        self._governance_change_request_repository.update_status(
+                            con,
+                            record_id=request_id,
+                            new_status="applied",
+                        )
+                        self._audit_event_writer.write(
+                            con,
+                            event_type="change_applied",
+                            actor=payload.applied_by,
+                            actor_role=payload.applied_by_role,
+                            target_type="change_request",
+                            target_id=request_id,
+                            occurred_at=applied_at,
+                            correlation_id=f"request:{request_id}",
+                        )
+                        con.commit()
+                        return {
+                            "request_id": request_id,
+                            "status": "applied",
+                            "resulting_version": resulting_version,
+                            "noop": is_noop,
+                        }
+                    except (
+                        _GovernanceApplyInvalidState,
+                        GovernanceApplyValidationError,
+                        _GovernanceApplyVersionConflict,
+                    ):
+                        self._audit_event_writer.write(
+                            con,
+                            event_type="change_apply_failed",
+                            actor=payload.applied_by,
+                            actor_role=payload.applied_by_role,
+                            target_type="change_request",
+                            target_id=request_id,
+                            occurred_at=applied_at,
+                            correlation_id=f"request:{request_id}",
+                        )
+                        con.commit()
+                        raise
+                except Exception:
+                    con.rollback()
+                    raise
+                finally:
+                    con.close()
+
+            try:
+                data = runner.submit("write", _write)
+                return {
+                    "ok": True,
+                    "data": data,
+                    "timestamp": to_utc_millis(datetime.now(UTC).isoformat()),
+                }
+            except GovernanceNotFoundError:
+                return not_found_error_response(
+                    message="change request not found",
+                    details={"request_id": str(request_id)},
+                )
+            except _GovernanceApplyInvalidState:
+                return conflict_error_response(
+                    code="INVALID_STATUS_TRANSITION",
+                    message="only approved change request can be applied",
+                    details={"request_id": str(request_id)},
+                )
+            except _GovernanceApplyChartNotFound:
+                return bad_request_error_response(
+                    code="CHART_NOT_FOUND",
+                    message="target chart not found",
+                    details={"request_id": str(request_id)},
+                )
+            except _GovernanceApplyVersionConflict as e:
+                return JSONResponse(
+                    status_code=409,
+                    content={
+                        "ok": False,
+                        "error": {
+                            "code": "STALE_EXPECTED_VERSION",
+                            "message": "expected_version does not match current version",
+                            "details": {
+                                "request_id": str(request_id),
+                                "current": {
+                                    "chart_id": e.chart_id,
+                                    "version": e.current_version,
+                                    "updated_at": e.current_updated_at,
+                                    "status": e.current_status,
+                                },
+                            },
+                        },
+                    },
+                )
+            except GovernanceApplyValidationError as e:
+                return validation_error_response(
+                    issues=[
+                        {
+                            "loc": ["body", "change_payload"],
+                            "msg": e.message,
+                            "type": "value_error",
+                        }
+                    ]
+                )
+            except Exception as e:
+                raise_api_error(
+                    operation="POST /governance/change-requests/{request_id}/apply",
+                    error=e,
+                )

--- a/src/portfolio_fdc/db_api/routers/ingest_router.py
+++ b/src/portfolio_fdc/db_api/routers/ingest_router.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import APIRouter, Request
+
+from ..aggregate_repository import (
+    delete_process,
+    write_aggregate_atomic,
+    write_parameters_bulk,
+    write_process,
+    write_step_windows_bulk,
+)
+from ..api_common import raise_api_error
+from ..schemas import AggregateWriteIn, ParameterIn, ProcessDeleteIn, ProcessInfoIn, StepWindowIn
+from ..task_runner import DBTaskRunner
+
+
+class IngestRouter:
+    """ingest 書き込み系エンドポイントをまとめるルータークラス。"""
+
+    def __init__(
+        self,
+        *,
+        get_runner: Callable[[Request], DBTaskRunner],
+        legacy_headers: Callable[[str | None], dict[str, str]],
+    ) -> None:
+        self._get_runner = get_runner
+        self._legacy_headers = legacy_headers
+        self.router = APIRouter()
+        self._register_routes()
+
+    def _register_routes(self) -> None:
+        @self.router.post("/processes")
+        def create_process(p: ProcessInfoIn, request: Request):
+            runner = self._get_runner(request)
+            try:
+                runner.submit("write", lambda: write_process(p))
+                return {"ok": True}
+            except Exception as e:
+                raise_api_error(operation="POST /processes", error=e)
+
+        @self.router.delete("/processes/{process_id:path}")
+        def remove_process_by_path(process_id: str, request: Request):
+            runner = self._get_runner(request)
+            try:
+                deleted = runner.submit("write", lambda: delete_process(process_id))
+                return {"ok": True, "deleted": deleted}
+            except Exception as e:
+                raise_api_error(operation="DELETE /processes/{process_id}", error=e)
+
+        @self.router.delete("/processes")
+        def remove_process_legacy(request: Request, req: ProcessDeleteIn):
+            runner = self._get_runner(request)
+            request.state.legacy_delete_process_id = req.process_id
+            headers = self._legacy_headers(req.process_id)
+            try:
+                deleted = runner.submit("write", lambda: delete_process(req.process_id))
+                return {"ok": True, "deleted": deleted}
+            except Exception as e:
+                raise_api_error(operation="DELETE /processes", error=e, headers=headers)
+
+        @self.router.post("/step_windows/bulk")
+        def create_step_windows_bulk(items: list[StepWindowIn], request: Request):
+            runner = self._get_runner(request)
+            try:
+                inserted = runner.submit("write", lambda: write_step_windows_bulk(items))
+                return {"ok": True, "inserted": inserted}
+            except Exception as e:
+                raise_api_error(operation="POST /step_windows/bulk", error=e)
+
+        @self.router.post("/parameters/bulk")
+        def create_parameters_bulk(params: list[ParameterIn], request: Request):
+            runner = self._get_runner(request)
+            try:
+                inserted = runner.submit("write", lambda: write_parameters_bulk(params))
+                return {"ok": True, "inserted": inserted}
+            except Exception as e:
+                raise_api_error(operation="POST /parameters/bulk", error=e)
+
+        @self.router.post("/aggregate/write")
+        def create_aggregate_write(payload: AggregateWriteIn, request: Request):
+            runner = self._get_runner(request)
+            try:
+                return runner.submit("write", lambda: write_aggregate_atomic(payload))
+            except Exception as e:
+                raise_api_error(operation="POST /aggregate/write", error=e)

--- a/src/portfolio_fdc/db_api/routers/ingest_router.py
+++ b/src/portfolio_fdc/db_api/routers/ingest_router.py
@@ -5,8 +5,12 @@ from collections.abc import Callable
 from fastapi import APIRouter, Request
 
 from ..aggregate_repository import (
-    delete_process,
-    write_aggregate_atomic,
+    delete_process as _delete_process,
+)
+from ..aggregate_repository import (
+    write_aggregate_atomic as _write_aggregate_atomic,
+)
+from ..aggregate_repository import (
     write_parameters_bulk,
     write_process,
     write_step_windows_bulk,
@@ -24,9 +28,13 @@ class IngestRouter:
         *,
         get_runner: Callable[[Request], DBTaskRunner],
         legacy_headers: Callable[[str | None], dict[str, str]],
+        delete_process: Callable[..., int] = _delete_process,
+        write_aggregate_atomic: Callable[..., dict[str, int | bool]] = _write_aggregate_atomic,
     ) -> None:
         self._get_runner = get_runner
         self._legacy_headers = legacy_headers
+        self._delete_process = delete_process
+        self._write_aggregate_atomic = write_aggregate_atomic
         self.router = APIRouter()
         self._register_routes()
 
@@ -44,7 +52,7 @@ class IngestRouter:
         def remove_process_by_path(process_id: str, request: Request):
             runner = self._get_runner(request)
             try:
-                deleted = runner.submit("write", lambda: delete_process(process_id))
+                deleted = runner.submit("write", lambda: self._delete_process(process_id))
                 return {"ok": True, "deleted": deleted}
             except Exception as e:
                 raise_api_error(operation="DELETE /processes/{process_id}", error=e)
@@ -55,7 +63,7 @@ class IngestRouter:
             request.state.legacy_delete_process_id = req.process_id
             headers = self._legacy_headers(req.process_id)
             try:
-                deleted = runner.submit("write", lambda: delete_process(req.process_id))
+                deleted = runner.submit("write", lambda: self._delete_process(req.process_id))
                 return {"ok": True, "deleted": deleted}
             except Exception as e:
                 raise_api_error(operation="DELETE /processes", error=e, headers=headers)
@@ -82,6 +90,6 @@ class IngestRouter:
         def create_aggregate_write(payload: AggregateWriteIn, request: Request):
             runner = self._get_runner(request)
             try:
-                return runner.submit("write", lambda: write_aggregate_atomic(payload))
+                return runner.submit("write", lambda: self._write_aggregate_atomic(payload))
             except Exception as e:
                 raise_api_error(operation="POST /aggregate/write", error=e)

--- a/src/portfolio_fdc/db_api/routers/query_router.py
+++ b/src/portfolio_fdc/db_api/routers/query_router.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import asdict
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
+
+from ..api_common import (
+    CHART_ID_PATTERN,
+    CHARTS_FILTER_MAX_LENGTH,
+    CHARTS_FILTER_PATTERN,
+    JUDGE_LEVEL_PATTERN,
+    RESULT_ID_PATTERN,
+    normalize_query_datetime,
+    not_found_error_response,
+    parse_chart_pk,
+    parse_result_pk,
+    raise_api_error,
+    validate_query_datetime_range,
+)
+from ..chart_repository import (
+    ActiveChartsQueryCriteria,
+    ChartRepository,
+    ChartsHistoryQueryCriteria,
+    ChartsQueryCriteria,
+)
+from ..db import MAIN_DB, _connect_readonly
+from ..judge_repository import JudgeDataCorruptionError, JudgeRepository, JudgeResultsQueryCriteria
+from ..schemas import ChangeRequestsQuery, GovernanceAuditEventsQuery
+from ..task_runner import DBTaskRunner
+
+logger = logging.getLogger("portfolio_fdc.db_api.app")
+
+
+class QueryRouter:
+    """参照系エンドポイントをまとめるルータークラス。"""
+
+    def __init__(
+        self,
+        *,
+        chart_repository: ChartRepository,
+        judge_repository: JudgeRepository,
+        governance_change_request_repository,
+        get_runner: Callable[[Request], DBTaskRunner],
+        build_waveform_preview: Callable[[str, int], dict[str, object]],
+    ) -> None:
+        self._chart_repository = chart_repository
+        self._judge_repository = judge_repository
+        self._governance_change_request_repository = governance_change_request_repository
+        self._get_runner = get_runner
+        self._build_waveform_preview = build_waveform_preview
+        self.router = APIRouter()
+        self._register_routes()
+
+    def _register_routes(self) -> None:
+        @self.router.get("/charts")
+        def get_charts(
+            tool_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            chamber_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            recipe_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            parameter: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            step_no: int | None = Query(default=None, ge=0),
+            feature_type: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            active_only: bool = False,
+        ):
+            criteria = ChartsQueryCriteria(
+                tool_id=tool_id,
+                chamber_id=chamber_id,
+                recipe_id=recipe_id,
+                parameter=parameter,
+                step_no=step_no,
+                feature_type=feature_type,
+                active_only=active_only,
+            )
+            try:
+                rows = self._chart_repository.find_charts(criteria)
+                return {"ok": True, "data": [asdict(row) for row in rows]}
+            except Exception as e:
+                raise_api_error(operation="GET /charts", error=e)
+
+        @self.router.get("/charts/active")
+        def get_active_charts(
+            tool_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            chamber_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            recipe_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+        ):
+            criteria = ActiveChartsQueryCriteria(
+                tool_id=tool_id,
+                chamber_id=chamber_id,
+                recipe_id=recipe_id,
+            )
+            try:
+                data = self._chart_repository.find_active_chart_set(criteria)
+                return {"ok": True, "data": asdict(data)}
+            except Exception as e:
+                raise_api_error(operation="GET /charts/active", error=e)
+
+        @self.router.get("/charts/history")
+        def get_charts_history(
+            chart_id: str | None = Query(
+                default=None, min_length=1, max_length=64, pattern=CHART_ID_PATTERN
+            ),
+            chart_set_id: int | None = Query(default=None, ge=1),
+            change_source: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            from_ts: datetime | None = Query(default=None),  # noqa: B008
+            to_ts: datetime | None = Query(default=None),  # noqa: B008
+            limit: int = Query(default=100, ge=1, le=500),
+            offset: int = Query(default=0, ge=0),
+        ):
+            validate_query_datetime_range(from_ts, to_ts, require_pair=False)
+            chart_pk = parse_chart_pk(chart_id)
+            criteria = ChartsHistoryQueryCriteria(
+                chart_pk=chart_pk,
+                chart_set_id=chart_set_id,
+                change_source=change_source,
+                from_ts=normalize_query_datetime(from_ts),
+                to_ts=normalize_query_datetime(to_ts),
+                limit=limit,
+                offset=offset,
+            )
+
+            try:
+                rows = self._chart_repository.find_chart_history(criteria)
+                return {"ok": True, "data": [asdict(row) for row in rows]}
+            except Exception as e:
+                raise_api_error(operation="GET /charts/history", error=e)
+
+        @self.router.get("/charts/{chart_id}/points")
+        def get_chart_points(
+            chart_id: str = Path(min_length=1, max_length=64, pattern=CHART_ID_PATTERN),
+            limit: int = Query(default=50, ge=1, le=500),
+        ):
+            chart_pk = parse_chart_pk(chart_id)
+            if chart_pk is None:
+                raise HTTPException(status_code=400, detail="Invalid chart_id")
+
+            try:
+                rows = self._chart_repository.find_chart_points(chart_pk, limit)
+                return {"ok": True, "data": [asdict(row) for row in rows]}
+            except Exception as e:
+                raise_api_error(operation="GET /charts/{chart_id}/points", error=e)
+
+        @self.router.get("/processes/{process_id}/waveform-preview")
+        def get_process_waveform_preview(
+            process_id: str = Path(
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            limit: int = Query(default=300, ge=10, le=2000),
+        ):
+            try:
+                data = self._build_waveform_preview(process_id, limit)
+                return {"ok": True, "data": data}
+            except HTTPException:
+                raise
+            except Exception as e:
+                raise_api_error(operation="GET /processes/{process_id}/waveform-preview", error=e)
+
+        @self.router.get("/judge/results")
+        def get_judge_results(
+            chart_id: str | None = Query(
+                default=None, min_length=1, max_length=64, pattern=CHART_ID_PATTERN
+            ),
+            process_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            lot_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            recipe_id: str | None = Query(
+                default=None,
+                min_length=1,
+                max_length=CHARTS_FILTER_MAX_LENGTH,
+                pattern=CHARTS_FILTER_PATTERN,
+            ),
+            level: str | None = Query(default=None, pattern=JUDGE_LEVEL_PATTERN),
+            from_ts: datetime | None = Query(default=None),  # noqa: B008
+            to_ts: datetime | None = Query(default=None),  # noqa: B008
+            limit: int = Query(default=200, ge=1, le=1000),
+            offset: int = Query(default=0, ge=0),
+        ):
+            validate_query_datetime_range(from_ts, to_ts, require_pair=True)
+            criteria = JudgeResultsQueryCriteria(
+                chart_id=chart_id,
+                process_id=process_id,
+                lot_id=lot_id,
+                recipe_id=recipe_id,
+                level=level,
+                from_ts=normalize_query_datetime(from_ts),
+                to_ts=normalize_query_datetime(to_ts),
+                limit=limit,
+                offset=offset,
+            )
+
+            try:
+                rows = self._judge_repository.find_results(criteria)
+                return {"ok": True, "data": [asdict(row) for row in rows]}
+            except Exception as e:
+                raise_api_error(operation="GET /judge/results", error=e)
+
+        @self.router.get("/judge/results/{result_id}")
+        def get_judge_result_by_id(
+            result_id: str = Path(min_length=1, max_length=64, pattern=RESULT_ID_PATTERN),
+        ):
+            result_pk = parse_result_pk(result_id)
+            try:
+                row = self._judge_repository.find_result_by_id(result_pk)
+                if row is None:
+                    return not_found_error_response(
+                        message="judge result not found",
+                        details={"result_id": result_id},
+                    )
+                return {"ok": True, "data": asdict(row)}
+            except JudgeDataCorruptionError as e:
+                logger.error(
+                    "JUDGE_DATA_CORRUPTION: GET /judge/results/{result_id} failed "
+                    "(requested_result_id=%s, result_pk=%s)",
+                    result_id,
+                    result_pk,
+                    exc_info=True,
+                )
+                raise HTTPException(status_code=500, detail="Internal server error") from e
+            except Exception as e:
+                raise_api_error(operation="GET /judge/results/{result_id}", error=e)
+
+        @self.router.get("/governance/change-requests")
+        def get_governance_change_requests(query: ChangeRequestsQuery = Depends()):  # noqa: B008
+            con = _connect_readonly(MAIN_DB)
+            try:
+                rows = self._governance_change_request_repository.list(
+                    con,
+                    status=query.status,
+                    chart_id=query.chart_id,
+                    from_ts=normalize_query_datetime(query.from_ts),
+                    to_ts=normalize_query_datetime(query.to_ts),
+                    limit=query.limit,
+                    offset=query.offset,
+                )
+                return {"ok": True, "data": [asdict(row) for row in rows]}
+            except Exception as e:
+                raise_api_error(operation="GET /governance/change-requests", error=e)
+            finally:
+                con.close()
+
+        @self.router.get("/governance/audit-events")
+        def get_governance_audit_events(query: GovernanceAuditEventsQuery = Depends()):  # noqa: B008
+            con = _connect_readonly(MAIN_DB)
+            try:
+                validate_query_datetime_range(query.from_ts, query.to_ts, require_pair=False)
+
+                sql = """
+                    SELECT
+                        id, event_type, actor, actor_role, target_type, target_id,
+                        occurred_at, before_json, after_json, correlation_id
+                    FROM GovernanceAuditEvents
+                """
+                where_clauses: list[str] = []
+                params: list[object] = []
+
+                if query.event_type is not None:
+                    where_clauses.append("event_type = ?")
+                    params.append(query.event_type)
+                if query.target_type is not None:
+                    where_clauses.append("target_type = ?")
+                    params.append(query.target_type)
+                if query.target_id is not None:
+                    where_clauses.append("target_id = ?")
+                    params.append(query.target_id)
+                if query.from_ts is not None:
+                    where_clauses.append("occurred_at >= ?")
+                    params.append(normalize_query_datetime(query.from_ts))
+                if query.to_ts is not None:
+                    where_clauses.append("occurred_at <= ?")
+                    params.append(normalize_query_datetime(query.to_ts))
+
+                if where_clauses:
+                    sql += " WHERE " + " AND ".join(where_clauses)
+
+                sql += " ORDER BY occurred_at DESC, id DESC LIMIT ? OFFSET ?"
+                params.extend((query.limit, query.offset))
+
+                rows = con.execute(sql, params).fetchall()
+                data = [
+                    {
+                        "id": int(row[0]),
+                        "event_type": str(row[1]),
+                        "actor": str(row[2]),
+                        "actor_role": str(row[3]),
+                        "target_type": str(row[4]),
+                        "target_id": int(row[5]),
+                        "occurred_at": str(row[6]),
+                        "before_json": row[7],
+                        "after_json": row[8],
+                        "correlation_id": row[9],
+                    }
+                    for row in rows
+                ]
+                return {"ok": True, "data": data}
+            except HTTPException:
+                raise
+            except Exception as e:
+                raise_api_error(operation="GET /governance/audit-events", error=e)
+            finally:
+                con.close()


### PR DESCRIPTION
## What

src/portfolio_fdc/db_api/app.py (~2000行) を OOP ルーター分割によって 253 行のエントリポイントに削減しました。

### 新規ファイル

| ファイル | 行数 | 役割 |
|---|---|---|
| db_api/api_common.py | ~349行 | 共通ヘルパー・バリデーション・レスポンスビルダー |
| db_api/routers/__init__.py | 1行 | パッケージ初期化 |
| db_api/routers/query_router.py | ~329行 | QueryRouter クラス（GET系エンドポイント） |
| db_api/routers/governance_router.py | ~873行 | GovernanceRouter クラス（ガバナンス書き込み系） |
| db_api/routers/ingest_router.py | ~69行 | IngestRouter クラス（ingest書き込み系） |

## Why

- pp.py が単一ファイル 2000 行超となっており保守性が低下していた
- ルーター・ヘルパー・モデルが混在し、責務が不明確だった

## How

### OOP ルーターパターン

各責務グループを self.router = APIRouter() を持つクラスに抽出。コンストラクタ注入でリポジトリ・runner を受け取る。

`python
class QueryRouter:
    def __init__(self, *, chart_repository, judge_repository, ..., get_runner):
        self.router = APIRouter()
        self._register_routes()
`

### 後方互換性の維持

テストが db_app モジュールの内部シンボルを monkeypatch しているため、pp.py で再エクスポートを維持:
- _parse_chart_pk, _connect_readonly, DATA_ROOT, pathlib
- _build_waveform_preview は lambda 経由で注入（monkeypatch 互換）

## Checklist

- [x] ruff / mypy / import-linter 全通過
- [x] 全 db_api エンドポイントテスト通過（126+ tests）
- [x] 後方互換シンボルを維持（既存テスト変更なし）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 概要
- monolithic な src/portfolio_fdc/db_api/app.py（約2000行）を OOP ルーター分割でスリム化：エントリポイントを約253行に削減、モジュール全体で行移動・分割を実施。
- 責務ごとにルーター化：QueryRouter（GET系）、GovernanceRouter（ガバナンス書き込み系）、IngestRouter（ingest 書き込み系）へ抽出。
- 共通ユーティリティを api_common.py に集約（バリデーション／エラーマッピング／レスポンスビルダー等）。

## 追加ファイル（主要）
- db_api/api_common.py (~349行)：日時正規化、ID 解析、閾値パッチ処理、エラー→HTTP マッピング、通知リトライ計算など。
- db_api/routers/query_router.py (~329行)：チャート履歴・波形プレビュー・判定結果・ガバナンス参照等の GET エンドポイントを提供。
- db_api/routers/governance_router.py (~873行)：緊急変更／承認／適用／通知リトライ等のガバナンス書き込みロジック。
- db_api/routers/ingest_router.py (~69行)：プロセス作成・削除、バルク書き込み、aggregate 書き込み等の ingest エンドポイント。
- db_api/routers/__init__.py (1行)

## 後方互換性とテスト対応
- テストが内部シンボルを monkeypatch しているため、app.py で _parse_chart_pk、_connect_readonly、DATA_ROOT、pathlib 等のエイリアス／再エクスポートを維持。
- _build_waveform_preview は lambda 経由で注入し monkeypatch 互換を保持。IngestRouter に注入可能な delete_process / write_aggregate_atomic を設け、app.py 側では lambda 経由で注入してテスト互換性を確保。
- チェック済み：ruff / mypy / import-linter 全通過、db_api 関連エンドポイントテスト（126+ テスト）全通過。

## テストギャップ
- api_common の低レベルユーティリティ（is_runner_unavailable_error / is_transient_operational_error）に対する単体テストが見当たらない可能性。
- parse_threshold_patch / validate_threshold_consistency に関するテストは限定的（少数ケース）。
- 新設した各 Router の細かな単体テストは少なく、現状は統合テスト中心。

## 主なリスク
- governance_router の複雑なトランザクション／例外→HTTP マッピング（複数の内部例外クラスと SQLite IntegrityError パターン判定）は誤判定や境界ケースの見落としリスクがある。
- 閾値パッチ処理のエイリアス・数値厳密検査（NaN/±Inf/順序制約）は仕様解釈差による不整合リスク。
- monkeypatch 互換のための再エクスポート・lambda 注入は互換性維持に寄与するが、将来のリファクタで意図せず依存関係が壊れる恐れがある（テストが内部シンボルに依存しているため）。
- 大規模なコード移動のため差分レビュー漏れ・ロジックの微妙な振る舞い変更が残る可能性（特にエラーハンドリング周り）。

## 推奨フォローアップ
- api_common の低レベルユーティリティと閾値バリデーションの単体テストを追加。
- router ごとの単体テスト（各エンドポイントの成功／失敗パス、例外マッピング、競合更新ケース）を充実化。
- governance_router のエラーパターン識別ロジックに対する明示的なテスト（SQLite 異常ケース再現）を追加。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/204)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->