### PR TITLE
feat(dashboard): reduce raw JSON dependency in governance UI (#223)

### DIFF
--- a/docs/db-api-endpoints.md
+++ b/docs/db-api-endpoints.md
@@ -81,9 +81,9 @@
 | `active`             | `GET /charts/active`                                                                      | Engineer/Ops: readonly, Audit: hidden           |
 | `history`            | `GET /charts/history`                                                                     | Engineer/Ops: readonly, Audit: hidden           |
 | `judge`              | `GET /judge/results*`                                                                     | Engineer/Ops: readonly, Audit: hidden           |
-| `change_requests`     | `GET/POST /governance/change-requests*`                                                   | Engineer/Ops: execute, Audit: hidden            |
-| `emergency:apply`     | `POST /governance/emergency-changes`                                                      | Engineer: execute, Ops: readonly, Audit: hidden |
-| `emergency:ratify`    | `POST /governance/emergency-changes/{request_id}/ratify`                                  | Ops: execute, Audit: readonly, Engineer: hidden |
+| `change_requests`    | `GET/POST /governance/change-requests*`                                                   | Engineer/Ops: execute, Audit: hidden            |
+| `emergency:apply`    | `POST /governance/emergency-changes`                                                      | Engineer: execute, Ops: readonly, Audit: hidden |
+| `emergency:ratify`   | `POST /governance/emergency-changes/{request_id}/ratify`                                  | Ops: execute, Audit: readonly, Engineer: hidden |
 | `notification_retry` | `GET /governance/notifications/failed`, `POST /governance/notifications/{event_id}/retry` | Ops: execute, Audit: readonly, Engineer: hidden |
 
 補足:

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 from typing import Any
@@ -123,6 +124,64 @@ def _to_positive_int(raw: str, field_name: str) -> tuple[int | None, str | None]
     if parsed <= 0:
         return None, f"{field_name} must be >= 1"
     return parsed, None
+
+
+def _to_optional_float(raw: str, field_name: str) -> tuple[float | None, str | None]:
+    value = (raw or "").strip()
+    if not value:
+        return None, None
+    try:
+        return float(value), None
+    except ValueError:
+        return None, f"{field_name} must be numeric"
+
+
+def _build_change_payload_text(
+    warn_low: str,
+    warn_high: str,
+    crit_low: str,
+    crit_high: str,
+    raw_payload: str,
+) -> tuple[str | None, str | None]:
+    warn_low_val, warn_low_err = _to_optional_float(warn_low, "warn_low")
+    if warn_low_err is not None:
+        return None, warn_low_err
+    warn_high_val, warn_high_err = _to_optional_float(warn_high, "warn_high")
+    if warn_high_err is not None:
+        return None, warn_high_err
+    crit_low_val, crit_low_err = _to_optional_float(crit_low, "crit_low")
+    if crit_low_err is not None:
+        return None, crit_low_err
+    crit_high_val, crit_high_err = _to_optional_float(crit_high, "crit_high")
+    if crit_high_err is not None:
+        return None, crit_high_err
+
+    threshold_payload: dict[str, float] = {}
+    if warn_low_val is not None:
+        threshold_payload["warn_low"] = warn_low_val
+    if warn_high_val is not None:
+        threshold_payload["warn_high"] = warn_high_val
+    if crit_low_val is not None:
+        threshold_payload["crit_low"] = crit_low_val
+    if crit_high_val is not None:
+        threshold_payload["crit_high"] = crit_high_val
+
+    # Prefer structured threshold fields. Raw JSON remains as an optional fallback.
+    if threshold_payload:
+        return json.dumps(threshold_payload, ensure_ascii=False), None
+
+    raw_text = (raw_payload or "").strip()
+    if not raw_text:
+        return None, "at least one threshold field or change_payload JSON is required"
+    try:
+        parsed = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return None, "change_payload must be valid JSON"
+    if not isinstance(parsed, dict):
+        return None, "change_payload must be JSON object"
+    if not parsed:
+        return None, "change_payload must not be empty"
+    return raw_text, None
 
 
 def _build_history_preview(rows: list[dict[str, Any]]) -> list[Any]:
@@ -366,6 +425,35 @@ def render_active_drilldown(
 
 
 @app.callback(
+    Output("emergency-payload-preview", "children"),
+    Input("emergency-warn-low", "value"),
+    Input("emergency-warn-high", "value"),
+    Input("emergency-crit-low", "value"),
+    Input("emergency-crit-high", "value"),
+    Input("emergency-change-payload", "value"),
+    prevent_initial_call=False,
+)
+def preview_emergency_payload(
+    warn_low: str,
+    warn_high: str,
+    crit_low: str,
+    crit_high: str,
+    raw_payload: str,
+) -> str:
+    payload_text, err = _build_change_payload_text(
+        warn_low,
+        warn_high,
+        crit_low,
+        crit_high,
+        raw_payload,
+    )
+    if err is not None:
+        return f"payload preview unavailable: {err}"
+    assert payload_text is not None
+    return payload_text
+
+
+@app.callback(
     Output("emergency-action-result", "children"),
     Output("emergency-history-preview", "children"),
     Input("emergency-submit-btn", "n_clicks"),
@@ -375,6 +463,10 @@ def render_active_drilldown(
     State("emergency-changed-by-role", "value"),
     State("emergency-reason", "value"),
     State("emergency-change-payload", "value"),
+    State("emergency-warn-low", "value"),
+    State("emergency-warn-high", "value"),
+    State("emergency-crit-low", "value"),
+    State("emergency-crit-high", "value"),
     prevent_initial_call=True,
 )
 def submit_emergency_change(
@@ -384,7 +476,11 @@ def submit_emergency_change(
     changed_by: str,
     changed_by_role: str,
     reason: str,
-    change_payload: str,
+    change_payload: str = "",
+    warn_low: str = "",
+    warn_high: str = "",
+    crit_low: str = "",
+    crit_high: str = "",
 ) -> tuple[str, list[Any]]:
     if not n_clicks:
         return "", [html.Div("Apply 実行後に履歴を表示します。")]
@@ -395,13 +491,21 @@ def submit_emergency_change(
 
     actor = (changed_by or "").strip()
     role = (changed_by_role or "").strip()
-    payload_text = (change_payload or "").strip()
     if not actor:
         return "changed_by is required", [html.Div("Apply 実行後に履歴を表示します。")]
     if not role:
         return "changed_by_role is required", [html.Div("Apply 実行後に履歴を表示します。")]
-    if not payload_text:
-        return "change_payload is required", [html.Div("Apply 実行後に履歴を表示します。")]
+
+    payload_text, payload_err = _build_change_payload_text(
+        warn_low,
+        warn_high,
+        crit_low,
+        crit_high,
+        change_payload,
+    )
+    if payload_err is not None:
+        return payload_err, [html.Div("Apply 実行後に履歴を表示します。")]
+    assert payload_text is not None
 
     try:
         safe_base_url = validate_base_url(base_url)[0]
@@ -610,6 +714,35 @@ def _build_change_request_list_view(
 
 
 @app.callback(
+    Output("change-request-payload-preview", "children"),
+    Input("change-request-warn-low", "value"),
+    Input("change-request-warn-high", "value"),
+    Input("change-request-crit-low", "value"),
+    Input("change-request-crit-high", "value"),
+    Input("change-request-change-payload", "value"),
+    prevent_initial_call=False,
+)
+def preview_change_request_payload(
+    warn_low: str,
+    warn_high: str,
+    crit_low: str,
+    crit_high: str,
+    raw_payload: str,
+) -> str:
+    payload_text, err = _build_change_payload_text(
+        warn_low,
+        warn_high,
+        crit_low,
+        crit_high,
+        raw_payload,
+    )
+    if err is not None:
+        return f"payload preview unavailable: {err}"
+    assert payload_text is not None
+    return payload_text
+
+
+@app.callback(
     Output("change-request-create-result", "children"),
     Input("change-request-create-btn", "n_clicks"),
     State("base-url", "value"),
@@ -618,6 +751,10 @@ def _build_change_request_list_view(
     State("change-request-change-payload", "value"),
     State("change-request-expected-version", "value"),
     State("change-request-idempotency-key", "value"),
+    State("change-request-warn-low", "value"),
+    State("change-request-warn-high", "value"),
+    State("change-request-crit-low", "value"),
+    State("change-request-crit-high", "value"),
     prevent_initial_call=True,
 )
 def submit_change_request_create(
@@ -625,9 +762,13 @@ def submit_change_request_create(
     base_url: str,
     chart_id: str,
     proposed_by: str,
-    change_payload: str,
-    expected_version: str,
-    idempotency_key: str,
+    change_payload: str = "",
+    expected_version: str = "",
+    idempotency_key: str = "",
+    warn_low: str = "",
+    warn_high: str = "",
+    crit_low: str = "",
+    crit_high: str = "",
 ) -> str:
     if not n_clicks:
         return ""
@@ -640,14 +781,22 @@ def submit_change_request_create(
         return version_err
 
     actor = (proposed_by or "").strip()
-    payload_text = (change_payload or "").strip()
     key = (idempotency_key or "").strip()
     if not actor:
         return "proposed_by is required"
-    if not payload_text:
-        return "change_payload is required"
     if not key:
         return "idempotency_key is required"
+
+    payload_text, payload_err = _build_change_payload_text(
+        warn_low,
+        warn_high,
+        crit_low,
+        crit_high,
+        change_payload,
+    )
+    if payload_err is not None:
+        return payload_err
+    assert payload_text is not None
 
     try:
         safe_base_url = validate_base_url(base_url)[0]

--- a/src/portfolio_fdc/dashboard/app.py
+++ b/src/portfolio_fdc/dashboard/app.py
@@ -166,22 +166,22 @@ def _build_change_payload_text(
     if crit_high_val is not None:
         threshold_payload["crit_high"] = crit_high_val
 
-    # Prefer structured threshold fields. Raw JSON remains as an optional fallback.
+    raw_text = (raw_payload or "").strip()
+    if raw_text:
+        try:
+            parsed = json.loads(raw_text)
+        except json.JSONDecodeError:
+            return None, "change_payload must be valid JSON"
+        if not isinstance(parsed, dict):
+            return None, "change_payload must be JSON object"
+        if not parsed:
+            return None, "change_payload must not be empty"
+        return raw_text, None
+
     if threshold_payload:
         return json.dumps(threshold_payload, ensure_ascii=False), None
 
-    raw_text = (raw_payload or "").strip()
-    if not raw_text:
-        return None, "at least one threshold field or change_payload JSON is required"
-    try:
-        parsed = json.loads(raw_text)
-    except json.JSONDecodeError:
-        return None, "change_payload must be valid JSON"
-    if not isinstance(parsed, dict):
-        return None, "change_payload must be JSON object"
-    if not parsed:
-        return None, "change_payload must not be empty"
-    return raw_text, None
+    return None, "at least one threshold field or change_payload JSON is required"
 
 
 def _build_history_preview(rows: list[dict[str, Any]]) -> list[Any]:

--- a/src/portfolio_fdc/dashboard/tab_renderers.py
+++ b/src/portfolio_fdc/dashboard/tab_renderers.py
@@ -293,6 +293,53 @@ def _build_change_request_sections(
     return list_block, detail_block
 
 
+def build_threshold_inputs(
+    prefix: str,
+    warn_low_default: str = "20.0",
+    warn_high_default: str = "30.0",
+    crit_low_default: str = "",
+    crit_high_default: str = "",
+) -> html.Div:
+    shared_input_style = {"width": "100%"}
+    return html.Div(
+        [
+            html.Label("warn_low"),
+            dcc.Input(
+                id=f"{prefix}-warn-low",
+                type="text",
+                value=warn_low_default,
+                style=shared_input_style,
+            ),
+            html.Label("warn_high"),
+            dcc.Input(
+                id=f"{prefix}-warn-high",
+                type="text",
+                value=warn_high_default,
+                style=shared_input_style,
+            ),
+            html.Label("crit_low (optional)"),
+            dcc.Input(
+                id=f"{prefix}-crit-low",
+                type="text",
+                value=crit_low_default,
+                style=shared_input_style,
+            ),
+            html.Label("crit_high (optional)"),
+            dcc.Input(
+                id=f"{prefix}-crit-high",
+                type="text",
+                value=crit_high_default,
+                style=shared_input_style,
+            ),
+        ],
+        style={
+            "padding": "8px",
+            "border": "1px dashed #bbb",
+            "marginBottom": "8px",
+        },
+    )
+
+
 def render_change_requests_tab(base_url: str) -> html.Div:
     rows = get_change_requests(base_url, params={"limit": 100, "offset": 0})
     list_block, detail_block = _build_change_request_sections(rows)
@@ -320,43 +367,7 @@ def render_change_requests_tab(base_url: str) -> html.Div:
                         style={"width": "100%"},
                     ),
                     html.Label("threshold fields (preferred)"),
-                    html.Div(
-                        [
-                            html.Label("warn_low"),
-                            dcc.Input(
-                                id="change-request-warn-low",
-                                type="text",
-                                value="20.0",
-                                style={"width": "100%"},
-                            ),
-                            html.Label("warn_high"),
-                            dcc.Input(
-                                id="change-request-warn-high",
-                                type="text",
-                                value="30.0",
-                                style={"width": "100%"},
-                            ),
-                            html.Label("crit_low (optional)"),
-                            dcc.Input(
-                                id="change-request-crit-low",
-                                type="text",
-                                value="",
-                                style={"width": "100%"},
-                            ),
-                            html.Label("crit_high (optional)"),
-                            dcc.Input(
-                                id="change-request-crit-high",
-                                type="text",
-                                value="",
-                                style={"width": "100%"},
-                            ),
-                        ],
-                        style={
-                            "padding": "8px",
-                            "border": "1px dashed #bbb",
-                            "marginBottom": "8px",
-                        },
-                    ),
+                    build_threshold_inputs("change-request"),
                     html.Label("advanced change_payload JSON (optional)"),
                     dcc.Textarea(
                         id="change-request-change-payload",
@@ -727,42 +738,12 @@ def _build_emergency_change_form(chart_id: str) -> html.Div:
                 style={"width": "100%"},
             ),
             html.Label("threshold fields (preferred)"),
-            html.Div(
-                [
-                    html.Label("warn_low (optional)"),
-                    dcc.Input(
-                        id="emergency-warn-low",
-                        type="text",
-                        value="",
-                        style={"width": "100%"},
-                    ),
-                    html.Label("warn_high (optional)"),
-                    dcc.Input(
-                        id="emergency-warn-high",
-                        type="text",
-                        value="1.9",
-                        style={"width": "100%"},
-                    ),
-                    html.Label("crit_low (optional)"),
-                    dcc.Input(
-                        id="emergency-crit-low",
-                        type="text",
-                        value="",
-                        style={"width": "100%"},
-                    ),
-                    html.Label("crit_high (optional)"),
-                    dcc.Input(
-                        id="emergency-crit-high",
-                        type="text",
-                        value="2.0",
-                        style={"width": "100%"},
-                    ),
-                ],
-                style={
-                    "padding": "8px",
-                    "border": "1px dashed #bbb",
-                    "marginBottom": "8px",
-                },
+            build_threshold_inputs(
+                "emergency",
+                warn_low_default="",
+                warn_high_default="1.9",
+                crit_low_default="",
+                crit_high_default="2.0",
             ),
             html.Label("advanced change_payload JSON (optional)"),
             dcc.Textarea(

--- a/src/portfolio_fdc/dashboard/tab_renderers.py
+++ b/src/portfolio_fdc/dashboard/tab_renderers.py
@@ -319,11 +319,54 @@ def render_change_requests_tab(base_url: str) -> html.Div:
                         placeholder="enter actor",
                         style={"width": "100%"},
                     ),
-                    html.Label("change_payload (JSON)"),
+                    html.Label("threshold fields (preferred)"),
+                    html.Div(
+                        [
+                            html.Label("warn_low"),
+                            dcc.Input(
+                                id="change-request-warn-low",
+                                type="text",
+                                value="20.0",
+                                style={"width": "100%"},
+                            ),
+                            html.Label("warn_high"),
+                            dcc.Input(
+                                id="change-request-warn-high",
+                                type="text",
+                                value="30.0",
+                                style={"width": "100%"},
+                            ),
+                            html.Label("crit_low (optional)"),
+                            dcc.Input(
+                                id="change-request-crit-low",
+                                type="text",
+                                value="",
+                                style={"width": "100%"},
+                            ),
+                            html.Label("crit_high (optional)"),
+                            dcc.Input(
+                                id="change-request-crit-high",
+                                type="text",
+                                value="",
+                                style={"width": "100%"},
+                            ),
+                        ],
+                        style={
+                            "padding": "8px",
+                            "border": "1px dashed #bbb",
+                            "marginBottom": "8px",
+                        },
+                    ),
+                    html.Label("advanced change_payload JSON (optional)"),
                     dcc.Textarea(
                         id="change-request-change-payload",
-                        value='{"warn_low": 20.0, "warn_high": 30.0}',
+                        value="",
                         style={"width": "100%", "height": "96px", "fontFamily": "Consolas"},
+                    ),
+                    html.Pre(
+                        id="change-request-payload-preview",
+                        children="payload preview will appear here",
+                        style={"backgroundColor": "#f5f5f5", "padding": "8px", "marginTop": "8px"},
                     ),
                     html.Label("expected_version"),
                     dcc.Input(
@@ -683,11 +726,54 @@ def _build_emergency_change_form(chart_id: str) -> html.Div:
                 value="",
                 style={"width": "100%"},
             ),
-            html.Label("change_payload (JSON)"),
+            html.Label("threshold fields (preferred)"),
+            html.Div(
+                [
+                    html.Label("warn_low (optional)"),
+                    dcc.Input(
+                        id="emergency-warn-low",
+                        type="text",
+                        value="",
+                        style={"width": "100%"},
+                    ),
+                    html.Label("warn_high (optional)"),
+                    dcc.Input(
+                        id="emergency-warn-high",
+                        type="text",
+                        value="1.9",
+                        style={"width": "100%"},
+                    ),
+                    html.Label("crit_low (optional)"),
+                    dcc.Input(
+                        id="emergency-crit-low",
+                        type="text",
+                        value="",
+                        style={"width": "100%"},
+                    ),
+                    html.Label("crit_high (optional)"),
+                    dcc.Input(
+                        id="emergency-crit-high",
+                        type="text",
+                        value="2.0",
+                        style={"width": "100%"},
+                    ),
+                ],
+                style={
+                    "padding": "8px",
+                    "border": "1px dashed #bbb",
+                    "marginBottom": "8px",
+                },
+            ),
+            html.Label("advanced change_payload JSON (optional)"),
             dcc.Textarea(
                 id="emergency-change-payload",
-                value='{"warn_high": 1.9, "crit_high": 2.0}',
+                value="",
                 style={"width": "100%", "height": "96px", "fontFamily": "Consolas"},
+            ),
+            html.Pre(
+                id="emergency-payload-preview",
+                children="payload preview will appear here",
+                style={"backgroundColor": "#f5f5f5", "padding": "8px", "marginTop": "8px"},
             ),
             html.Button(
                 "Apply Emergency Change",


### PR DESCRIPTION
## Summary
- add threshold field inputs for Change Request and Emergency actions to reduce raw JSON-only operation
- keep advanced JSON textarea as optional fallback and build payload from structured fields first
- add payload preview callbacks so users can confirm request body before submit
- keep callback signatures backward-compatible while extending with new UI fields
- include minor alignment-only docs update in dashboard tab access table

## Validation
- python -m pytest tests/dashboard/test_dashboard_app.py tests/dashboard/test_tab_renderers.py -q
- python -m pre_commit run --files src/portfolio_fdc/dashboard/app.py src/portfolio_fdc/dashboard/tab_renderers.py docs/db-api-endpoints.md

Closes #223 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更概要（要点）
- Change Request / Emergency の UI から生の JSON 編集の依存を低減：warn_low/high、crit_low/high の閾値フィールドを追加し、構造化フィールドから優先的にペイロードを生成。既存の JSON テキストエリアは「advanced change_payload JSON (optional)」として残す。
- プレビュー機能を追加：preview_emergency_payload / preview_change_request_payload による送信前ペイロード確認（エラー時は "payload preview unavailable: {err}" を表示）。
- サーバ送信コールバックを非破壊的に拡張：submit_emergency_change と submit_change_request_create のシグネチャに閾値パラメータ（デフォルト ""）を追加。
- UI コンポーネント整理：閾値入力を組み立てる公開ヘルパ build_threshold_inputs を追加。ドキュメントではダッシュボード API エンドポイント表の行配置を微修正。

## 実装の要点
- _to_optional_float(raw, field_name) を導入（空文字→ None、数値変換失敗→エラーメッセージ）。
- _build_change_payload_text(...) を導入（閾値フィールドが1つ以上あれば構造化 JSON を生成、そうでなければ advanced JSON を検証。どちらも無効ならエラー返却）。
- 既存の「change_payload 必須」チェックを廃止し、構造化入力優先ロジックに置換。

## リスク・テストギャップ（短く）
- テスト不足：新パラメータを含む統合テスト／エンドツーエンドのカバレッジが見当たらない（submit_change_request_create / submit_emergency_change の実動作検証不足）。
- ユニットテスト欠如：_to_optional_float と _build_change_payload_text の境界ケース（空入力、混在入力、不正 JSON、特殊値 "inf"/"nan"）の単体テストが未検出。
- プレビュー表示テスト欠如：プレビューのエラーメッセージと UI 反映がテストされていない。
- バリデーション不足：数値範囲チェック（負値や極端値）や生成された JSON のスキーマ/フィールド妥当性チェックが限定的で、バックエンド依存が残る。
- UX の曖昧性：構造化フィールド優先ルールと既存 JSON の扱い（ユーザーに明示されているか）が不明瞭で誤操作の可能性あり。
- ローカリゼーション・一貫性：エラーメッセージに英語文言が混在しており UI 言語トーンの不整合がある。

## 推奨アクション（優先度低めに短記）
- _to_optional_float / _build_change_payload_text の単体テスト追加（エッジケース含む）。
- submit_* 系の統合テスト追加で既存 JSON の後方互換性と閾値フィールド併用時の挙動を検証。
- 生成 JSON に対する簡易スキーマ検証（必須フィールド名・型・論理レンジ）を追加検討。
- UI に「構造化フィールド優先」「advanced JSON のフォールバック」ルールを明確に表示し、エラーメッセージを日本語ローカライズする。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->