### PR TITLE
docs: add first-time dashboard user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ make demo-dashboard
 
 - `http://localhost:8050` を開く
 - Change Requests / Emergency タブでフォーム入力から payload preview を確認
+- 初見向けの操作手順は `docs/dashboard-user-guide.md` を参照
 
 `db_api` をまだ起動していない場合:
 

--- a/docs/dashboard-user-guide.md
+++ b/docs/dashboard-user-guide.md
@@ -57,7 +57,7 @@
 
 ## 5分で触る最小操作
 
-## 1. チャートを確認する（Charts）
+### 1. チャートを確認する（Charts）
 
 1. `Charts` タブを開く
 2. `Load` を押す
@@ -68,7 +68,7 @@
 - 一覧に `warning` / `critical` の範囲が見える
 - `open` リンクで `Active` タブへ遷移できる
 
-## 2. Active で点と生波形を確認する
+### 2. Active で点と生波形を確認する
 
 1. `Active` タブを開く
 2. 上段グラフの点を1つクリックする
@@ -79,7 +79,7 @@
 - `Focused chart` が表示される
 - 下段グラフに対象点の波形が描画される
 
-## 3. 通常変更を試す（Change Requests）
+### 3. 通常変更を試す（Change Requests）
 
 1. `Change Requests` タブを開く
 2. `Create Change Request` で以下を入力する
@@ -98,7 +98,7 @@
 - `advanced change_payload JSON` は上級者向けです。
 - raw JSON を入力した場合は、threshold fields より raw JSON が優先されます。
 
-## 4. 緊急変更を試す（Emergency）
+### 4. 緊急変更を試す（Emergency）
 
 1. `Emergency` タブを開く
 2. `Emergency Change` で以下を入力する
@@ -113,7 +113,7 @@
 - 結果欄に `request_id` や `resulting_version` が表示される
 - 下部 `History Preview` に履歴反映が出る
 
-## 5. 失敗通知を再送する（Notification Retry）
+### 5. 失敗通知を再送する（Notification Retry）
 
 1. `Notification Retry` タブを開く
 2. `Refresh Failed Notifications` を押す

--- a/docs/dashboard-user-guide.md
+++ b/docs/dashboard-user-guide.md
@@ -1,0 +1,150 @@
+# Dashboard 使い方ガイド（初見ユーザー向け）
+
+このガイドは、初めてこのリポジトリを触る人が dashboard を迷わず動かすための最短手順です。
+
+## 対象
+
+- dashboard をローカルで起動し、主要タブの意味と基本操作を把握したい人
+- Change Requests / Emergency / Notification Retry の最小操作を確認したい人
+
+## 事前準備
+
+1. 依存関係をインストールする
+
+```powershell
+.\tasks.ps1 install
+```
+
+2. db_api を起動する
+
+```powershell
+.\tasks.ps1 demo-db-api
+```
+
+3. サンプルデータを投入する
+
+```powershell
+.\tasks.ps1 demo-data
+```
+
+4. dashboard を起動する
+
+```powershell
+.\tasks.ps1 demo-dashboard
+```
+
+5. ブラウザで `http://localhost:8050` を開く
+
+## 画面の見方（最初に見る場所）
+
+### 上部フィルタ
+
+- `db_api base URL`: 通常は `http://localhost:8000`
+- `recipe_id` / `chart_id` / `chart_name` / `result_id`: 各タブの絞り込み条件
+- `Load`: 現在のタブを再読み込み
+
+最初は base URL だけ確認して `Load` を押せば十分です。
+
+### タブ構成
+
+- `Charts`: チャート定義一覧。監視対象を俯瞰するタブ
+- `Active`: 有効な閾値セットと最新点群。点クリックで生波形ドリルダウン
+- `History`: 閾値変更履歴（誰がいつ変更したか）
+- `Judge`: 判定結果（NG/WARN/OK）と詳細
+- `Change Requests`: 通常変更フロー（申請/承認/適用）
+- `Emergency`: 緊急変更と追認（Ratify）
+- `Notification Retry`: 失敗通知の再送
+
+## 5分で触る最小操作
+
+## 1. チャートを確認する（Charts）
+
+1. `Charts` タブを開く
+2. `Load` を押す
+3. 行数と各 `chart_id` が表示されることを確認する
+
+期待結果:
+
+- 一覧に `warning` / `critical` の範囲が見える
+- `open` リンクで `Active` タブへ遷移できる
+
+## 2. Active で点と生波形を確認する
+
+1. `Active` タブを開く
+2. 上段グラフの点を1つクリックする
+3. 下段にドリルダウン波形が表示されることを確認する
+
+期待結果:
+
+- `Focused chart` が表示される
+- 下段グラフに対象点の波形が描画される
+
+## 3. 通常変更を試す（Change Requests）
+
+1. `Change Requests` タブを開く
+2. `Create Change Request` で以下を入力する
+   - `chart_id`
+   - `proposed_by`
+   - `warn_low` / `warn_high`（threshold fields）
+3. `Create Change Request` を押す
+
+期待結果:
+
+- payload preview にJSONが表示される
+- 結果欄に `ok: true` のレスポンスが表示される
+
+補足:
+
+- `advanced change_payload JSON` は上級者向けです。
+- raw JSON を入力した場合は、threshold fields より raw JSON が優先されます。
+
+## 4. 緊急変更を試す（Emergency）
+
+1. `Emergency` タブを開く
+2. `Emergency Change` で以下を入力する
+   - `chart_id`
+   - `changed_by`
+   - `changed_by_role`
+   - `warn_high` / `crit_high` など必要な閾値
+3. `Apply Emergency Change` を押す
+
+期待結果:
+
+- 結果欄に `request_id` や `resulting_version` が表示される
+- 下部 `History Preview` に履歴反映が出る
+
+## 5. 失敗通知を再送する（Notification Retry）
+
+1. `Notification Retry` タブを開く
+2. `Refresh Failed Notifications` を押す
+3. `event_id` を入力して `Retry Notification` を実行する
+
+期待結果:
+
+- failed レコード一覧が更新される
+- 再送結果が結果欄に表示される
+
+## よくあるつまずき
+
+### 一覧が空のまま
+
+- `db_api` が起動しているか確認する
+- `demo-data` を実行済みか確認する
+- `db_api base URL` が `http://localhost:8000` になっているか確認する
+
+### 4xx / 5xx エラーが出る
+
+- dashboard は API の error envelope をそのまま表示します
+- 入力値（ID、role、payload JSON）の形式を見直す
+- 競合時（409）は最新状態を再読込して再実行する
+
+### payload preview と送信内容が合っているか不安
+
+- preview に表示された JSON が API に送られる内容です
+- raw JSON を埋めた場合は raw が優先されます
+
+## 関連ドキュメント
+
+- endpoint 契約一覧: `docs/db-api-endpoints.md`
+- dashboard 設計方針: `docs/dashboard-architecture-playbook.md`
+- 全体設計: `docs/architecture.md`

--- a/src/portfolio_fdc/main/aggregate.py
+++ b/src/portfolio_fdc/main/aggregate.py
@@ -621,7 +621,7 @@ def delete_process(db_api: str, process_id: str) -> None:
     api_delete(db_api, f"/processes/{process_id}")
 
 
-def main():
+def main(argv: list[str] | None = None):
     """入力CSVを集約し、プロセス切り出し・詳細保存・特徴量計算・DB登録を実行する。"""
     ap = argparse.ArgumentParser()
     ap.add_argument(
@@ -637,7 +637,7 @@ def main():
         action="store_true",
         help="DB APIへはPOSTせず、ローカル処理（切り出し/CSV保存/特徴量計算）のみ実行する",
     )
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
     cfg = load_yaml(Path(args.config)).get("tools", {})
     df = pd.read_csv(args.input)
     ensure_cols(df, ["timestamp", "tool_id", "chamber_id"])
@@ -650,7 +650,7 @@ def main():
     for (tool_id, chamber_id), g in df.groupby(["tool_id", "chamber_id"]):
         if tool_id not in cfg:
             # unknown tool: fallback edge on dc_bias if exists
-            local = {
+            local: dict[str, Any] = {
                 "mode": "edge",
                 "key_channels": {"dc_bias": "dc_bias"},
                 "edge": {
@@ -664,7 +664,7 @@ def main():
             local = cfg[tool_id]
         mode = local.get("mode", "edge")
         g2 = g.copy()
-        key_channels = local.get("key_channels", {})
+        key_channels: dict[str, Any] = local.get("key_channels", {})
         required = [key_channels.get("dc_bias")]
         if mode == "steppeak":
             required.append(key_channels.get("cl2_flow"))

--- a/src/portfolio_fdc/main/run_once.py
+++ b/src/portfolio_fdc/main/run_once.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -62,14 +61,9 @@ def run_once(
     if dry_run:
         argv.append("--dry-run")
 
-    original_argv = sys.argv
-    try:
-        sys.argv = argv
-        aggregate.main()
-    finally:
-        sys.argv = original_argv
+    aggregate.main(argv[1:])
 
-    return RunOnceSummary(scraped_rows=int(len(scrape_df)), scrape_output_csv=out_csv.as_posix())
+    return RunOnceSummary(scraped_rows=len(scrape_df), scrape_output_csv=out_csv.as_posix())
 
 
 def main() -> None:

--- a/src/portfolio_fdc/main/run_once.py
+++ b/src/portfolio_fdc/main/run_once.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from . import aggregate, scrape
+
+DEFAULT_AGGREGATE_CONFIG = Path("src/portfolio_fdc/configs/aggregate_tools.yaml")
+
+
+@dataclass(frozen=True)
+class RunOnceSummary:
+    scraped_rows: int
+    scrape_output_csv: str
+
+
+def run_once(
+    *,
+    tool_id: str,
+    raw_csv_path: Path,
+    db_api: str,
+    now: datetime | None = None,
+    lookback_minutes: int = 30,
+    config_path: Path = DEFAULT_AGGREGATE_CONFIG,
+    scrape_output_csv: Path | None = None,
+    detail_out_dir: Path = Path("data/detail"),
+    dry_run: bool = False,
+) -> RunOnceSummary:
+    tools_cfg = scrape.load_tool_channel_map(config_path)
+    if tool_id not in tools_cfg:
+        raise ValueError(f"tool_id={tool_id} is not defined in {config_path.as_posix()}")
+
+    scrape_df = scrape.scrape_logger_csv(
+        raw_csv_path=raw_csv_path,
+        tool_id=tool_id,
+        tool_cfg=tools_cfg[tool_id],
+        now=now or datetime.now(),
+        lookback_minutes=lookback_minutes,
+    )
+
+    out_csv = scrape_output_csv or Path("data/scrape") / f"scrape_{tool_id}.csv"
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    scrape_df.to_csv(out_csv, index=False)
+
+    if scrape_df.empty:
+        return RunOnceSummary(scraped_rows=0, scrape_output_csv=out_csv.as_posix())
+
+    argv = [
+        "aggregate.py",
+        "--input",
+        out_csv.as_posix(),
+        "--config",
+        config_path.as_posix(),
+        "--detail-out",
+        detail_out_dir.as_posix(),
+        "--db-api",
+        db_api,
+    ]
+    if dry_run:
+        argv.append("--dry-run")
+
+    original_argv = sys.argv
+    try:
+        sys.argv = argv
+        aggregate.main()
+    finally:
+        sys.argv = original_argv
+
+    return RunOnceSummary(scraped_rows=int(len(scrape_df)), scrape_output_csv=out_csv.as_posix())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tool", required=True)
+    parser.add_argument("--raw", required=True)
+    parser.add_argument("--db-api", default="http://localhost:8000")
+    parser.add_argument("--lookback-minutes", type=int, default=30)
+    parser.add_argument("--config", default=DEFAULT_AGGREGATE_CONFIG.as_posix())
+    parser.add_argument("--scrape-out", default="")
+    parser.add_argument("--detail-out", default="data/detail")
+    parser.add_argument("--dry-run", action="store_true", default=False)
+    args = parser.parse_args()
+
+    summary = run_once(
+        tool_id=args.tool,
+        raw_csv_path=Path(args.raw),
+        db_api=args.db_api,
+        lookback_minutes=args.lookback_minutes,
+        config_path=Path(args.config),
+        scrape_output_csv=Path(args.scrape_out) if args.scrape_out else None,
+        detail_out_dir=Path(args.detail_out),
+        dry_run=args.dry_run,
+    )
+    print(
+        "run_once completed "
+        f"tool={args.tool} scraped_rows={summary.scraped_rows} "
+        f"scrape_out={summary.scrape_output_csv}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/portfolio_fdc/tools/generate_logger_csv.py
+++ b/src/portfolio_fdc/tools/generate_logger_csv.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .sim_data_generator.generate_logger_csv import main, write_logger_csv
+
+__all__ = ["main", "write_logger_csv"]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_readme_demo_flow.py
+++ b/tests/integration/test_readme_demo_flow.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import pytest
+from fastapi.testclient import TestClient
+
+from portfolio_fdc.dashboard.app import app as dashboard_app
+from portfolio_fdc.db_api.db import MAIN_DB
+from portfolio_fdc.main import aggregate, run_once, scrape
+from portfolio_fdc.tools import generate_logger_csv
+
+pytestmark = pytest.mark.integration
+
+
+class _BridgeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP error status={self.status_code}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_readme_demo_flow_smoke(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    db_api_client: TestClient,
+) -> None:
+    raw_csv = tmp_path / "raw" / "logger_raw_demo.csv"
+    scrape_out = tmp_path / "scrape" / "scrape_TOOL_A.csv"
+    detail_dir = tmp_path / "detail"
+    monkeypatch.setattr(scrape, "STATE_DIR", tmp_path / "state")
+
+    generate_logger_csv.write_logger_csv(
+        path=raw_csv,
+        start_ts=datetime.fromisoformat("2026-02-19T00:00:00"),
+        seconds=180,
+        scenario="mix",
+        seed=41,
+        append=False,
+        tool_id="TOOL_A",
+    )
+
+    def fake_post(url: str, json, timeout: int):
+        path = urlsplit(url).path
+        response = db_api_client.post(path, json=json)
+        return _BridgeResponse(status_code=response.status_code, payload=response.json())
+
+    def fake_delete(url: str, json=None, timeout: int = 30):
+        path = urlsplit(url).path
+        if json is None:
+            response = db_api_client.request("DELETE", path)
+        else:
+            response = db_api_client.request("DELETE", path, json=json)
+        return _BridgeResponse(status_code=response.status_code, payload=response.json())
+
+    monkeypatch.setattr(aggregate.requests, "post", fake_post)
+    monkeypatch.setattr(aggregate.requests, "delete", fake_delete)
+
+    summary = run_once.run_once(
+        tool_id="TOOL_A",
+        raw_csv_path=raw_csv,
+        db_api="http://testserver",
+        now=datetime.fromisoformat("2026-02-19T00:02:59"),
+        config_path=Path("src/portfolio_fdc/configs/aggregate_tools.yaml"),
+        scrape_output_csv=scrape_out,
+        detail_out_dir=detail_dir,
+    )
+
+    assert summary.scraped_rows > 0
+    assert scrape_out.exists()
+
+    con = sqlite3.connect(MAIN_DB.as_posix())
+    try:
+        rows = con.execute(
+            """
+            SELECT process_id
+            FROM processInfo
+            WHERE raw_csv_path LIKE ?
+            """,
+            (f"{detail_dir.as_posix()}%",),
+        ).fetchall()
+    finally:
+        con.close()
+
+    process_ids = [str(row[0]) for row in rows]
+    assert process_ids
+
+    for process_id in process_ids:
+        aggregate.delete_process("http://testserver", process_id)
+
+    dashboard_client = dashboard_app.server.test_client()
+    response = dashboard_client.get("/_dash-layout")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add a first-time dashboard user guide for portfolio demos
- document minimal 5-minute walkthrough across key tabs
- add README link from quick demo section to the new guide

## Files
- README.md
- docs/dashboard-user-guide.md

## Validation
- documentation-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 概要
初見ユーザー向けダッシュボード操作ガイドを新規追加し、README のクイックスタートから参照を追加。ポートフォリオデモ向けの最小 5 分ウォークスルーを提供。

## 変更内容（簡潔）
- README.md: クイックスタートに docs/dashboard-user-guide.md への参照を1行追加。
- docs/dashboard-user-guide.md: 新規追加（約+150行）
  - ローカル起動手順（依存インストール、db_api 起動、データ投入、dashboard 起動、ブラウザアクセス）
  - 画面の見方（上部フィルタ、主要タブと役割）
  - 「5分で触る最小操作」（Charts / Active / Change Requests / Emergency / Notification Retry）の具体手順と期待結果
  - よくあるつまずきと関連ドキュメントへのリンク集
- src/portfolio_fdc/main/run_once.py: 新規エントリポイント追加（RunOnceSummary dataclass、run_once 関数、CLI main）
- src/portfolio_fdc/tools/generate_logger_csv.py: 新規追加・別モジュールからの再エクスポート（main, write_logger_csv）
- tests/integration/test_readme_demo_flow.py: README デモフローの統合スモークテストを追加（一時ディレクトリ化、HTTP モンキーパッチ、run_once 実行検証、dashboard レイアウト応答確認）

## リスク
- ドキュメント
  - OS/環境依存（PowerShell 等）やポート競合に関する補足が不足し、手順が環境によって動作しない可能性。
  - スクリーンショットや画面配置の可視的案内がなく、UI 変更時に案内と齟齬が生じやすい。
  - ドキュメントの手順が現行コード・依存バージョンで実環境検証されているか不明。
- 実装／テスト
  - run_once 等の新規 CLI やパスのデフォルトが既存ワークフローと衝突する恐れ（パス/引数の互換性）。
  - 統合テストのモンキーパッチにより実ネットワーク相互作用やエラー挙動の検証が限定的。

## テストギャップ
- ドキュメント手順のクロスプラットフォーム（Windows/Linux/Mac）でのエンドツーエンド検証が不足。
- run_once のユニットテスト（空データ、異常系、dry-run 等）や generate_logger_csv のインポート互換性テストが未追加。
- 統合スモークテストは存在するが、モンキーパッチに頼るため実ネットワーク経由のケースや各種 HTTP エラー応答の検証が不十分。
- UI 操作手順が現在の UI 実装と一致するかの回帰チェックが未実施。

## 推奨アクション（短め）
- ドキュメント手順を実機で検証し、OS別補足とスクリーンショットを追加する。
- run_once と generate_logger_csv に境界・異常系のユニットテストを追加する。
- 統合テストに実ネットワークを使うケースと各種エラーケースを補う（モンキーパッチ併用可）。
- ドキュメント参照リンクの存在と整合性を自動チェックする簡易 CI（リンク検証／ドキュメントビルド）を導入する。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->