### PR TITLE
feat(governance): enforce 403 on emergency routes

### DIFF
--- a/src/portfolio_fdc/db_api/routers/governance_router.py
+++ b/src/portfolio_fdc/db_api/routers/governance_router.py
@@ -114,8 +114,8 @@ class _GovernanceEmergencyForbiddenRole(Exception):
         self.route = route
 
 
-_EMERGENCY_APPLY_ALLOWED_ROLES = {"operator", "ops", "admin"}
-_EMERGENCY_RATIFY_ALLOWED_ROLES = {"manager", "ops", "admin"}
+_EMERGENCY_APPLY_ALLOWED_ROLES = {"engineer", "operator", "ops", "admin"}
+_EMERGENCY_RATIFY_ALLOWED_ROLES = {"manager", "manager_on_call", "ops", "admin"}
 
 
 def _normalize_role(role: str) -> str:

--- a/src/portfolio_fdc/db_api/routers/governance_router.py
+++ b/src/portfolio_fdc/db_api/routers/governance_router.py
@@ -108,6 +108,44 @@ class _GovernanceEmergencyRatificationConflict(Exception):
         self.ec_id = ec_id
 
 
+class _GovernanceEmergencyForbiddenRole(Exception):
+    def __init__(self, *, role: str, route: str) -> None:
+        self.role = role
+        self.route = route
+
+
+_EMERGENCY_APPLY_ALLOWED_ROLES = {"operator", "ops", "admin"}
+_EMERGENCY_RATIFY_ALLOWED_ROLES = {"manager", "ops", "admin"}
+
+
+def _normalize_role(role: str) -> str:
+    return role.strip().lower()
+
+
+def _ensure_allowed_role(*, role: str, route: str, allowed_roles: set[str]) -> None:
+    normalized_role = _normalize_role(role)
+    if normalized_role in allowed_roles:
+        return
+    raise _GovernanceEmergencyForbiddenRole(role=role, route=route)
+
+
+def _forbidden_role_error_response(*, role: str, route: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=403,
+        content={
+            "ok": False,
+            "error": {
+                "code": "FORBIDDEN",
+                "message": "role is not allowed for emergency route",
+                "details": {
+                    "route": route,
+                    "role": role,
+                },
+            },
+        },
+    )
+
+
 def _is_duplicate_change_request_idempotency_error(error: sqlite3.IntegrityError) -> bool:
     message = str(error)
     return (
@@ -343,8 +381,15 @@ class GovernanceRouter:
                     con.close()
 
             try:
+                _ensure_allowed_role(
+                    role=payload.changed_by_role,
+                    route="/governance/emergency-changes",
+                    allowed_roles=_EMERGENCY_APPLY_ALLOWED_ROLES,
+                )
                 data = runner.submit("write", _write)
                 return {"ok": True, "data": data}
+            except _GovernanceEmergencyForbiddenRole as e:
+                return _forbidden_role_error_response(role=e.role, route=e.route)
             except _GovernanceEmergencyChangeChartNotFound:
                 return not_found_error_response(
                     code="CHART_NOT_FOUND",
@@ -426,8 +471,15 @@ class GovernanceRouter:
                     con.close()
 
             try:
+                _ensure_allowed_role(
+                    role=payload.ratified_by_role,
+                    route="/governance/emergency-changes/{request_id}/ratify",
+                    allowed_roles=_EMERGENCY_RATIFY_ALLOWED_ROLES,
+                )
                 data = runner.submit("write", _write)
                 return {"ok": True, "data": data}
+            except _GovernanceEmergencyForbiddenRole as e:
+                return _forbidden_role_error_response(role=e.role, route=e.route)
             except GovernanceNotFoundError:
                 return not_found_error_response(
                     message="emergency change not found",

--- a/tests/db_api/test_db_api_governance_emergency_changes_endpoint.py
+++ b/tests/db_api/test_db_api_governance_emergency_changes_endpoint.py
@@ -366,6 +366,29 @@ def test_post_emergency_changes_returns_404_when_chart_not_found(client: TestCli
     assert body["error"]["code"] == "CHART_NOT_FOUND"
 
 
+def test_post_emergency_changes_returns_403_for_disallowed_role(
+    client: TestClient,
+    seeded_emergency_chart: tuple[int, int],
+) -> None:
+    _, chart_id = seeded_emergency_chart
+    res = client.post(
+        "/governance/emergency-changes",
+        json={
+            "chart_id": chart_id,
+            "changed_by": "ops-user",
+            "changed_by_role": "viewer",
+            "reason": "incident mitigation",
+            "change_payload": '{"warn_high": 1.9}',
+        },
+    )
+
+    assert res.status_code == 403
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "FORBIDDEN"
+    assert body["error"]["details"]["role"] == "viewer"
+
+
 def test_post_emergency_changes_returns_422_for_invalid_change_payload(
     client: TestClient,
     seeded_emergency_chart: tuple[int, int],
@@ -499,6 +522,39 @@ def test_post_emergency_changes_ratify_returns_404_when_not_found(client: TestCl
     body = res.json()
     assert body["ok"] is False
     assert body["error"]["code"] == "NOT_FOUND"
+
+
+def test_post_emergency_changes_ratify_returns_403_for_disallowed_role(
+    client: TestClient,
+    seeded_emergency_chart: tuple[int, int],
+) -> None:
+    _, chart_id = seeded_emergency_chart
+    create_res = client.post(
+        "/governance/emergency-changes",
+        json={
+            "chart_id": chart_id,
+            "changed_by": "ops-user",
+            "changed_by_role": "operator",
+            "reason": "incident mitigation",
+            "change_payload": '{"warn_high": 1.9, "crit_high": 2.0}',
+        },
+    )
+    assert create_res.status_code == 200
+    ec_id = int(create_res.json()["data"]["request_id"])
+
+    res = client.post(
+        f"/governance/emergency-changes/{ec_id}/ratify",
+        json={
+            "ratified_by": "ops-manager",
+            "ratified_by_role": "viewer",
+        },
+    )
+
+    assert res.status_code == 403
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "FORBIDDEN"
+    assert body["error"]["details"]["role"] == "viewer"
 
 
 def test_post_emergency_changes_ratify_returns_409_when_already_ratified(

--- a/tests/integration/test_governance_flow_integration.py
+++ b/tests/integration/test_governance_flow_integration.py
@@ -81,6 +81,32 @@ def _insert_chart(
         con.close()
 
 
+def _count_emergency_changes_for_chart(chart_id: int) -> int:
+    """指定 chart_id の緊急変更件数を返す。"""
+    con = _connect(MAIN_DB)
+    try:
+        count = con.execute(
+            "SELECT COUNT(*) FROM GovernanceEmergencyChanges WHERE chart_id = ?",
+            (chart_id,),
+        ).fetchone()[0]
+        return int(count)
+    finally:
+        con.close()
+
+
+def _count_ratifications_for_ec(ec_id: int) -> int:
+    """指定 ec_id の追認件数を返す。"""
+    con = _connect(MAIN_DB)
+    try:
+        count = con.execute(
+            "SELECT COUNT(*) FROM GovernanceRatifications WHERE ec_id = ?",
+            (ec_id,),
+        ).fetchone()[0]
+        return int(count)
+    finally:
+        con.close()
+
+
 def test_governance_normal_flow_e2e(client: TestClient) -> None:
     """
     通常フロー E2E: create -> approve -> apply
@@ -240,12 +266,15 @@ def test_governance_emergency_apply_forbidden_role_returns_403(client: TestClien
         "reason": "forbidden apply check",
         "change_payload": '{"warn_low": 19.0}',
     }
+    before_count = _count_emergency_changes_for_chart(chart_id)
     response = client.post("/governance/emergency-changes", json=payload)
+    after_count = _count_emergency_changes_for_chart(chart_id)
 
     assert response.status_code == 403
     body = response.json()
     assert body["ok"] is False
     assert body["error"]["code"] == "FORBIDDEN"
+    assert after_count == before_count
 
 
 def test_governance_emergency_ratify_forbidden_role_returns_403(client: TestClient) -> None:
@@ -269,15 +298,18 @@ def test_governance_emergency_ratify_forbidden_role_returns_403(client: TestClie
         "ratified_by_role": "viewer",
         "related_pr": "https://github.com/mdht-daiki/fdc-logger-toolkit/pull/1001",
     }
+    before_count = _count_ratifications_for_ec(emergency_id)
     response = client.post(
         f"/governance/emergency-changes/{emergency_id}/ratify",
         json=ratify_payload,
     )
+    after_count = _count_ratifications_for_ec(emergency_id)
 
     assert response.status_code == 403
     body = response.json()
     assert body["ok"] is False
     assert body["error"]["code"] == "FORBIDDEN"
+    assert after_count == before_count
 
 
 def test_governance_read_endpoints_non_regression(client: TestClient) -> None:

--- a/tests/integration/test_governance_flow_integration.py
+++ b/tests/integration/test_governance_flow_integration.py
@@ -228,6 +228,58 @@ def test_governance_duplicate_ratify_blocked(client: TestClient) -> None:
     assert response.status_code == 409
 
 
+def test_governance_emergency_apply_forbidden_role_returns_403(client: TestClient) -> None:
+    """緊急変更で非許可ロールが 403 になることを確認。"""
+    chart_set_id = _insert_chart_set("emergency_forbidden_apply")
+    chart_id = _insert_chart(chart_set_id)
+
+    payload = {
+        "chart_id": chart_id,
+        "changed_by": "viewer_user",
+        "changed_by_role": "viewer",
+        "reason": "forbidden apply check",
+        "change_payload": '{"warn_low": 19.0}',
+    }
+    response = client.post("/governance/emergency-changes", json=payload)
+
+    assert response.status_code == 403
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "FORBIDDEN"
+
+
+def test_governance_emergency_ratify_forbidden_role_returns_403(client: TestClient) -> None:
+    """追認で非許可ロールが 403 になることを確認。"""
+    chart_set_id = _insert_chart_set("emergency_forbidden_ratify")
+    chart_id = _insert_chart(chart_set_id)
+
+    create_payload = {
+        "chart_id": chart_id,
+        "changed_by": "duty_engineer",
+        "changed_by_role": "engineer",
+        "reason": "ratify forbidden check",
+        "change_payload": '{"warn_low": 17.0}',
+    }
+    create_response = client.post("/governance/emergency-changes", json=create_payload)
+    assert create_response.status_code == 200
+    emergency_id = create_response.json()["data"]["request_id"]
+
+    ratify_payload = {
+        "ratified_by": "viewer_user",
+        "ratified_by_role": "viewer",
+        "related_pr": "https://github.com/mdht-daiki/fdc-logger-toolkit/pull/1001",
+    }
+    response = client.post(
+        f"/governance/emergency-changes/{emergency_id}/ratify",
+        json=ratify_payload,
+    )
+
+    assert response.status_code == 403
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "FORBIDDEN"
+
+
 def test_governance_read_endpoints_non_regression(client: TestClient) -> None:
     """
     既存 read endpoint の非回帰確認。


### PR DESCRIPTION
## Summary
- enforce role-based 403 checks on emergency governance routes
- apply route: POST /governance/emergency-changes
- ratify route: POST /governance/emergency-changes/{request_id}/ratify
- add failure-path tests for disallowed roles on both routes

## Test
- pytest tests/db_api/test_db_api_governance_emergency_changes_endpoint.py -q

Refs #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 状態：実装済み — 緊急ガバナンス経路でのロールベース拒否(403)を導入・修正。
  - 実装ファイル：src/portfolio_fdc/db_api/routers/governance_router.py
  - 追加/変更点：
    - _EMERGENCY_APPLY_ALLOWED_ROLES = {"engineer", "operator", "ops", "admin"}（engineer を追加して統合テスト契約に整合）
    - _EMERGENCY_RATIFY_ALLOWED_ROLES = {"manager", "manager_on_call", "ops", "admin"}（manager_on_call を追加）
    - ロール正規化関数 _normalize_role、許可チェック _ensure_allowed_role、403 応答生成 _forbidden_role_error_response、例外クラス _GovernanceEmergencyForbiddenRole を導入
    - 該当ルート：
      - POST /governance/emergency-changes（apply） — payload.changed_by_role を検証
      - POST /governance/emergency-changes/{request_id}/ratify（ratify） — payload.ratified_by_role を検証
  - テスト追加・強化：
    - 単体テスト：tests/db_api/test_db_api_governance_emergency_changes_endpoint.py に apply と ratify の disallowed-role が 403 を返すケースを追加（error.details.role を検証）
    - 統合テスト：tests/integration/test_governance_flow_integration.py に apply／ratify の 403 ケースを追加。いずれもリクエストで拒否された場合に DB に副作用がないこと（行数カウントで増加しない）を明示的にアサートするよう強化
  - CI 修正：以前の CI 失敗は apply 側で engineer が許可されていなかったことが原因で、今回の修正で解消

- リスクとテストギャップ
  - ロール正規化は strip().lower() ベースの単純マッピングのため、別名（例："mgr" 等）や外部ソースで使われる異表記には未対応。
  - ネガティブケースの網羅性：テストは主に "viewer" を使った拒否ケースを検証しているが、他の非許可ロール群や境界ケース（空文字、null、長い文字列、特殊文字等）の網羅は不足している。
  - ポリシー運用性：許可ロール集合がコード内定数のまま（ハードコード）であるため、将来的にロール変更を運用で反映する必要がある場合は設定化／ポリシー化を検討すべき。
  - エラーフォーマット依存：403 応答のペイロード形式にクライアントが依存している場合は仕様化が望ましい（テストは現行フォーマットを期待）。

- 結論／推奨
  - PR は目的を達成しており、apply/ratify の不許可ロールでの早期拒否と副作用なしの保証までカバーされている。
  - 推奨追加対応：ロール別名対応や設定化（動的許可リスト）、および追加のネガティブ・境界テストを追加して堅牢性を高める。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdht-daiki/fdc-logger-toolkit/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->