### PR TITLE
docs(dashboard): define tab role boundary and visibility policy (#222)

### DIFF
--- a/docs/dashboard-architecture-playbook.md
+++ b/docs/dashboard-architecture-playbook.md
@@ -153,7 +153,8 @@ URL 契約トラッキング（Discussion #94）:
 | `history`            | Ops           | Engineer        | Audit            | readonly | readonly | hidden   |
 | `judge`              | Engineer      | Ops             | Audit            | readonly | readonly | hidden   |
 | `change_requests`    | Engineer      | Ops             | Audit            | execute  | execute  | hidden   |
-| `emergency`          | Engineer      | Ops             | Audit            | execute  | execute  | hidden   |
+| `emergency:apply`    | Engineer      | Ops             | Audit            | execute  | readonly | hidden   |
+| `emergency:ratify`   | Ops           | Audit           | Engineer         | hidden   | execute  | readonly |
 | `notification_retry` | Ops           | Audit           | Engineer         | hidden   | execute  | readonly |
 
 運用ルール:

--- a/docs/dashboard-architecture-playbook.md
+++ b/docs/dashboard-architecture-playbook.md
@@ -137,6 +137,40 @@ URL 契約トラッキング（Discussion #94）:
 - role/認可結果に応じた 403 表示
 - 実行結果と履歴（`/charts/history`）の確認導線
 
+### Tab Role Boundary and Visibility Policy（Issue #222）
+
+対象ロールは Engineer / Ops / Audit の 3 つとし、タブ単位で以下を固定する。
+
+- 表示制御モード定義
+  - `hidden`: タブを表示しない
+  - `readonly`: 閲覧のみ許可（更新系ボタン・送信操作は無効化）
+  - `execute`: 閲覧 + 操作を許可
+
+| Tab                  | Primary Actor | Secondary Actor | Prohibited Actor | Engineer | Ops      | Audit    |
+| -------------------- | ------------- | --------------- | ---------------- | -------- | -------- | -------- |
+| `charts`             | Engineer      | Ops             | Audit            | readonly | readonly | hidden   |
+| `active`             | Engineer      | Ops             | Audit            | readonly | readonly | hidden   |
+| `history`            | Ops           | Engineer        | Audit            | readonly | readonly | hidden   |
+| `judge`              | Engineer      | Ops             | Audit            | readonly | readonly | hidden   |
+| `change_requests`    | Engineer      | Ops             | Audit            | execute  | execute  | hidden   |
+| `emergency`          | Engineer      | Ops             | Audit            | execute  | execute  | hidden   |
+| `notification_retry` | Ops           | Audit           | Engineer         | hidden   | execute  | readonly |
+
+運用ルール:
+
+1. Prohibited Actor はタブ自体を `hidden` とする。
+2. `readonly` ロールはフォーム送信・再送・承認・適用など状態変更操作を実行できない。
+3. `execute` ロールでも最終認可は db_api 側で判定し、権限外は 403 envelope を表示する。
+
+### New Tab Onboarding Checklist（Issue #222）
+
+新規タブ（例: governed activation flow）を追加する場合、次を同一 PR で満たす。
+
+1. Primary/Secondary/Prohibited を定義し、`hidden/readonly/execute` を各ロールに割り当てる。
+2. タブが利用する endpoint を列挙し、`docs/db-api-endpoints.md` の Consumer 範囲と矛盾しないことを確認する。
+3. 更新系操作を含む場合、`readonly` ロールの操作無効化と 403 表示方針を明記する。
+4. 仕様変更がある場合は `docs/decision-log.md` を同一 PR で更新する。
+
 #### Phase 2 Endpoint Contract Detail（Change Request 系）
 
 **Change Request Workflow Endpoints**（approval flow）

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -75,15 +75,16 @@
 
 `dashboard` のタブ表示制御は endpoint の Consumer 範囲に従う。
 
-| Dashboard Tab         | Main Endpoint Group                                                                                         | Access Baseline |
-| --------------------- | ----------------------------------------------------------------------------------------------------------- | --------------- |
-| `charts`              | `GET /charts`                                                                                               | Engineer/Ops: readonly, Audit: hidden |
-| `active`              | `GET /charts/active`                                                                                        | Engineer/Ops: readonly, Audit: hidden |
-| `history`             | `GET /charts/history`                                                                                       | Engineer/Ops: readonly, Audit: hidden |
-| `judge`               | `GET /judge/results*`                                                                                       | Engineer/Ops: readonly, Audit: hidden |
-| `change_requests`     | `GET/POST /governance/change-requests*`                                                                     | Engineer/Ops: execute, Audit: hidden |
-| `emergency`           | `POST /governance/emergency-changes`                                                                        | Engineer/Ops: execute, Audit: hidden |
-| `notification_retry`  | `GET /governance/notifications/failed`, `POST /governance/notifications/{event_id}/retry`                 | Ops: execute, Audit: readonly, Engineer: hidden |
+| Dashboard Tab        | Main Endpoint Group                                                                       | Access Baseline                                 |
+| -------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `charts`             | `GET /charts`                                                                             | Engineer/Ops: readonly, Audit: hidden           |
+| `active`             | `GET /charts/active`                                                                      | Engineer/Ops: readonly, Audit: hidden           |
+| `history`            | `GET /charts/history`                                                                     | Engineer/Ops: readonly, Audit: hidden           |
+| `judge`              | `GET /judge/results*`                                                                     | Engineer/Ops: readonly, Audit: hidden           |
+| `change_requests`     | `GET/POST /governance/change-requests*`                                                   | Engineer/Ops: execute, Audit: hidden            |
+| `emergency:apply`     | `POST /governance/emergency-changes`                                                      | Engineer: execute, Ops: readonly, Audit: hidden |
+| `emergency:ratify`    | `POST /governance/emergency-changes/{request_id}/ratify`                                  | Ops: execute, Audit: readonly, Engineer: hidden |
+| `notification_retry` | `GET /governance/notifications/failed`, `POST /governance/notifications/{event_id}/retry` | Ops: execute, Audit: readonly, Engineer: hidden |
 
 補足:
 

--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -71,6 +71,25 @@
 1. import 境界は `import-linter` で pre-commit と CI の両方で機械検出する（Issue #108 対応）。
 2. endpoint 権限は API スキーマ実装時にテスト（認可・認証）で検証する。
 
+## Dashboard Tab Access Baseline（Issue #222）
+
+`dashboard` のタブ表示制御は endpoint の Consumer 範囲に従う。
+
+| Dashboard Tab         | Main Endpoint Group                                                                                         | Access Baseline |
+| --------------------- | ----------------------------------------------------------------------------------------------------------- | --------------- |
+| `charts`              | `GET /charts`                                                                                               | Engineer/Ops: readonly, Audit: hidden |
+| `active`              | `GET /charts/active`                                                                                        | Engineer/Ops: readonly, Audit: hidden |
+| `history`             | `GET /charts/history`                                                                                       | Engineer/Ops: readonly, Audit: hidden |
+| `judge`               | `GET /judge/results*`                                                                                       | Engineer/Ops: readonly, Audit: hidden |
+| `change_requests`     | `GET/POST /governance/change-requests*`                                                                     | Engineer/Ops: execute, Audit: hidden |
+| `emergency`           | `POST /governance/emergency-changes`                                                                        | Engineer/Ops: execute, Audit: hidden |
+| `notification_retry`  | `GET /governance/notifications/failed`, `POST /governance/notifications/{event_id}/retry`                 | Ops: execute, Audit: readonly, Engineer: hidden |
+
+補足:
+
+1. `readonly` は閲覧のみ許可し、更新系操作は UI で無効化する。
+2. `execute` の最終可否は API 側認可で判定し、権限外は 403 を返す。
+
 ## Must-Test Cases for API Contract
 
 しきい値更新 API を実装する際、以下のケースを最小必須テストとする.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -16,7 +16,8 @@ Phase 2 実装後、dashboard タブごとの利用主体と表示制御方針�
 3. Prohibited Actor はタブを表示しない。
 4. `readonly` は閲覧のみとし、更新系操作を実行不可にする。
 5. `execute` でも最終認可は API 側判定を正本とする（権限外は 403）。
-6. 新規タブ追加時は同一 PR で playbook と endpoint catalog と decision log の整合更新を必須にする。
+6. `emergency` タブは action-level に分割し、`emergency:apply` は Engineer 主導、`emergency:ratify` は Ops 主導とする。
+7. 新規タブ追加時は同一 PR で playbook と endpoint catalog と decision log の整合更新を必須にする。
 
 ### Why
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,5 +1,35 @@
 # Decision Log
 
+## 2026-05-31: `#222` dashboard タブ役割境界（Engineer/Ops/Audit）を確定
+
+日付基準: JST
+
+### Context
+
+Phase 2 実装後、dashboard タブごとの利用主体と表示制御方針が暗黙運用になっており、
+新規タブ追加時に同じ基準で判断できない状態だった。
+
+### Decision
+
+1. 既存 7 タブ（`charts` / `active` / `history` / `judge` / `change_requests` / `emergency` / `notification_retry`）の Primary/Secondary/Prohibited を固定する。
+2. 表示制御モードを `hidden` / `readonly` / `execute` の 3 段階で定義する。
+3. Prohibited Actor はタブを表示しない。
+4. `readonly` は閲覧のみとし、更新系操作を実行不可にする。
+5. `execute` でも最終認可は API 側判定を正本とする（権限外は 403）。
+6. 新規タブ追加時は同一 PR で playbook と endpoint catalog と decision log の整合更新を必須にする。
+
+### Why
+
+1. 役割境界を文書契約化し、運用依存の判断揺れをなくすため。
+2. API Consumer 範囲と UI 表示制御を対応付け、責務境界の齟齬を減らすため。
+3. 将来の Phase 3 タブ追加時のレビューチェックを定型化するため。
+
+### Consequence
+
+1. `docs/dashboard-architecture-playbook.md` にタブごとの役割境界マトリクスと onboarding checklist を追加する。
+2. `docs/db-api-endpoints.md` に endpoint Consumer と dashboard タブ表示制御の対応表を追加する。
+3. 以後の dashboard 新規タブ PR は #222 のチェックリストを満たすことを受け入れ条件に含める。
+
 ## 2026-05-11: `#143` emergency-changes/ratify - 実装前論点 B/B/A/A/B を確定
 
 日付基準: JST


### PR DESCRIPTION
## Summary
- define Primary/Secondary/Prohibited actors for each existing dashboard tab
- define tab visibility modes (hidden/readonly/execute) and operational rules
- add onboarding checklist for future tabs to enforce consistent role decisions
- sync endpoint catalog and decision log with the new role boundary policy

## Updated docs
- docs/dashboard-architecture-playbook.md
- docs/db-api-endpoints.md
- docs/decision-log.md

Closes #222 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ダッシュボードタブロール境界と表示制御ポリシーの定義

### 変更概要
- **docs/dashboard-architecture-playbook.md**: Engineer/Ops/Audit 3ロールに対する hidden/readonly/execute モード割当を表形式で定義（+35行）
- **docs/db-api-endpoints.md**: 各タブの対象APIエンドポイントとアクセス基準を明文化（+20行）
- **docs/decision-log.md**: Issue `#222` の決定記録を追加、emergency タブをアクション単位に分割（+31行）

### リスク
- **同期ずれリスク**: 3ファイル間で定義内容が一致していることを保証する自動検証がなく、手動更新時の不整合が発生しやすい
- **実装との乖離**: ドキュメント定義が API/UI の実装で実際に強制されておらず、ドキュメント変更後の実装追従が保証されない
- **Emergency 機能分割**: emergency:apply / emergency:ratify への分割が、フロントエンド・バックエンド両側で正確に実装されない可能性
- **403 ハンドリング**: UI 側で prohibited 役割を hidden 制御していても、API 側が 403 を返さない場合に認可ギャップが生じる

### テストギャップ
- **ロール別アクセス検証なし**: API エンドポイントが documented なロール・モード定義に従って実際に readonly/execute を制御しているか検証するテストがない
- **UI 表示制御テストなし**: 各ロールユーザーが正しく hidden/readonly/execute 状態でコンポーネントを表示・制御できているか検証する統合テストが不在
- **Emergency 分割統合テストなし**: emergency:apply（Engineer）と emergency:ratify（Ops）の分離動作を、エラーケース含めて検証するテストがない
- **チェックリスト自動化なし**: 新規タブ追加時に要求される docs/decision-log.md / endpoint catalog / playbook の整合性更新をチェックする自動化がない

<!-- end of auto-generated comment: release notes by coderabbit.ai -->