### PR TITLE
docs(portfolio): milestone A baseline for demo and quality visibility (#227)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all help venv install-dev pre-commit fmt lint type test test-fast test-slow test-db-api-aggregate check aggregate-dry-run clean
+.PHONY: all help venv install-dev pre-commit fmt lint type test test-fast test-slow test-db-api-aggregate check aggregate-dry-run clean demo-db-api demo-data demo-dashboard
 
 all: help
 
@@ -10,6 +10,7 @@ PRECOMMIT := $(VENV_DIR)/bin/pre-commit
 AGG_INPUT ?= data/scrape/scrape_TOOL_A.csv
 AGG_CONFIG ?= src/portfolio_fdc/configs/aggregate_tools.yaml
 AGG_DETAIL_OUT ?= data/detail
+DEMO_RAW ?= data/raw/logger_raw_demo.csv
 
 help:
 	@echo "Targets:"
@@ -25,6 +26,9 @@ help:
 	@echo "  make test-db-api-aggregate  Pytest for db_api + aggregate connection"
 	@echo "  make check         lint + type + test"
 	@echo "  make aggregate-dry-run  Run aggregate without DB POST"
+	@echo "  make demo-db-api   Start db_api for portfolio demo"
+	@echo "  make demo-data     Generate sample data and run one pipeline cycle"
+	@echo "  make demo-dashboard Start dashboard (http://localhost:8050)"
 	@echo "  make clean         Remove caches/build artifacts"
 
 venv:
@@ -62,6 +66,16 @@ check: lint type test
 
 aggregate-dry-run: install-dev
 	$(PY) -m portfolio_fdc.main.aggregate --input $(AGG_INPUT) --config $(AGG_CONFIG) --detail-out $(AGG_DETAIL_OUT) --dry-run
+
+demo-db-api: install-dev
+	$(PY) -m portfolio_fdc.db_api.app
+
+demo-data: install-dev
+	$(PY) -m portfolio_fdc.tools.generate_logger_csv --out $(DEMO_RAW) --seconds 7200 --scenario mix
+	$(PY) -m portfolio_fdc.main.run_once --tool TOOL_A --raw $(DEMO_RAW) --db-api http://localhost:8000
+
+demo-dashboard: install-dev
+	$(PY) -m portfolio_fdc.dashboard.app
 
 clean:
 	rm -rf .pytest_cache .mypy_cache .ruff_cache build dist *.egg-info htmlcov .coverage

--- a/README.md
+++ b/README.md
@@ -16,13 +16,18 @@
 
 現在の公開版で「デモ可能」な範囲を明示します。
 
-| Area      | Status | Portfolio Scope |
-| --------- | ------ | --------------- |
-| db_api    | Ready  | SQLite gateway, governance endpoints, read/write API |
-| dashboard | Ready  | chart/judge/governance UI（change request / emergency / retry） |
-| ingest    | Ready  | synthetic data -> scrape/aggregate -> DB 反映 |
-| judge     | Partial | `run_once` ベース。通知/MES 連携は段階対応中 |
-| ops docs  | Partial | runbook/rollback/checklist は継続整備中 |
+| Area      | Status  | Portfolio Scope                                                 |
+| --------- | ------- | --------------------------------------------------------------- |
+| db_api    | Ready   | SQLite gateway, governance endpoints, read/write API            |
+| dashboard | Ready   | chart/judge/governance UI（change request / emergency / retry） |
+| ingest    | Ready   | synthetic data -> scrape/aggregate -> DB 反映                   |
+| judge     | Partial | `run_once` ベース。通知/MES 連携は段階対応中                    |
+| ops docs  | Partial | runbook/rollback/checklist は継続整備中                         |
+
+注記:
+
+- `Ready` は「ポートフォリオのローカルデモ導線で再現できる範囲」を示します。
+- `db_api` / `dashboard` の endpoint 詳細は `docs/db-api-endpoints.md` を参照してください。
 
 ---
 
@@ -248,18 +253,17 @@ $env:PORTFOLIO_DB_DIR = "E:/work/python/logger/data/db"
 python -m portfolio_fdc.db_api.app
 ```
 
-現時点の実装スコープ（PR を小さく保つため）:
+現時点の実装スコープ（ポートフォリオデモ）:
 
-- `aggregate` 連携エンドポイントのみ実装
+- `aggregate` 連携 endpoint
   - `POST /aggregate/write`（推奨）
   - `POST /processes`
   - `DELETE /processes/{process_id}`（推奨）
-  - `DELETE /processes`（互換用、2026-06-30 まで併存予定）
+  - `DELETE /processes`（互換）
   - `POST /step_windows/bulk`
   - `POST /parameters/bulk`
-- 先送りしたエンドポイント（charts/judge/chart_sets/charts_v2）は
-  `src/portfolio_fdc/db_api/app.py.backup_non_aggregate_endpoints.py` に退避
-- 退避ファイルは `.gitignore` でレビュー対象外
+- dashboard/judge/governance の read/write endpoint（change request / emergency / retry を含む）
+- 主要 endpoint 一覧と consumer 範囲は `docs/db-api-endpoints.md` を正本として参照
 
 ### 2) 疑似 logger CSV を生成
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FDC Logger Toolkit (Portfolio Edition)
 
+[![CI](https://github.com/mdht-daiki/fdc-logger-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/mdht-daiki/fdc-logger-toolkit/actions/workflows/ci.yml)
+
 製造装置ログを対象にした、ポートフォリオ向け FDC (Fault Detection & Classification) ツールキットです。
 
 このプロジェクトは社内監視ツールを再構成した公開版で、機密情報や固有ロジックは削除し、以下に置き換えています。
@@ -7,6 +9,20 @@
 - 疑似 logger データ生成機能
 - 設定ファイルベースのマッピング/ルール
 - ローカル SQLite パイプライン
+
+---
+
+## Portfolio Scope Snapshot
+
+現在の公開版で「デモ可能」な範囲を明示します。
+
+| Area      | Status | Portfolio Scope |
+| --------- | ------ | --------------- |
+| db_api    | Ready  | SQLite gateway, governance endpoints, read/write API |
+| dashboard | Ready  | chart/judge/governance UI（change request / emergency / retry） |
+| ingest    | Ready  | synthetic data -> scrape/aggregate -> DB 反映 |
+| judge     | Partial | `run_once` ベース。通知/MES 連携は段階対応中 |
+| ops docs  | Partial | runbook/rollback/checklist は継続整備中 |
 
 ---
 
@@ -165,6 +181,53 @@ pre-commit install
 
 ## クイックスタート（ローカル）
 
+### 0) 最短デモ（3ステップ）
+
+`db_api` を起動した状態で、次の 3 ステップで dashboard まで確認できます。
+
+1. サンプルデータ生成 + 1サイクル投入
+
+```powershell
+.\tasks.ps1 demo-data
+```
+
+```bash
+make demo-data
+```
+
+2. dashboard 起動
+
+```powershell
+.\tasks.ps1 demo-dashboard
+```
+
+```bash
+make demo-dashboard
+```
+
+3. ブラウザで確認
+
+- `http://localhost:8050` を開く
+- Change Requests / Emergency タブでフォーム入力から payload preview を確認
+
+`db_api` をまだ起動していない場合:
+
+```powershell
+.\tasks.ps1 demo-db-api
+```
+
+```bash
+make demo-db-api
+```
+
+トラブル時の最小復旧:
+
+1. `PORTFOLIO_DB_DIR` が不整合なら unset して再起動
+2. `data/db/main.db` をバックアップ退避後に再生成
+3. `.\tasks.ps1 install`（または `make install-dev`）を再実行
+
+---
+
 ### 1) db_api を起動
 
 ```bash
@@ -278,10 +341,13 @@ make all
 
 Pull Request では以下の通過が必要です。
 
-- Ruff（lint + format）
-- MyPy（型チェック）
-- Pytest
+- Ruff（lint + format check）
+- MyPy（`src` 型チェック）
+- Import Linter（モジュール境界）
+- Pytest（回帰）
 - （任意）CodeRabbit review
+
+CI 定義: `.github/workflows/ci.yml`
 
 ---
 

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -1,6 +1,6 @@
 ﻿param(
   [Parameter(Position=0)]
-  [ValidateSet("help","venv","install","precommit","fmt","lint","type","test","test-fast","test-slow","test-db-api-aggregate","check","aggregate-dry-run","clean","cleanup-retention","vacuum-db","judge-run-once")]
+  [ValidateSet("help","venv","install","precommit","fmt","lint","type","test","test-fast","test-slow","test-db-api-aggregate","check","aggregate-dry-run","clean","cleanup-retention","vacuum-db","judge-run-once","demo-db-api","demo-data","demo-dashboard")]
   [string]$Task = "help"
   ,
   [string]$AggInput = "data/scrape/scrape_TOOL_A.csv"
@@ -70,6 +70,9 @@ switch ($Task) {
     Write-Host "  .\tasks.ps1 cleanup-retention - delete retention-expired data (daily task)"
     Write-Host "  .\tasks.ps1 vacuum-db - VACUUM SQLite database (weekly task)"
     Write-Host "  .\tasks.ps1 judge-run-once - execute one judge cycle (scheduler entry point)"
+    Write-Host "  .\tasks.ps1 demo-db-api - start db_api for portfolio demo"
+    Write-Host "  .\tasks.ps1 demo-data - generate sample data and run one pipeline cycle"
+    Write-Host "  .\tasks.ps1 demo-dashboard - start dashboard (http://localhost:8050)"
   }
 
   "venv" {
@@ -155,6 +158,23 @@ switch ($Task) {
 
     & $Py @JudgeArgs | Out-Host
     exit $LASTEXITCODE
+  }
+
+  "demo-db-api" {
+    Ensure-DevInstall
+    & $Py -m portfolio_fdc.db_api.app | Out-Host
+  }
+
+  "demo-data" {
+    Ensure-DevInstall
+    $RawPath = "data/raw/logger_raw_demo.csv"
+    & $Py -m portfolio_fdc.tools.generate_logger_csv --out $RawPath --seconds 7200 --scenario mix | Out-Host
+    & $Py -m portfolio_fdc.main.run_once --tool TOOL_A --raw $RawPath --db-api http://localhost:8000 | Out-Host
+  }
+
+  "demo-dashboard" {
+    Ensure-DevInstall
+    & $Py -m portfolio_fdc.dashboard.app | Out-Host
   }
 
   "clean" {


### PR DESCRIPTION
## Summary
- add portfolio snapshot section to README (Ready/Partial scope by area)
- add 3-step demo run guide with minimal recovery notes
- add CI badge and explicit quality gates (ruff/mypy/import-linter/pytest)
- add demo shortcut tasks to tasks.ps1 and Makefile

## Validation
- python -m pre_commit run --files README.md tasks.ps1 Makefile
- .\\tasks.ps1 help (demo tasks visible)

## Notes
- On this Windows environment, make command is not available by default; PowerShell tasks are the primary local path.

Closes #227 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 概要
Portfolio Milestone A のベースライン整備PR。README にポートフォリオのスコープスナップショット、最短3ステップのデモ手順、最小復旧手順、CIバッジと品質ゲートの明記を追加。Makefile と PowerShell タスクにデモ用ショートカット（demo-db-api / demo-data / demo-dashboard）を追加。Issue `#227` をクローズ。

## 変更点（要点）
- README.md
  - CI（GitHub Actions）バッジ追加。
  - 「Portfolio Scope Snapshot」セクション（Ready/Partial 範囲表）追加。
  - 「0) 最短デモ（3ステップ）」手順追加（db_api → data/main → dashboard）。
  - 最小復旧手順（PORTFOLIO_DB_DIR 不整合、DB 再生成、再インストール）追記。
  - CI 品質ゲートに ruff / mypy / import-linter / pytest を明記。
- Makefile
  - 変数追加: DEMO_RAW ?= data/raw/logger_raw_demo.csv
  - PHONY/help に demo-db-api / demo-data / demo-dashboard を追加。
  - 各 demo ターゲットを対応する Python エントリポイントに接続。
- tasks.ps1
  - ValidateSet と switch に demo-db-api / demo-data / demo-dashboard を追加。
  - 各タスクで依存セットアップ後に対応エントリポイントを起動（db_api、CSV 生成→main.run_once、dashboard）。
- 検証手順（ドキュメント記載）
  - pre-commit 実行: python -m pre_commit run --files README.md tasks.ps1 Makefile
  - PowerShell タスク確認: .\tasks.ps1 help（デモタスクが表示されること）
  - 注: Windows 環境では make がデフォルトで使えない場合がある旨を記載（PowerShell が主経路）。

## 主なリスク
- db_api 起動依存の未強制化：demo-data 実行には localhost:8000 上の db_api が前提だが、実行前確認や自動起動は組み込まれていない（ドキュメント依存）。
- パス・存在確認不足：DEMO_RAW と tasks.ps1 内のパスは整合しているが、data/raw/ ディレクトリやファイル存在チェック・エラーハンドリングがない。
- 環境差異（Windows vs Unix）：README は make 非在性を注意喚起しているが、Makefile と PowerShell の二重経路が混同を招く可能性。
- データ消失リスクの曖昧さ：最小復旧手順で DB 再生成を推奨するが、既存データの扱いやバックアップ方針が明確でない。

## テストギャップ（未解決の検証項目）
- E2E 自動テスト欠如：3ステップデモ（db_api 起動確認、CSV 生成、dashboard 表示）を自動検証するテストが無い。
- 手順・出力検証：ドキュメント手順（コマンド実行可能性、出力/ポート確認、ログ確認）の自動検証がない。
- 環境変数挙動：PORTFOLIO_DB_DIR 指定時の動作確認・ドキュメント上の具体例が不足。
- 依存インストール/仮想環境チェック：demo タスク実行前の依存（venv, pip）状態を自動チェックする仕組みがない。

## 所見（スコープ評価）
- README により「Ready / Partial」領域が明示され、初回レビュー→再現の導線は大幅に改善されている（短時間での把握が現実的）。
- ただし、現状は手動手順と人手による前提確認に依存しており、信頼性向上には E2E 検証と前提条件の自動チェック（またはタスク内での起動・待機処理追加）が望ましい。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->