### PR TITLE
feat(judge): phase-1 MVP checkpoint with scheduler entrypoint

### DIFF
--- a/docs/issues/child-judge-mvp.md
+++ b/docs/issues/child-judge-mvp.md
@@ -13,18 +13,22 @@ Background
 
 Scope
 
-- judge MVP の実装
+- judge MVP の最小実装を checkpoint として固定する
   - warning / critical 判定ロジック
   - 同一 run 内の評価対象データ取得（db_api read path 準拠）
   - 判定結果の保存（JudgementResults）
-  - 通知送信（warning/critical）
-  - critical 時の停止 API 呼び出しフック
+  - 通知送信フック（warning/critical、実送信アダプタは Phase 2）
+  - critical 時の停止 API 呼び出しフック（MES POST アダプタは Phase 2）
+  - Windows Task Scheduler から呼べる CLI / task エントリポイント
 - 監査可能性の担保
   - stop_api_called / stop_api_status の記録
   - 判定時刻・入力特徴量・参照 chart のトレース情報保持
 
 Out of Scope
 
+- Windows Task Scheduler への本番ジョブ登録（30 分周期設定・運用 runbook 確定）
+- メール通知の実送信実装（SMTP / API / 再送戦略 / 宛先決定）
+- MES API への実 POST 実装（認証 / timeout / retry / idempotency）
 - suppression 高度化（重複通知最適化の拡張）
 - 複雑な運転モード別ポリシー
 - governance 承認状態を加味した編集反映制御
@@ -32,10 +36,11 @@ Out of Scope
 Acceptance Criteria
 
 - warning/critical のしきい値判定が docs 方針どおり動作する
-- warning/critical いずれも通知処理が実行される
-- critical で停止 API 呼び出しが行われ、結果が記録される
+- warning/critical いずれも通知フックが実行される
+- critical で停止 API フックが呼ばれ、結果が記録される
 - stop API 失敗時でも judge 全体が異常終了せず、結果に失敗状態を残せる
 - db_api read endpoint の契約変更なしで judge が必要データを取得できる
+- Task Scheduler から呼ぶための実行入口が固定される
 
 Tests
 
@@ -44,6 +49,26 @@ Tests
 - 単体テスト: 停止 API 成功/失敗/タイムアウト
 - 統合テスト: 入力 -> 判定 -> JudgementResults 記録 -> db_api /judge/results 参照
 - 回帰確認: 既存 ingest/db_api の write/read フローに非影響
+
+Roadmap
+
+1. Phase 1: 現在の checkpoint
+
+- JudgeEngine.run_once と CLI を固定
+- 通知 / 停止 API は hook 注入で置換可能に留める
+- `tasks.ps1 judge-run-once` を scheduler の呼び出し口にする
+
+2. Phase 2: 運用接続
+
+- Windows Task Scheduler に 30 分周期ジョブを登録する
+- warning / critical 時のメール通知アダプタを実装する
+- critical 時に MES API へ POST するアダプタを実装する
+
+3. Phase 3: 運用強化
+
+- 重複通知抑制、再送、dead-letter 相当の失敗管理
+- 停止 API の認証・idempotency・運転モード別ポリシー
+- dashboard での状態可視化と runbook 整備
 
 Docs
 

--- a/src/portfolio_fdc/judge/__init__.py
+++ b/src/portfolio_fdc/judge/__init__.py
@@ -1,0 +1,5 @@
+"""judge モジュールの公開 API。"""
+
+from .run_once import JudgeEngine, JudgeRunSummary, main, run_once
+
+__all__ = ["JudgeEngine", "JudgeRunSummary", "main", "run_once"]

--- a/src/portfolio_fdc/judge/run_once.py
+++ b/src/portfolio_fdc/judge/run_once.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from portfolio_fdc.db_api.datetime_util import to_utc_millis
+from portfolio_fdc.db_api.db import MAIN_DB, _connect, _init_schema
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class JudgeRunSummary:
+    evaluated: int = 0
+    written: int = 0
+    notifications_attempted: int = 0
+    notifications_failed: int = 0
+    stop_api_attempted: int = 0
+    stop_api_failed: int = 0
+    skipped_without_chart: int = 0
+
+
+@dataclass(frozen=True)
+class _ProcessRow:
+    process_id: str
+    tool_id: str
+    chamber_id: str
+    recipe_id: str
+    start_ts: str
+
+
+@dataclass(frozen=True)
+class _ParameterRow:
+    parameter: str
+    step_no: int
+    feature_type: str
+    feature_value: float
+
+
+@dataclass(frozen=True)
+class _ChartRow:
+    chart_id: str
+    tool_id: str
+    chamber_id: str
+    recipe_id: str
+    parameter: str
+    step_no: int
+    feature_type: str
+    warning_lcl: float | None
+    warning_ucl: float | None
+    critical_lcl: float | None
+    critical_ucl: float | None
+
+
+NotificationSink = Callable[[dict[str, Any]], None]
+StopApiHook = Callable[[dict[str, Any]], None]
+
+
+class JudgeEngine:
+    """ProcessInfo/Parameters を読み、JudgementResults へ書き込む最小 judge エンジン。"""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path = MAIN_DB,
+        notification_sink: NotificationSink | None = None,
+        stop_api_hook: StopApiHook | None = None,
+    ) -> None:
+        self._db_path = db_path
+        self._notification_sink = notification_sink or (lambda _payload: None)
+        self._stop_api_hook = stop_api_hook or (lambda _payload: None)
+
+    def run_once(self, *, process_id: str | None = None) -> JudgeRunSummary:
+        """1 回分の判定を実行し、書き込み件数などの集計を返す。"""
+        _init_schema(self._db_path)
+        con = _connect(self._db_path)
+        try:
+            process_rows = self._load_process_rows(con, process_id=process_id)
+            if not process_rows:
+                return JudgeRunSummary()
+
+            chart_lookup = self._load_active_chart_lookup(con)
+            summary = JudgeRunSummary()
+
+            for process_row in process_rows:
+                parameter_rows = self._load_parameter_rows(con, process_row.process_id)
+                for parameter_row in parameter_rows:
+                    chart_row = chart_lookup.get(
+                        self._chart_key(
+                            process_row.tool_id,
+                            process_row.chamber_id,
+                            process_row.recipe_id,
+                            parameter_row.parameter,
+                            parameter_row.step_no,
+                            parameter_row.feature_type,
+                        )
+                    )
+                    if chart_row is None:
+                        summary = self._replace_summary(
+                            summary,
+                            skipped_without_chart=summary.skipped_without_chart + 1,
+                        )
+                        continue
+
+                    judged_at = to_utc_millis(datetime.now(UTC).isoformat())
+                    level = self._evaluate_level(parameter_row.feature_value, chart_row)
+                    notification_called = False
+                    notification_status = "NOT_CALLED"
+                    stop_api_called = False
+                    stop_api_status = "NOT_CALLED"
+
+                    if level in {"WARN", "NG"}:
+                        notification_called = True
+                        summary = self._replace_summary(
+                            summary,
+                            notifications_attempted=summary.notifications_attempted + 1,
+                        )
+                        try:
+                            self._notification_sink(
+                                self._build_message_json(
+                                    process_row=process_row,
+                                    parameter_row=parameter_row,
+                                    chart_row=chart_row,
+                                    level=level,
+                                    judged_at=judged_at,
+                                    notification_called=True,
+                                    notification_status=notification_status,
+                                    stop_api_called=False,
+                                    stop_api_status="NOT_CALLED",
+                                )
+                            )
+                            notification_status = "CALLED"
+                        except Exception:
+                            notification_status = "FAILED"
+                            summary = self._replace_summary(
+                                summary,
+                                notifications_failed=summary.notifications_failed + 1,
+                            )
+                            logger.exception(
+                                "Notification sink failed for process_id=%s chart_id=%s",
+                                process_row.process_id,
+                                chart_row.chart_id,
+                            )
+
+                    if level == "NG":
+                        stop_api_called = True
+                        summary = self._replace_summary(
+                            summary,
+                            stop_api_attempted=summary.stop_api_attempted + 1,
+                        )
+                        try:
+                            self._stop_api_hook(
+                                {
+                                    "process_id": process_row.process_id,
+                                    "chart_id": chart_row.chart_id,
+                                    "level": level,
+                                    "judged_at": judged_at,
+                                    "feature_value": parameter_row.feature_value,
+                                }
+                            )
+                            stop_api_status = "CALLED"
+                        except Exception:
+                            stop_api_status = "FAILED"
+                            summary = self._replace_summary(
+                                summary,
+                                stop_api_failed=summary.stop_api_failed + 1,
+                            )
+                            logger.exception(
+                                "Stop API hook failed for process_id=%s chart_id=%s",
+                                process_row.process_id,
+                                chart_row.chart_id,
+                            )
+
+                    payload = self._build_message_json(
+                        process_row=process_row,
+                        parameter_row=parameter_row,
+                        chart_row=chart_row,
+                        level=level,
+                        judged_at=judged_at,
+                        notification_called=notification_called,
+                        notification_status=notification_status,
+                        stop_api_called=stop_api_called,
+                        stop_api_status=stop_api_status,
+                    )
+                    self._insert_result(
+                        con,
+                        process_row=process_row,
+                        level=level,
+                        judged_at=judged_at,
+                        payload=payload,
+                    )
+                    summary = self._replace_summary(
+                        summary,
+                        evaluated=summary.evaluated + 1,
+                        written=summary.written + 1,
+                    )
+
+            con.commit()
+            return summary
+        finally:
+            con.close()
+
+    @staticmethod
+    def _replace_summary(summary: JudgeRunSummary, **changes: int) -> JudgeRunSummary:
+        return JudgeRunSummary(
+            evaluated=changes.get("evaluated", summary.evaluated),
+            written=changes.get("written", summary.written),
+            notifications_attempted=changes.get(
+                "notifications_attempted",
+                summary.notifications_attempted,
+            ),
+            notifications_failed=changes.get("notifications_failed", summary.notifications_failed),
+            stop_api_attempted=changes.get("stop_api_attempted", summary.stop_api_attempted),
+            stop_api_failed=changes.get("stop_api_failed", summary.stop_api_failed),
+            skipped_without_chart=changes.get(
+                "skipped_without_chart",
+                summary.skipped_without_chart,
+            ),
+        )
+
+    def _load_process_rows(
+        self,
+        con: sqlite3.Connection,
+        *,
+        process_id: str | None,
+    ) -> list[_ProcessRow]:
+        if process_id is not None:
+            rows = con.execute(
+                """
+                SELECT process_id, tool_id, chamber_id, recipe_id, start_ts
+                FROM ProcessInfo
+                WHERE process_id = ?
+                """,
+                (process_id,),
+            ).fetchall()
+        else:
+            rows = con.execute(
+                """
+                SELECT pi.process_id, pi.tool_id, pi.chamber_id, pi.recipe_id, pi.start_ts
+                FROM ProcessInfo pi
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM Parameters p
+                    WHERE p.process_id = pi.process_id
+                )
+                ORDER BY julianday(pi.start_ts) DESC, pi.process_id DESC
+                """,
+            ).fetchall()
+
+        return [
+            _ProcessRow(
+                process_id=str(row[0]),
+                tool_id=str(row[1]),
+                chamber_id=str(row[2]),
+                recipe_id=str(row[3]),
+                start_ts=str(row[4]),
+            )
+            for row in rows
+        ]
+
+    def _load_parameter_rows(self, con: sqlite3.Connection, process_id: str) -> list[_ParameterRow]:
+        rows = con.execute(
+            """
+            SELECT parameter, step_no, feature_type, feature_value
+            FROM Parameters
+            WHERE process_id = ?
+            ORDER BY parameter, step_no, feature_type, id
+            """,
+            (process_id,),
+        ).fetchall()
+        return [
+            _ParameterRow(
+                parameter=str(row[0]),
+                step_no=int(row[1]),
+                feature_type=str(row[2]),
+                feature_value=float(row[3]),
+            )
+            for row in rows
+        ]
+
+    def _load_active_chart_lookup(
+        self,
+        con: sqlite3.Connection,
+    ) -> dict[tuple[str, str, str, str, int, str], _ChartRow]:
+        rows = con.execute(
+            """
+            SELECT
+                c.id,
+                c.tool_id,
+                c.chamber_id,
+                c.recipe_id,
+                c.parameter,
+                c.step_no,
+                c.feature_type,
+                c.warn_low,
+                c.warn_high,
+                c.crit_low,
+                c.crit_high
+            FROM ChartsV2 c
+            INNER JOIN ActiveChartSet active
+                ON active.id = 1
+               AND active.chart_set_id = c.chart_set_id
+            """,
+        ).fetchall()
+
+        lookup: dict[tuple[str, str, str, str, int, str], _ChartRow] = {}
+        for row in rows:
+            chart_row = _ChartRow(
+                chart_id=f"CHART_{int(row[0])}",
+                tool_id=str(row[1]),
+                chamber_id=str(row[2]),
+                recipe_id=str(row[3]),
+                parameter=str(row[4]),
+                step_no=int(row[5]),
+                feature_type=str(row[6]),
+                warning_lcl=None if row[7] is None else float(row[7]),
+                warning_ucl=None if row[8] is None else float(row[8]),
+                critical_lcl=None if row[9] is None else float(row[9]),
+                critical_ucl=None if row[10] is None else float(row[10]),
+            )
+            lookup[
+                self._chart_key(
+                    chart_row.tool_id,
+                    chart_row.chamber_id,
+                    chart_row.recipe_id,
+                    chart_row.parameter,
+                    chart_row.step_no,
+                    chart_row.feature_type,
+                )
+            ] = chart_row
+        return lookup
+
+    @staticmethod
+    def _chart_key(
+        tool_id: str,
+        chamber_id: str,
+        recipe_id: str,
+        parameter: str,
+        step_no: int,
+        feature_type: str,
+    ) -> tuple[str, str, str, str, int, str]:
+        return (tool_id, chamber_id, recipe_id, parameter, step_no, feature_type)
+
+    @staticmethod
+    def _evaluate_level(feature_value: float, chart_row: _ChartRow) -> str:
+        if chart_row.critical_lcl is not None and feature_value < chart_row.critical_lcl:
+            return "NG"
+        if chart_row.critical_ucl is not None and feature_value > chart_row.critical_ucl:
+            return "NG"
+        if chart_row.warning_lcl is not None and feature_value < chart_row.warning_lcl:
+            return "WARN"
+        if chart_row.warning_ucl is not None and feature_value > chart_row.warning_ucl:
+            return "WARN"
+        return "OK"
+
+    def _build_message_json(
+        self,
+        *,
+        process_row: _ProcessRow,
+        parameter_row: _ParameterRow,
+        chart_row: _ChartRow,
+        level: str,
+        judged_at: str,
+        notification_called: bool,
+        notification_status: str,
+        stop_api_called: bool,
+        stop_api_status: str,
+    ) -> dict[str, Any]:
+        return {
+            "chart_id": chart_row.chart_id,
+            "process_id": process_row.process_id,
+            "tool_id": process_row.tool_id,
+            "chamber_id": process_row.chamber_id,
+            "recipe_id": process_row.recipe_id,
+            "start_ts": to_utc_millis(process_row.start_ts),
+            "parameter": parameter_row.parameter,
+            "step_no": parameter_row.step_no,
+            "feature_type": parameter_row.feature_type,
+            "feature_value": parameter_row.feature_value,
+            "warning_lcl": chart_row.warning_lcl,
+            "warning_ucl": chart_row.warning_ucl,
+            "critical_lcl": chart_row.critical_lcl,
+            "critical_ucl": chart_row.critical_ucl,
+            "level": level,
+            "judged_at": judged_at,
+            "notification_called": notification_called,
+            "notification_status": notification_status,
+            "stop_api_called": stop_api_called,
+            "stop_api_status": stop_api_status,
+        }
+
+    def _insert_result(
+        self,
+        con: sqlite3.Connection,
+        *,
+        process_row: _ProcessRow,
+        level: str,
+        judged_at: str,
+        payload: dict[str, Any],
+    ) -> None:
+        payload_str = json.dumps(payload, ensure_ascii=False)
+        con.execute(
+            """
+            INSERT INTO JudgementResults(
+                process_id, tool_id, chamber_id, recipe_id, status, judged_at, message_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                process_row.process_id,
+                process_row.tool_id,
+                process_row.chamber_id,
+                process_row.recipe_id,
+                level,
+                judged_at,
+                payload_str,
+            ),
+        )
+
+
+def run_once(
+    *,
+    db_path: Path = MAIN_DB,
+    process_id: str | None = None,
+    notification_sink: NotificationSink | None = None,
+    stop_api_hook: StopApiHook | None = None,
+) -> JudgeRunSummary:
+    """judge MVP の 1 回実行を行う。"""
+    engine = JudgeEngine(
+        db_path=db_path,
+        notification_sink=notification_sink,
+        stop_api_hook=stop_api_hook,
+    )
+    return engine.run_once(process_id=process_id)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run judge MVP once")
+    parser.add_argument("--db-path", type=Path, default=MAIN_DB, help="SQLite DB path")
+    parser.add_argument(
+        "--process-id",
+        default=None,
+        help="Target process_id. If omitted, all processes with Parameters are judged.",
+    )
+    parser.add_argument(
+        "--db-api",
+        default=None,
+        help="Reserved for future remote integration. The MVP uses the local DB path.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.db_api:
+        logger.info("--db-api is reserved in MVP and will be ignored: %s", args.db_api)
+
+    summary = run_once(db_path=args.db_path, process_id=args.process_id)
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "data": {
+                    "evaluated": summary.evaluated,
+                    "written": summary.written,
+                    "notifications_attempted": summary.notifications_attempted,
+                    "notifications_failed": summary.notifications_failed,
+                    "stop_api_attempted": summary.stop_api_attempted,
+                    "stop_api_failed": summary.stop_api_failed,
+                    "skipped_without_chart": summary.skipped_without_chart,
+                },
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/portfolio_fdc/judge/run_once.py
+++ b/src/portfolio_fdc/judge/run_once.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class JudgeRunSummary:
+    """run_once の集計結果。
+
+    Note:
+        written は「論理レコード件数」ではなく DB 書き込み操作回数。
+        NG の場合は PENDING INSERT と最終 UPDATE の 2 操作になる。
+    """
+
     evaluated: int = 0
     written: int = 0
     notifications_attempted: int = 0
@@ -78,7 +85,7 @@ class JudgeEngine:
         self._stop_api_hook = stop_api_hook or (lambda _payload: None)
 
     def run_once(self, *, process_id: str | None = None) -> JudgeRunSummary:
-        """1 回分の判定を実行し、書き込み件数などの集計を返す。"""
+        """1 回分の判定を実行し、集計を返す。"""
         _init_schema(self._db_path)
         con = _connect(self._db_path)
         try:
@@ -150,6 +157,7 @@ class JudgeEngine:
                             )
 
                     if level == "NG":
+                        # NG は PENDING INSERT -> stop API -> 最終 UPDATE の 2 操作。
                         pending_payload = self._build_message_json(
                             process_row=process_row,
                             parameter_row=parameter_row,
@@ -253,6 +261,7 @@ class JudgeEngine:
 
     @staticmethod
     def _replace_summary(summary: JudgeRunSummary, **changes: int) -> JudgeRunSummary:
+        # written は DB 操作回数を表す。
         return JudgeRunSummary(
             evaluated=changes.get("evaluated", summary.evaluated),
             written=changes.get("written", summary.written),
@@ -279,8 +288,13 @@ class JudgeEngine:
             rows = con.execute(
                 """
                 SELECT process_id, tool_id, chamber_id, recipe_id, start_ts
-                FROM ProcessInfo
-                WHERE process_id = ?
+                FROM ProcessInfo pi
+                WHERE pi.process_id = ?
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM JudgementResults jr
+                    WHERE jr.process_id = pi.process_id
+                )
                 """,
                 (process_id,),
             ).fetchall()

--- a/src/portfolio_fdc/judge/run_once.py
+++ b/src/portfolio_fdc/judge/run_once.py
@@ -150,9 +150,28 @@ class JudgeEngine:
                             )
 
                     if level == "NG":
-                        stop_api_called = True
+                        pending_payload = self._build_message_json(
+                            process_row=process_row,
+                            parameter_row=parameter_row,
+                            chart_row=chart_row,
+                            level=level,
+                            judged_at=judged_at,
+                            notification_called=notification_called,
+                            notification_status=notification_status,
+                            stop_api_called=False,
+                            stop_api_status="PENDING",
+                        )
+                        result_id = self._insert_result(
+                            con,
+                            process_row=process_row,
+                            level=level,
+                            judged_at=judged_at,
+                            payload=pending_payload,
+                        )
                         summary = self._replace_summary(
                             summary,
+                            evaluated=summary.evaluated + 1,
+                            written=summary.written + 1,
                             stop_api_attempted=summary.stop_api_attempted + 1,
                         )
                         try:
@@ -165,8 +184,10 @@ class JudgeEngine:
                                     "feature_value": parameter_row.feature_value,
                                 }
                             )
+                            stop_api_called = True
                             stop_api_status = "CALLED"
                         except Exception:
+                            stop_api_called = True
                             stop_api_status = "FAILED"
                             summary = self._replace_summary(
                                 summary,
@@ -177,6 +198,29 @@ class JudgeEngine:
                                 process_row.process_id,
                                 chart_row.chart_id,
                             )
+                        final_payload = self._build_message_json(
+                            process_row=process_row,
+                            parameter_row=parameter_row,
+                            chart_row=chart_row,
+                            level=level,
+                            judged_at=judged_at,
+                            notification_called=notification_called,
+                            notification_status=notification_status,
+                            stop_api_called=stop_api_called,
+                            stop_api_status=stop_api_status,
+                        )
+                        self._update_result(
+                            con,
+                            result_id=result_id,
+                            level=level,
+                            judged_at=judged_at,
+                            payload=final_payload,
+                        )
+                        summary = self._replace_summary(
+                            summary,
+                            written=summary.written + 1,
+                        )
+                        continue
 
                     payload = self._build_message_json(
                         process_row=process_row,
@@ -249,6 +293,11 @@ class JudgeEngine:
                     SELECT 1
                     FROM Parameters p
                     WHERE p.process_id = pi.process_id
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM JudgementResults jr
+                    WHERE jr.process_id = pi.process_id
                 )
                 ORDER BY julianday(pi.start_ts) DESC, pi.process_id DESC
                 """,
@@ -404,9 +453,9 @@ class JudgeEngine:
         level: str,
         judged_at: str,
         payload: dict[str, Any],
-    ) -> None:
+    ) -> int:
         payload_str = json.dumps(payload, ensure_ascii=False)
-        con.execute(
+        cur = con.execute(
             """
             INSERT INTO JudgementResults(
                 process_id, tool_id, chamber_id, recipe_id, status, judged_at, message_json
@@ -421,6 +470,29 @@ class JudgeEngine:
                 judged_at,
                 payload_str,
             ),
+        )
+        result_id = cur.lastrowid
+        if result_id is None:
+            raise RuntimeError("failed to get inserted judgement result id")
+        return int(result_id)
+
+    def _update_result(
+        self,
+        con: sqlite3.Connection,
+        *,
+        result_id: int,
+        level: str,
+        judged_at: str,
+        payload: dict[str, Any],
+    ) -> None:
+        payload_str = json.dumps(payload, ensure_ascii=False)
+        con.execute(
+            """
+            UPDATE JudgementResults
+            SET status = ?, judged_at = ?, message_json = ?
+            WHERE id = ?
+            """,
+            (level, judged_at, payload_str, result_id),
         )
 
 

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Position=0)]
-  [ValidateSet("help","venv","install","precommit","fmt","lint","type","test","test-fast","test-slow","test-db-api-aggregate","check","aggregate-dry-run","clean","cleanup-retention","vacuum-db")]
+  [ValidateSet("help","venv","install","precommit","fmt","lint","type","test","test-fast","test-slow","test-db-api-aggregate","check","aggregate-dry-run","clean","cleanup-retention","vacuum-db","judge-run-once")]
   [string]$Task = "help"
   ,
   [string]$AggInput = "data/scrape/scrape_TOOL_A.csv"
@@ -8,6 +8,12 @@ param(
   [string]$AggConfig = "src/portfolio_fdc/configs/aggregate_tools.yaml"
   ,
   [string]$AggDetailOut = "data/detail"
+  ,
+  [string]$JudgeDbPath = ""
+  ,
+  [string]$JudgeProcessId = ""
+  ,
+  [string]$JudgeDbApi = ""
 )
 
 $RepoRoot = $PSScriptRoot
@@ -18,6 +24,7 @@ $PreCommit = Join-Path $VenvDir "Scripts\pre-commit.exe"
 # Mirror db.py: use PORTFOLIO_DB_DIR env var when set, otherwise fall back to <repo>/data/db
 $DbDir = if ($env:PORTFOLIO_DB_DIR) { $env:PORTFOLIO_DB_DIR } else { Join-Path $RepoRoot "data\db" }
 $DbPath = Join-Path $DbDir "main.db"
+$ResolvedJudgeDbPath = if ($JudgeDbPath) { $JudgeDbPath } else { $DbPath }
 
 function Ensure-Venv {
   param(
@@ -62,6 +69,7 @@ switch ($Task) {
     Write-Host "  .\tasks.ps1 clean      - remove caches/build artifacts"
     Write-Host "  .\tasks.ps1 cleanup-retention - delete retention-expired data (daily task)"
     Write-Host "  .\tasks.ps1 vacuum-db - VACUUM SQLite database (weekly task)"
+    Write-Host "  .\tasks.ps1 judge-run-once - execute one judge cycle (scheduler entry point)"
   }
 
   "venv" {
@@ -123,6 +131,30 @@ switch ($Task) {
   "aggregate-dry-run" {
     Ensure-DevInstall
     & $Py -m portfolio_fdc.main.aggregate --input $AggInput --config $AggConfig --detail-out $AggDetailOut --dry-run | Out-Host
+  }
+
+  "judge-run-once" {
+    # Scheduler entry point for the judge MVP. The actual Task Scheduler registration
+    # and real email / MES integrations are handled as follow-up phases.
+    Ensure-Venv -SkipPipUpgrade
+
+    $JudgeArgs = @(
+      "-m",
+      "portfolio_fdc.judge.run_once",
+      "--db-path",
+      $ResolvedJudgeDbPath
+    )
+
+    if ($JudgeProcessId) {
+      $JudgeArgs += @("--process-id", $JudgeProcessId)
+    }
+
+    if ($JudgeDbApi) {
+      $JudgeArgs += @("--db-api", $JudgeDbApi)
+    }
+
+    & $Py @JudgeArgs | Out-Host
+    exit $LASTEXITCODE
   }
 
   "clean" {

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
   [Parameter(Position=0)]
   [ValidateSet("help","venv","install","precommit","fmt","lint","type","test","test-fast","test-slow","test-db-api-aggregate","check","aggregate-dry-run","clean","cleanup-retention","vacuum-db","judge-run-once")]
   [string]$Task = "help"

--- a/tests/judge/test_judge_run_once.py
+++ b/tests/judge/test_judge_run_once.py
@@ -531,3 +531,53 @@ def test_judge_run_once_skips_already_judged_processes(tmp_path: Path) -> None:
 
     results = _read_judge_results(db_path)
     assert len(results) == 1
+
+
+def test_judge_run_once_skips_already_judged_process_with_explicit_id(tmp_path: Path) -> None:
+    db_path = tmp_path / "main.db"
+    _init_schema(db_path)
+    chart_set_id = _seed_chart_set_and_active_chart(db_path)
+
+    tool_id = "TOOL_SKIP_BY_ID"
+    chamber_id = "CH1"
+    recipe_id = "RECIPE_SKIP_BY_ID"
+    process_id = "P_SKIP_BY_ID_1"
+
+    _insert_chart(
+        db_path,
+        chart_set_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        warn_low=1.4,
+        warn_high=2.6,
+        crit_low=1.2,
+        crit_high=2.8,
+    )
+    _insert_process(
+        db_path,
+        process_id=process_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+    )
+    _insert_parameter(
+        db_path,
+        process_id=process_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        feature_value=2.9,
+    )
+
+    first = run_once(db_path=db_path, process_id=process_id)
+    second = run_once(db_path=db_path, process_id=process_id)
+
+    assert first.evaluated == 1
+    assert second.evaluated == 0
+
+    results = _read_judge_results(db_path)
+    assert len(results) == 1

--- a/tests/judge/test_judge_run_once.py
+++ b/tests/judge/test_judge_run_once.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from portfolio_fdc.db_api.db import _init_schema
+from portfolio_fdc.judge.run_once import JudgeEngine, run_once
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    con = sqlite3.connect(db_path.as_posix())
+    con.execute("PRAGMA foreign_keys=ON;")
+    return con
+
+
+def _seed_chart_set_and_active_chart(db_path: Path) -> int:
+    con = _connect(db_path)
+    try:
+        now = datetime.now(UTC).isoformat()
+        con.execute(
+            "INSERT INTO ChartSet(name, note, created_at, created_by) VALUES (?, ?, ?, ?)",
+            ("judge-mvp", "test", now, "tester"),
+        )
+        chart_set_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+        con.execute(
+            (
+                "UPDATE ActiveChartSet SET chart_set_id = ?, updated_at = ?, "
+                "updated_by = ? WHERE id = 1"
+            ),
+            (chart_set_id, now, "tester"),
+        )
+        con.commit()
+        return chart_set_id
+    finally:
+        con.close()
+
+
+def _insert_chart(
+    db_path: Path,
+    chart_set_id: int,
+    *,
+    tool_id: str,
+    chamber_id: str,
+    recipe_id: str,
+    parameter: str,
+    step_no: int,
+    feature_type: str,
+    warn_low: float,
+    warn_high: float,
+    crit_low: float,
+    crit_high: float,
+) -> str:
+    con = _connect(db_path)
+    try:
+        con.execute(
+            """
+            INSERT INTO ChartsV2(
+                chart_set_id, tool_id, chamber_id, recipe_id, parameter,
+                step_no, feature_type, warn_low, warn_high, crit_low, crit_high,
+                updated_at, updated_by, update_reason, update_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chart_set_id,
+                tool_id,
+                chamber_id,
+                recipe_id,
+                parameter,
+                step_no,
+                feature_type,
+                warn_low,
+                warn_high,
+                crit_low,
+                crit_high,
+                "2026-05-13T00:00:00.000Z",
+                "tester",
+                "seed",
+                "test",
+            ),
+        )
+        chart_id = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+        con.commit()
+        return f"CHART_{chart_id}"
+    finally:
+        con.close()
+
+
+def _insert_process(
+    db_path: Path,
+    *,
+    process_id: str,
+    tool_id: str,
+    chamber_id: str,
+    recipe_id: str,
+) -> None:
+    con = _connect(db_path)
+    try:
+        con.execute(
+            """
+            INSERT INTO ProcessInfo(
+                process_id, tool_id, chamber_id, recipe_id, start_ts, end_ts, raw_csv_path
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                process_id,
+                tool_id,
+                chamber_id,
+                recipe_id,
+                "2026-05-13T08:00:00+09:00",
+                "2026-05-13T08:05:00+09:00",
+                "data/raw/test.csv",
+            ),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _insert_parameter(
+    db_path: Path,
+    *,
+    process_id: str,
+    parameter: str,
+    step_no: int,
+    feature_type: str,
+    feature_value: float,
+) -> None:
+    con = _connect(db_path)
+    try:
+        con.execute(
+            """
+            INSERT INTO Parameters(process_id, parameter, step_no, feature_type, feature_value)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (process_id, parameter, step_no, feature_type, feature_value),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _read_judge_results(db_path: Path) -> list[tuple[str, dict[str, object]]]:
+    con = _connect(db_path)
+    try:
+        rows = con.execute(
+            """
+            SELECT status, message_json
+            FROM JudgementResults
+            ORDER BY id
+            """,
+        ).fetchall()
+        return [(str(row[0]), json.loads(str(row[1]))) for row in rows]
+    finally:
+        con.close()
+
+
+def test_judge_run_once_records_warn_and_ng_results(tmp_path: Path) -> None:
+    db_path = tmp_path / "main.db"
+    _init_schema(db_path)
+    chart_set_id = _seed_chart_set_and_active_chart(db_path)
+
+    tool_id = "TOOL_JUDGE"
+    chamber_id = "CH1"
+    recipe_id = "RECIPE_JUDGE"
+    process_id = "P_JUDGE_1"
+
+    _insert_chart(
+        db_path,
+        chart_set_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        warn_low=1.4,
+        warn_high=2.6,
+        crit_low=1.2,
+        crit_high=2.8,
+    )
+    _insert_chart(
+        db_path,
+        chart_set_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter="cl2_flow",
+        step_no=2,
+        feature_type="mean",
+        warn_low=10.0,
+        warn_high=20.0,
+        crit_low=8.0,
+        crit_high=22.0,
+    )
+
+    _insert_process(
+        db_path,
+        process_id=process_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+    )
+    _insert_parameter(
+        db_path,
+        process_id=process_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        feature_value=2.7,
+    )
+    _insert_parameter(
+        db_path,
+        process_id=process_id,
+        parameter="cl2_flow",
+        step_no=2,
+        feature_type="mean",
+        feature_value=23.5,
+    )
+
+    notifications: list[dict[str, object]] = []
+    stop_calls: list[dict[str, object]] = []
+
+    summary = JudgeEngine(
+        db_path=db_path,
+        notification_sink=notifications.append,
+        stop_api_hook=stop_calls.append,
+    ).run_once()
+
+    assert summary.evaluated == 2
+    assert summary.written == 2
+    assert summary.notifications_attempted == 2
+    assert summary.stop_api_attempted == 1
+    assert summary.notifications_failed == 0
+    assert summary.stop_api_failed == 0
+    assert summary.skipped_without_chart == 0
+    assert len(notifications) == 2
+    assert len(stop_calls) == 1
+
+    results = _read_judge_results(db_path)
+    payload_by_chart_id = {payload["chart_id"]: (status, payload) for status, payload in results}
+
+    assert payload_by_chart_id["CHART_1"][0] == "WARN"
+    assert payload_by_chart_id["CHART_1"][1]["notification_status"] == "CALLED"
+    assert payload_by_chart_id["CHART_1"][1]["stop_api_status"] == "NOT_CALLED"
+
+    assert payload_by_chart_id["CHART_2"][0] == "NG"
+    assert payload_by_chart_id["CHART_2"][1]["notification_status"] == "CALLED"
+    assert payload_by_chart_id["CHART_2"][1]["stop_api_called"] is True
+    assert payload_by_chart_id["CHART_2"][1]["stop_api_status"] == "CALLED"
+
+
+def test_judge_run_once_marks_failed_stop_api_without_crashing(tmp_path: Path) -> None:
+    db_path = tmp_path / "main.db"
+    _init_schema(db_path)
+    chart_set_id = _seed_chart_set_and_active_chart(db_path)
+
+    tool_id = "TOOL_JUDGE_FAIL"
+    chamber_id = "CH1"
+    recipe_id = "RECIPE_JUDGE_FAIL"
+    process_id = "P_JUDGE_FAIL"
+
+    _insert_chart(
+        db_path,
+        chart_set_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        warn_low=1.4,
+        warn_high=2.6,
+        crit_low=1.2,
+        crit_high=2.8,
+    )
+    _insert_process(
+        db_path,
+        process_id=process_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+    )
+    _insert_parameter(
+        db_path,
+        process_id=process_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        feature_value=3.2,
+    )
+
+    def _raise_stop_api(_payload: dict[str, object]) -> None:
+        raise RuntimeError("stop api failed")
+
+    summary = run_once(db_path=db_path, stop_api_hook=_raise_stop_api)
+
+    assert summary.evaluated == 1
+    assert summary.written == 1
+    assert summary.notifications_attempted == 1
+    assert summary.stop_api_attempted == 1
+    assert summary.stop_api_failed == 1
+
+    results = _read_judge_results(db_path)
+    assert results[0][0] == "NG"
+    assert results[0][1]["stop_api_status"] == "FAILED"
+    assert results[0][1]["stop_api_called"] is True

--- a/tests/judge/test_judge_run_once.py
+++ b/tests/judge/test_judge_run_once.py
@@ -5,6 +5,8 @@ import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from portfolio_fdc.db_api.db import _init_schema
 from portfolio_fdc.judge.run_once import JudgeEngine, run_once
 
@@ -229,7 +231,7 @@ def test_judge_run_once_records_warn_and_ng_results(tmp_path: Path) -> None:
     ).run_once()
 
     assert summary.evaluated == 2
-    assert summary.written == 2
+    assert summary.written == 3
     assert summary.notifications_attempted == 2
     assert summary.stop_api_attempted == 1
     assert summary.notifications_failed == 0
@@ -297,7 +299,7 @@ def test_judge_run_once_marks_failed_stop_api_without_crashing(tmp_path: Path) -
     summary = run_once(db_path=db_path, stop_api_hook=_raise_stop_api)
 
     assert summary.evaluated == 1
-    assert summary.written == 1
+    assert summary.written == 2
     assert summary.notifications_attempted == 1
     assert summary.stop_api_attempted == 1
     assert summary.stop_api_failed == 1
@@ -306,3 +308,226 @@ def test_judge_run_once_marks_failed_stop_api_without_crashing(tmp_path: Path) -
     assert results[0][0] == "NG"
     assert results[0][1]["stop_api_status"] == "FAILED"
     assert results[0][1]["stop_api_called"] is True
+
+
+@pytest.mark.parametrize(
+    (
+        "feature_value",
+        "expected_status",
+        "expected_notification_attempted",
+        "expected_stop_attempted",
+        "expected_written",
+    ),
+    [
+        (1.4, "OK", 0, 0, 1),
+        (2.6, "OK", 0, 0, 1),
+        (1.2, "WARN", 1, 0, 1),
+        (2.8, "WARN", 1, 0, 1),
+        (1.39, "WARN", 1, 0, 1),
+        (2.81, "NG", 1, 1, 2),
+    ],
+)
+def test_judge_evaluate_boundaries(
+    tmp_path: Path,
+    feature_value: float,
+    expected_status: str,
+    expected_notification_attempted: int,
+    expected_stop_attempted: int,
+    expected_written: int,
+) -> None:
+    db_path = tmp_path / "main.db"
+    _init_schema(db_path)
+    chart_set_id = _seed_chart_set_and_active_chart(db_path)
+
+    tool_id = "TOOL_BOUNDARY"
+    chamber_id = "CH1"
+    recipe_id = "RECIPE_BOUNDARY"
+    process_id = f"P_BOUNDARY_{str(feature_value).replace('.', '_')}"
+
+    _insert_chart(
+        db_path,
+        chart_set_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        warn_low=1.4,
+        warn_high=2.6,
+        crit_low=1.2,
+        crit_high=2.8,
+    )
+    _insert_process(
+        db_path,
+        process_id=process_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+    )
+    _insert_parameter(
+        db_path,
+        process_id=process_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        feature_value=feature_value,
+    )
+
+    summary = JudgeEngine(db_path=db_path).run_once(process_id=process_id)
+
+    assert summary.evaluated == 1
+    assert summary.written == expected_written
+    assert summary.notifications_attempted == expected_notification_attempted
+    assert summary.stop_api_attempted == expected_stop_attempted
+
+    results = _read_judge_results(db_path)
+    assert len(results) == 1
+    assert results[0][0] == expected_status
+
+
+def test_judge_handles_timeout(tmp_path: Path) -> None:
+    db_path = tmp_path / "main.db"
+    _init_schema(db_path)
+    chart_set_id = _seed_chart_set_and_active_chart(db_path)
+
+    tool_id = "TOOL_TIMEOUT"
+    chamber_id = "CH1"
+    recipe_id = "RECIPE_TIMEOUT"
+
+    _insert_chart(
+        db_path,
+        chart_set_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter="warn_param",
+        step_no=1,
+        feature_type="mean",
+        warn_low=1.4,
+        warn_high=2.6,
+        crit_low=1.2,
+        crit_high=2.8,
+    )
+    _insert_chart(
+        db_path,
+        chart_set_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter="ng_param",
+        step_no=1,
+        feature_type="mean",
+        warn_low=10.0,
+        warn_high=20.0,
+        crit_low=8.0,
+        crit_high=22.0,
+    )
+
+    _insert_process(
+        db_path,
+        process_id="P_TIMEOUT_WARN",
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+    )
+    _insert_parameter(
+        db_path,
+        process_id="P_TIMEOUT_WARN",
+        parameter="warn_param",
+        step_no=1,
+        feature_type="mean",
+        feature_value=2.7,
+    )
+
+    _insert_process(
+        db_path,
+        process_id="P_TIMEOUT_NG",
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+    )
+    _insert_parameter(
+        db_path,
+        process_id="P_TIMEOUT_NG",
+        parameter="ng_param",
+        step_no=1,
+        feature_type="mean",
+        feature_value=23.0,
+    )
+
+    def _raise_timeout(_payload: dict[str, object]) -> None:
+        raise TimeoutError("timeout")
+
+    summary = run_once(
+        db_path=db_path,
+        notification_sink=_raise_timeout,
+        stop_api_hook=_raise_timeout,
+    )
+
+    assert summary.evaluated == 2
+    assert summary.written == 3
+    assert summary.notifications_attempted == 2
+    assert summary.notifications_failed == 2
+    assert summary.stop_api_attempted == 1
+    assert summary.stop_api_failed == 1
+
+    results = _read_judge_results(db_path)
+    by_process_id = {payload["process_id"]: (status, payload) for status, payload in results}
+
+    assert by_process_id["P_TIMEOUT_WARN"][0] == "WARN"
+    assert by_process_id["P_TIMEOUT_WARN"][1]["notification_status"] == "FAILED"
+
+    assert by_process_id["P_TIMEOUT_NG"][0] == "NG"
+    assert by_process_id["P_TIMEOUT_NG"][1]["notification_status"] == "FAILED"
+    assert by_process_id["P_TIMEOUT_NG"][1]["stop_api_status"] == "FAILED"
+
+
+def test_judge_run_once_skips_already_judged_processes(tmp_path: Path) -> None:
+    db_path = tmp_path / "main.db"
+    _init_schema(db_path)
+    chart_set_id = _seed_chart_set_and_active_chart(db_path)
+
+    tool_id = "TOOL_SKIP"
+    chamber_id = "CH1"
+    recipe_id = "RECIPE_SKIP"
+    process_id = "P_SKIP_1"
+
+    _insert_chart(
+        db_path,
+        chart_set_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        warn_low=1.4,
+        warn_high=2.6,
+        crit_low=1.2,
+        crit_high=2.8,
+    )
+    _insert_process(
+        db_path,
+        process_id=process_id,
+        tool_id=tool_id,
+        chamber_id=chamber_id,
+        recipe_id=recipe_id,
+    )
+    _insert_parameter(
+        db_path,
+        process_id=process_id,
+        parameter="dc_bias",
+        step_no=1,
+        feature_type="mean",
+        feature_value=2.9,
+    )
+
+    first = run_once(db_path=db_path)
+    second = run_once(db_path=db_path)
+
+    assert first.evaluated == 1
+    assert second.evaluated == 0
+
+    results = _read_judge_results(db_path)
+    assert len(results) == 1


### PR DESCRIPTION
## 概要
judge MVP の Phase 1 を checkpoint として保存するPRです。

- run_once ベースの最小判定フローを実装
- warning/critical 通知フックと critical 停止 API フックを導入（注入式）
- Task Scheduler 呼び出し口としてtasks.ps1 judge-run-once を追加
- Phase 1 / Phase 2 / Phase 3 のロードマップを docs に整理

## 変更内容
- src/portfolio_fdc/judge/run_once.py
- src/portfolio_fdc/judge/__init__.py
- tests/judge/test_judge_run_once.py
- tasks.ps1
- docs/issues/child-judge-mvp.md

## テスト
- python -m pytest tests/judge/test_judge_run_once.py -q
- python -m pytest tests/judge/test_db_api_judge_results_endpoint.py -q

## 補足
今回のPRでは、メール実送信・MES API実POST・Task Scheduler本番登録（30分周期）は未実装です。
これらは別Issueで段階的に実装します。

Closes #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 目的: Judge MVP フェーズ1 のチェックポイント実装（run_once ベースの最小ジャッジフロー、通知/クリティカル停止用フック、Task Scheduler エントリポイント追加）。
- 主要変更:
  - src/portfolio_fdc/judge/run_once.py: JudgeEngine、run_once、CLI（build_parser/main）を追加。SQLite から ProcessInfo/Parameters を読み取り、ActiveChartSet/ChartsV2 の閾値で各フィーチャを OK/WARN/NG に評価し、JudgementResults を永続化。WARN/NG で通知フックを呼び、NG で stop_api_hook を呼び出して呼出し結果（notification_status, stop_api_called, stop_api_status 等）を message_json に記録。ラン概要（evaluated/written/notifications_attempted/notifications_failed/stop_api_attempted/stop_api_failed/skipped_without_chart）を返却。
  - src/portfolio_fdc/judge/__init__.py: JudgeEngine, JudgeRunSummary, main, run_once をパッケージ公開。
  - tasks.ps1: judge-run-once タスクとパラメータ（JudgeDbPath/JudgeProcessId/JudgeDbApi）を追加し、venv 経由で -m portfolio_fdc.judge.run_once を実行するエントリを実装。
  - docs/issues/child-judge-mvp.md: フェーズ1–3 ロードマップ、受け入れ基準、監査要件を文書化。
  - tests/judge/test_judge_run_once.py: run_once のエンドツーエンド系ユニットテスト群を追加（閾値境界、通知/stop API 呼出し、タイムアウト、idempotency スキップ等）。
  - その他: コミットで process-id ベースの冪等ガードを追加。issue #147 をクローズ。
- リスク／未実装（要注意）:
  - 実運用の通知（実メール送信）および MES API POST は未実装（Phase 2 に先送り）。現状はフック呼び出しの注入のみ。
  - Task Scheduler の本番登録（30分間隔など）は未実装。tasks.ps1 は実行エントリを追加するのみ。
  - stop API 呼出し失敗はプロセスをクラッシュさせないが、外部依存へのリトライ・バックオフや復旧ポリシーは未整備。
  - db_api の実際の HTTP 統合（/judge/results への E2E 書き込み／読み取り）は本 PR 内での完全な統合実体が不足している可能性あり。
- テストギャップ／推奨追加試験:
  - 本番 db_api サービスとのエンドツーエンド統合テスト（/judge/results の読取・書込と read-path 契約検証）。
  - 実メール／MES アダプタを用いた通知の E2E 検証。
  - スケジューラ運用下での重複実行・並行実行耐性テスト（複数ジョブ同時実行時の排他性／整合性）。
  - stop API のリトライ／バックオフ挙動、複数試行時の監査ログ整合性テスト。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/210)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->