### PR TITLE
test(governance): add #144 audit-events boundary tests

### DIFF
--- a/src/portfolio_fdc/db_api/governance_repository.py
+++ b/src/portfolio_fdc/db_api/governance_repository.py
@@ -263,6 +263,14 @@ class EmergencyChangeRow:
     related_issue_or_pr: str | None
 
 
+def _normalize_reason(reason: str | None) -> str:
+    """GovernanceEmergencyChanges.reason の保存値を正規化する。
+
+    None は空文字として保存する。
+    """
+    return "" if reason is None else reason
+
+
 class GovernanceEmergencyChangesRepository:
     """GovernanceEmergencyChanges テーブルへの操作を提供する。"""
 
@@ -279,8 +287,10 @@ class GovernanceEmergencyChangesRepository:
         resulting_version: int,
         related_issue_or_pr: str | None = None,
     ) -> int:
-        """緊急変更レコードを INSERT し、生成された id を返す。"""
-        stored_reason = reason if reason is not None else ""
+        """緊急変更レコードを INSERT し、生成された id を返す。
+
+        GovernanceEmergencyChanges.reason は None の場合に空文字として保存する。
+        """
         cur = con.execute(
             """
             INSERT INTO GovernanceEmergencyChanges
@@ -293,7 +303,7 @@ class GovernanceEmergencyChangesRepository:
                 changed_by,
                 changed_by_role,
                 changed_at,
-                stored_reason,
+                _normalize_reason(reason),
                 before_json,
                 after_json,
                 resulting_version,

--- a/tests/db_api/test_db_api_governance_audit_events_endpoint.py
+++ b/tests/db_api/test_db_api_governance_audit_events_endpoint.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from fastapi.testclient import TestClient
 
 from portfolio_fdc.db_api.db import MAIN_DB, _connect
+from tests.utils.test_utils import assert_validation_error_envelope
 
 
 def _insert_audit_event(
@@ -236,3 +237,60 @@ def test_get_governance_audit_events_returns_400_for_naive_from_ts(
 
     assert res.status_code == 400
     assert "timezone" in res.json()["detail"]
+
+
+def test_get_governance_audit_events_returns_400_for_naive_to_ts_only(
+    client: TestClient,
+) -> None:
+    res = client.get(
+        "/governance/audit-events",
+        params={
+            "to_ts": "2026-05-02T00:00:00",
+        },
+    )
+
+    assert res.status_code == 400
+    assert "timezone" in res.json()["detail"]
+
+
+def test_get_governance_audit_events_returns_400_when_from_ts_is_after_to_ts(
+    client: TestClient,
+) -> None:
+    res = client.get(
+        "/governance/audit-events",
+        params={
+            "from_ts": "2026-05-03T00:00:00Z",
+            "to_ts": "2026-05-02T00:00:00Z",
+        },
+    )
+
+    assert res.status_code == 400
+    assert "end_ts must be greater than or equal to start_ts" in res.json()["detail"]
+
+
+def test_get_governance_audit_events_returns_422_for_invalid_limit(
+    client: TestClient,
+) -> None:
+    res = client.get(
+        "/governance/audit-events",
+        params={
+            "limit": 0,
+        },
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="limit")
+
+
+def test_get_governance_audit_events_returns_422_for_invalid_offset(
+    client: TestClient,
+) -> None:
+    res = client.get(
+        "/governance/audit-events",
+        params={
+            "offset": -1,
+        },
+    )
+
+    assert res.status_code == 422
+    assert_validation_error_envelope(res.json(), expected_loc_fragment="offset")


### PR DESCRIPTION
## What

Issue #144 (Child 5) の受け入れ条件補強として、`GET /governance/audit-events` の4xx/422境界テストを追加しました。

## Why

実装と主要テストは既に存在していましたが、以下の境界条件を明示しておくことで契約のぶれを防ぐためです。

- naive `to_ts` 単独指定
- `from_ts > to_ts`
- `limit`/`offset` の不正値

## Changes

- `tests/db_api/test_db_api_governance_audit_events_endpoint.py`
  - 400: naive `to_ts` 単独
  - 400: `from_ts` が `to_ts` より後
  - 422: `limit=0`
  - 422: `offset=-1`

## Validation

- `E:/work/python/logger/.venv/Scripts/python.exe -m pytest tests/db_api/test_db_api_governance_audit_events_endpoint.py tests/db_api/test_db_api_governance_notifications_retry_endpoint.py -q`
- result: pass

## Related

- Issue #144
- Parent: #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更の概要

- **ガバナンス監査イベント エンドポイント検証テスト追加**
  - GET /governance/audit-events の境界ケーステスト4件を実装
    - ナイーブなto_ts単独指定 → 400期待値
    - from_ts > to_ts の場合 → 400期待値
    - limit=0 → 422期待値
    - offset=-1 → 422期待値
  - 検証エラーハンドラー`assert_validation_error_envelope`をインポート
  - テスト行数: +58

- **緊急理由正規化の明示化**
  - `GovernanceEmergencyChangesRepository.create()` メソッドの署名変更
    - `reason: str` → `reason: str | None` へ拡張
  - 新規モジュールレベルヘルパー関数 `_normalize_reason()` を追加
    - `None` を空文字列に正規化してDBに永続化
  - メソッドドキュメント更新で `None`→空文字列 の保存動作を記録
  - コード行数: +13/-3

## テスト検証

- pytest実行結果: **合格**
  - 対象: `test_db_api_governance_audit_events_endpoint.py` および `test_db_api_governance_notifications_retry_endpoint.py`

## リスク・課題

- **テストギャップ**
  - `_normalize_reason()` 関数単体テストの記載が確認されない
  - `reason=None` 時の永続化動作を検証するリポジトリレイヤーテストが不明確
  - 既存の`create()`呼び出し箇所で `None` 引数への後方互換性確認が必要

- **潜在的リスク**
  - 署名変更による既存呼び出し元への影響を完全に把握する必要
  - 空文字列正規化がクエリフィルタ等の他のレイヤーロジックに影響しないか確認

- **タイムゾーン検証テスト**
  - from_ts/to_ts のタイムゾーン有無判定ロジックの実装詳細がテストから不明確

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/208)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->